### PR TITLE
QueryDSL 초기 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ src/main/resources/*.properties
 ### docker ###
 docker-infra/*
 !docker-infra/*.yml
+
+### QueryDSL Generated ###
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+    /* findbugs */
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
+
     /* Swagger */
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation(group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0') {

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,12 @@ dependencies {
     /* Redis */
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.1'
 
+    /* QueryDSL */
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     /* Security */
     implementation 'org.springframework.boot:spring-boot-starter-security:3.3.1'
     testImplementation 'org.springframework.security:spring-security-test:6.2.3'
@@ -71,6 +77,25 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.3.1'
 }
 
+// QueryDSL 설정
+def querydslDir = "src/main/generated"
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean.doLast {
+    file(querydslDir).deleteDir()
+}
+
+// test 커버리지 측정용
 tasks.named('test') {
     finalizedBy jacocoTestReport
     useJUnitPlatform()

--- a/src/main/java/im/toduck/global/config/querydsl/QueryDslConfig.java
+++ b/src/main/java/im/toduck/global/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package im.toduck.global.config.querydsl;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QueryDslConfig {
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+		return new JPAQueryFactory(entityManager);
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ QueryDSL 초기 설정**
- 프로젝트에 QueryDSL 초기 설정을 추가합니다. QueryDSL은 타입-세이프한 SQL 쿼리를 생성할 수 있게 해주는 프레임워크로, 복잡한 쿼리를 자바 코드로 작성할 수 있게 해줍니다.

1. `build.gradle` 파일에 QueryDSL 의존성 추가
2. QueryDSL Q 클래스 생성을 위한 Annotation Processor 설정
3. QueryDSL 설정을 위한 `JPAQueryFactory` 빈 등록
4. 샘플 엔티티에 대한 QueryDSL Q 클래스 생성 확인

<br/>

기타 내용
- @Nullable 어노테이션 처리를 위한 의존성 추가
  
## ✅ 리뷰 요구사항
https://github.com/TEAM-NANUM/server/tree/main/src/main/java/server/nanum/repository
위 레포지터리의 디렉터리 구조와 같이 QueryDSL을 통해 생성한 QClass를 사용하면 됩니다. 자세한 사용법은 사용이 필요한 경우에 별도로 공부하면 될 것 같습니다!