### PR TITLE
루틴 목록 조회 API 개발

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -53,6 +53,7 @@ CREATE TABLE routine_record
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
     routine_id BIGINT NULL,
     record_at DATETIME NOT NULL,
+    is_all_day BOOLEAN NOT NULL,
     is_completed BOOLEAN NOT NULL DEFAULT false,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,

--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -1,9 +1,15 @@
 package im.toduck.domain.routine.common.mapper;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
 import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.routine.persistence.vo.PlanCategoryColor;
 import im.toduck.domain.routine.persistence.vo.RoutineMemo;
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineReadListResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.helper.DaysOfWeekBitmask;
@@ -11,7 +17,9 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class RoutineMapper {
-	public static Routine toRoutine(User user, RoutineCreateRequest request) {
+	private static final boolean INCOMPLETE_STATUS = false;
+
+	public static Routine toRoutine(final User user, final RoutineCreateRequest request) {
 		DaysOfWeekBitmask daysOfWeekBitmask = DaysOfWeekBitmask.createByDayOfWeek(request.daysOfWeek());
 		PlanCategoryColor planCategoryColor = PlanCategoryColor.from(request.color());
 		RoutineMemo routineMemo = RoutineMemo.from(request.memo());
@@ -29,10 +37,44 @@ public class RoutineMapper {
 			.build();
 	}
 
-	public static RoutineCreateResponse toRoutineCreateResponse(Routine routine) {
+	public static RoutineCreateResponse toRoutineCreateResponse(final Routine routine) {
 		return RoutineCreateResponse.builder()
 			.routineId(routine.getId())
 			.build();
 	}
 
+	public static MyRoutineReadListResponse toMyRoutineReadResponse(
+		final LocalDate queryDate,
+		final List<Routine> routines,
+		final List<RoutineRecord> routineRecords
+	) {
+		List<MyRoutineReadListResponse.MyRoutineReadResponse> routineResponses = routines.stream()
+			.map(routine -> toMyRoutineReadResponse(routine, INCOMPLETE_STATUS))
+			.toList();
+
+		List<MyRoutineReadListResponse.MyRoutineReadResponse> recordResponses = routineRecords.stream()
+			.map(record -> toMyRoutineReadResponse(record.getRoutine(), record.getIsCompleted()))
+			.toList();
+
+		List<MyRoutineReadListResponse.MyRoutineReadResponse> combinedResponses =
+			Stream.concat(routineResponses.stream(), recordResponses.stream()).toList();
+
+		return MyRoutineReadListResponse.builder()
+			.queryDate(queryDate)
+			.routines(combinedResponses)
+			.build();
+	}
+
+	private static MyRoutineReadListResponse.MyRoutineReadResponse toMyRoutineReadResponse(
+		final Routine routine,
+		final boolean isCompleted
+	) {
+		return MyRoutineReadListResponse.MyRoutineReadResponse.builder()
+			.routineId(routine.getId())
+			.color(routine.getColorValue())
+			.time(routine.getTime())
+			.title(routine.getTitle())
+			.isCompleted(isCompleted)
+			.build();
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
@@ -1,0 +1,23 @@
+package im.toduck.domain.routine.domain.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.routine.persistence.repository.RoutineRecordRepository;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoutineRecordService {
+	private final RoutineRecordRepository routineRecordRepository;
+
+	public List<RoutineRecord> getRecords(final User user, final LocalDate date) {
+		return routineRecordRepository.findRoutineRecordsForUserAndDate(user, date);
+	}
+}

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -1,10 +1,14 @@
 package im.toduck.domain.routine.domain.service;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.domain.routine.common.mapper.RoutineMapper;
 import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.routine.persistence.repository.RoutineRepository;
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
@@ -27,4 +31,11 @@ public class RoutineService {
 		);
 	}
 
+	public List<Routine> getUnrecordedRoutinesForDate(
+		final User user,
+		final LocalDate date,
+		final List<RoutineRecord> routineRecords
+	) {
+		return routineRepository.findUnrecordedRoutinesForDate(user, date, routineRecords);
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
+++ b/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
@@ -48,6 +48,7 @@ public class RoutineUseCase {
 		List<RoutineRecord> routineRecords = routineRecordService.getRecords(user, date);
 		List<Routine> routines = routineService.getUnrecordedRoutinesForDate(user, date, routineRecords);
 
+		log.info("본인 루틴 목록 조회 - UserId: {}, 조회한 날짜: {}", userId, date);
 		return RoutineMapper.toMyRoutineReadResponse(date, routines, routineRecords);
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
+++ b/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
@@ -1,14 +1,23 @@
 package im.toduck.domain.routine.domain.usecase;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.routine.common.mapper.RoutineMapper;
+import im.toduck.domain.routine.domain.service.RoutineRecordService;
 import im.toduck.domain.routine.domain.service.RoutineService;
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineReadListResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.annotation.UseCase;
 import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RoutineUseCase {
 	private final UserService userService;
 	private final RoutineService routineService;
+	private final RoutineRecordService routineRecordService;
 
 	@Transactional
 	public RoutineCreateResponse createRoutine(final Long userId, final RoutineCreateRequest request) {
@@ -28,5 +38,16 @@ public class RoutineUseCase {
 
 		log.info("루틴 생성 - UserId: {}, RoutineId:{}", userId, routineCreateResponse.routineId());
 		return routineCreateResponse;
+	}
+
+	@Transactional(readOnly = true)
+	public MyRoutineReadListResponse readMyRoutineList(final Long userId, final LocalDate date) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		List<RoutineRecord> routineRecords = routineRecordService.getRecords(user, date);
+		List<Routine> routines = routineService.getUnrecordedRoutinesForDate(user, date, routineRecords);
+
+		return RoutineMapper.toMyRoutineReadResponse(date, routines, routineRecords);
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -30,6 +30,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "routine")
 @NoArgsConstructor
+// TODO: SQLRestriction 등 Soft delete 를 위한 설정 및 어노테이션 필요
 public class Routine extends BaseEntity {
 
 	@Id
@@ -88,5 +89,9 @@ public class Routine extends BaseEntity {
 		this.time = time;
 		this.daysOfWeekBitmask = daysOfWeekBitmask;
 		this.user = user;
+	}
+
+	public String getColorValue() {
+		return color.getValue();
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/RoutineRecord.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/RoutineRecord.java
@@ -12,9 +12,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "routine_record")
 @NoArgsConstructor
 public class RoutineRecord extends BaseEntity {

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/RoutineRecord.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/RoutineRecord.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +33,17 @@ public class RoutineRecord extends BaseEntity {
 	@Column(name = "record_at", nullable = false)
 	private LocalDateTime recordAt;
 
+	@Column(name = "is_all_day", nullable = false)
+	private Boolean isAllDay;
+
 	@Column(name = "is_completed", nullable = false)
 	private Boolean isCompleted = false;
+
+	@Builder
+	private RoutineRecord(Routine routine, LocalDateTime recordAt, Boolean isAllDay, Boolean isCompleted) {
+		this.routine = routine;
+		this.recordAt = recordAt;
+		this.isAllDay = isAllDay;
+		this.isCompleted = isCompleted;
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepository.java
@@ -1,0 +1,11 @@
+package im.toduck.domain.routine.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.routine.persistence.repository.querydsl.RoutineRecordRepositoryCustom;
+
+@Repository
+public interface RoutineRecordRepository extends JpaRepository<RoutineRecord, Long>, RoutineRecordRepositoryCustom {
+}

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
@@ -1,8 +1,11 @@
 package im.toduck.domain.routine.persistence.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.repository.querydsl.RoutineRepositoryCustom;
 
-public interface RoutineRepository extends JpaRepository<Routine, Long> {
+@Repository
+public interface RoutineRepository extends JpaRepository<Routine, Long>, RoutineRepositoryCustom {
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustom.java
@@ -1,0 +1,11 @@
+package im.toduck.domain.routine.persistence.repository.querydsl;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.user.persistence.entity.User;
+
+public interface RoutineRecordRepositoryCustom {
+	List<RoutineRecord> findRoutineRecordsForUserAndDate(User user, LocalDate date);
+}

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
@@ -1,0 +1,38 @@
+package im.toduck.domain.routine.persistence.repository.querydsl;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import im.toduck.domain.routine.persistence.entity.QRoutine;
+import im.toduck.domain.routine.persistence.entity.QRoutineRecord;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RoutineRecordRepositoryCustomImpl implements RoutineRecordRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<RoutineRecord> findRoutineRecordsForUserAndDate(User user, LocalDate date) {
+		QRoutine routine = QRoutine.routine;
+		QRoutineRecord record = QRoutineRecord.routineRecord;
+
+		LocalDateTime startOfDay = date.atStartOfDay();
+		LocalDateTime endOfDay = date.plusDays(1).atStartOfDay();
+
+		return queryFactory
+			.selectFrom(record)
+			.join(record.routine, routine)
+			.where(
+				record.recordAt.between(startOfDay, endOfDay)
+			)
+			.fetch();
+	}
+}

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
@@ -1,0 +1,12 @@
+package im.toduck.domain.routine.persistence.repository.querydsl;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.user.persistence.entity.User;
+
+public interface RoutineRepositoryCustom {
+	List<Routine> findUnrecordedRoutinesForDate(User user, LocalDate date, List<RoutineRecord> routineRecords);
+}

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
@@ -1,0 +1,65 @@
+package im.toduck.domain.routine.persistence.repository.querydsl;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import im.toduck.domain.routine.persistence.entity.QRoutine;
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.helper.DaysOfWeekBitmask;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+	private final QRoutine routine = QRoutine.routine;
+
+	@Override
+	public List<Routine> findUnrecordedRoutinesForDate(User user, LocalDate date,
+		List<RoutineRecord> recordedRoutines) {
+		return queryFactory
+			.selectFrom(routine)
+			.where(
+				routine.user.eq(user),
+				routineCreatedOnOrBeforeDate(date),
+				routineNotRecorded(recordedRoutines),
+				routineMatchesDate(date)
+			)
+			.fetch();
+	}
+
+	private BooleanExpression routineCreatedOnOrBeforeDate(LocalDate date) {
+		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+		return routine.createdAt.loe(endOfDay);
+	}
+
+	private BooleanExpression routineNotRecorded(List<RoutineRecord> recordedRoutines) {
+		if (recordedRoutines == null || recordedRoutines.isEmpty()) {
+			return null;
+		}
+
+		return routine.id.notIn(recordedRoutines.stream()
+			.map(RoutineRecord::getRoutine)
+			.map(Routine::getId)
+			.toList());
+	}
+
+	private BooleanExpression routineMatchesDate(LocalDate date) {
+		byte dayBitmask = DaysOfWeekBitmask.getDayBitmask(date.getDayOfWeek());
+		return Expressions.numberTemplate(
+				Byte.class, "function('bitand', {0}, {1})", routine.daysOfWeekBitmask, dayBitmask
+			)
+
+			.gt((byte)0);
+	}
+}

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
@@ -57,7 +57,7 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 	private BooleanExpression routineMatchesDate(LocalDate date) {
 		byte dayBitmask = DaysOfWeekBitmask.getDayBitmask(date.getDayOfWeek());
 		return Expressions.numberTemplate(
-				Byte.class, "function('bitand', {0}, {1})", routine.daysOfWeekBitmask, dayBitmask
+				Byte.class, "function('bitand', {0}, CAST({1} as byte))", routine.daysOfWeekBitmask, dayBitmask
 			)
 
 			.gt((byte)0);

--- a/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
@@ -38,7 +38,7 @@ public interface RoutineApi {
 
 	@Operation(
 		summary = "특정 날짜 본인 루틴 목록 조회",
-		description = "특정 날짜에 대한 자신의 루틴 목록을 조회합니다."
+		description = "특정 날짜에 대한 자신의 루틴 목록을 조회합니다. 루틴 목록은 시간순으로 정렬되어 있지 않을 수 있습니다."
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(

--- a/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
@@ -16,6 +16,7 @@ import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
@@ -40,17 +41,16 @@ public interface RoutineApi {
 		summary = "특정 날짜 본인 루틴 목록 조회",
 		description = "특정 날짜에 대한 자신의 루틴 목록을 조회합니다. 루틴 목록은 시간순으로 정렬되어 있지 않을 수 있습니다."
 	)
+
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
 			responseClass = MyRoutineReadListResponse.class,
 			description = "루틴 목록 조회 성공, 루틴의 고유 Id, 루틴 Color, 완료 여부를 반환합니다."
-		),
-		errors = {
-
-		}
+		)
 	)
 	ResponseEntity<ApiResponse<MyRoutineReadListResponse>> getMyRoutineList(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@Parameter(description = "조회할 루틴의 날짜 (형식: YYYY-MM-DD)", required = true, example = "2024-09-02")
 		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
 	);
 }

--- a/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
@@ -1,10 +1,15 @@
 package im.toduck.domain.routine.presentation.api;
 
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineReadListResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -26,8 +31,26 @@ public interface RoutineApi {
 			description = "루틴 생성 성공, 생성된 루틴의 Id를 반환합니다."
 		)
 	)
-	ResponseEntity<ApiResponse<RoutineCreateResponse>> createRoutine(
+	ResponseEntity<ApiResponse<RoutineCreateResponse>> postRoutine(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
 		@RequestBody @Valid final RoutineCreateRequest request
+	);
+
+	@Operation(
+		summary = "특정 날짜 본인 루틴 목록 조회",
+		description = "특정 날짜에 대한 자신의 루틴 목록을 조회합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = MyRoutineReadListResponse.class,
+			description = "루틴 목록 조회 성공, 루틴의 고유 Id, 루틴 Color, 완료 여부를 반환합니다."
+		),
+		errors = {
+
+		}
+	)
+	ResponseEntity<ApiResponse<MyRoutineReadListResponse>> getMyRoutineList(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
 	);
 }

--- a/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
@@ -1,16 +1,22 @@
 package im.toduck.domain.routine.presentation.controller;
 
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import im.toduck.domain.routine.domain.usecase.RoutineUseCase;
 import im.toduck.domain.routine.presentation.api.RoutineApi;
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineReadListResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
@@ -26,12 +32,23 @@ public class RoutineController implements RoutineApi {
 
 	@PostMapping
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<RoutineCreateResponse>> createRoutine(
+	public ResponseEntity<ApiResponse<RoutineCreateResponse>> postRoutine(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
 		@RequestBody @Valid final RoutineCreateRequest request
 	) {
 		return ResponseEntity.ok(
 			ApiResponse.createSuccess(routineUseCase.createRoutine(userDetails.getUserId(), request))
+		);
+	}
+
+	@GetMapping("/me")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<MyRoutineReadListResponse>> getMyRoutineList(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.createSuccess(routineUseCase.readMyRoutineList(userDetails.getUserId(), date))
 		);
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineReadListResponse.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineReadListResponse.java
@@ -4,12 +4,19 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Schema(description = "본인 루틴 목록 응답 DTO")
 @Builder
 public record MyRoutineReadListResponse(
+	@JsonSerialize(using = LocalDateSerializer.class)
+	@JsonFormat(pattern = "yyyy-MM-dd")
 	@Schema(description = "조회 날짜", example = "2024-08-31")
 	LocalDate queryDate,
 
@@ -26,6 +33,8 @@ public record MyRoutineReadListResponse(
 		@Schema(description = "루틴 색상(null 이면 없는 색상)", example = "#FCDCDF")
 		String color,
 
+		@JsonSerialize(using = LocalTimeSerializer.class)
+		@JsonFormat(pattern = "HH:mm")
 		@Schema(description = "루틴 시간(null 이면 종일 루틴)", example = "14:30")
 		LocalTime time,
 

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineReadListResponse.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineReadListResponse.java
@@ -1,0 +1,39 @@
+package im.toduck.domain.routine.presentation.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "본인 루틴 목록 응답 DTO")
+@Builder
+public record MyRoutineReadListResponse(
+	@Schema(description = "조회 날짜", example = "2024-08-31")
+	LocalDate queryDate,
+
+	@Schema(description = "루틴 목록")
+	List<MyRoutineReadResponse> routines
+
+) {
+	@Schema(description = "본인 루틴 목록 내부 DTO")
+	@Builder
+	public record MyRoutineReadResponse(
+		@Schema(description = "루틴 Id", example = "1")
+		Long routineId,
+
+		@Schema(description = "루틴 색상(null 이면 없는 색상)", example = "#FCDCDF")
+		String color,
+
+		@Schema(description = "루틴 시간(null 이면 종일 루틴)", example = "14:30")
+		LocalTime time,
+
+		@Schema(description = "루틴 제목", example = "디자인팀 회의")
+		String title,
+
+		@Schema(description = "루틴 완료 여부", example = "true")
+		Boolean isCompleted
+	) {
+	}
+}

--- a/src/main/java/im/toduck/global/helper/DaysOfWeekBitmask.java
+++ b/src/main/java/im/toduck/global/helper/DaysOfWeekBitmask.java
@@ -71,7 +71,7 @@ public class DaysOfWeekBitmask {
 			.collect(Collectors.toCollection(() -> EnumSet.noneOf(DayOfWeek.class)));
 	}
 
-	private static byte getDayBitmask(DayOfWeek day) {
+	public static byte getDayBitmask(DayOfWeek day) {
 		return (byte)(1 << (day.getValue() - 1));
 	}
 

--- a/src/test/java/im/toduck/RepositoryTest.java
+++ b/src/test/java/im/toduck/RepositoryTest.java
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.builder.BuilderSupporter;
 import im.toduck.builder.TestFixtureBuilder;
@@ -37,7 +36,6 @@ import im.toduck.global.config.querydsl.QueryDslConfig;
 @AutoConfigureDataRedis
 @ActiveProfiles("test")
 @Import(value = {TestFixtureBuilder.class, BuilderSupporter.class, QueryDslConfig.class})
-@Transactional
 public abstract class RepositoryTest {
 
 	@Autowired

--- a/src/test/java/im/toduck/RepositoryTest.java
+++ b/src/test/java/im/toduck/RepositoryTest.java
@@ -1,0 +1,45 @@
+package im.toduck;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataRedis;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTypeExcludeFilter;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.builder.BuilderSupporter;
+import im.toduck.builder.TestFixtureBuilder;
+import im.toduck.global.config.querydsl.QueryDslConfig;
+
+/**
+ * 이 추상 클래스는 JPA와 Redis 기능을 모두 필요로 하는 리포지토리 테스트를 위한 기본 구성을 제공합니다.
+ * {@link org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest}와
+ * {@link org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest}의 기능을 결합하여
+ * JPA 리포지토리와 Redis 작업의 통합 테스팅을 가능하게 합니다.
+ *
+ * <p>주요 특징:</p>
+ * <ul>
+ *   <li>JPA와 Redis 테스트 환경을 모두 구성합니다.</li>
+ *   <li>"test" 프로필을 활성화합니다.</li>
+ *   <li>테스트 픽스처를 위한 필요한 설정과 빌더를 가져옵니다.</li>
+ *   <li>테스트를 위한 트랜잭션 관리를 활성화합니다.</li>
+ * </ul>
+ *
+ * <p>사용법: JPA와 Redis 테스팅 기능을 모두 활용하려면 리포지토리 테스트 클래스에서 이 클래스를 상속하세요.</p>
+ *
+ * @see org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+ * @see org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataRedis
+ */
+@DataJpaTest
+@TypeExcludeFilters(DataRedisTypeExcludeFilter.class)
+@AutoConfigureDataRedis
+@ActiveProfiles("test")
+@Import(value = {TestFixtureBuilder.class, BuilderSupporter.class, QueryDslConfig.class})
+@Transactional
+public abstract class RepositoryTest {
+
+	@Autowired
+	protected TestFixtureBuilder testFixtureBuilder;
+}

--- a/src/test/java/im/toduck/builder/BuilderSupporter.java
+++ b/src/test/java/im/toduck/builder/BuilderSupporter.java
@@ -3,6 +3,8 @@ package im.toduck.builder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import im.toduck.domain.routine.persistence.repository.RoutineRecordRepository;
+import im.toduck.domain.routine.persistence.repository.RoutineRepository;
 import im.toduck.domain.user.persistence.repository.UserRepository;
 import im.toduck.infra.redis.phonenumber.PhoneNumberRepository;
 
@@ -11,8 +13,15 @@ public class BuilderSupporter {
 
 	@Autowired
 	private UserRepository userRepository;
+
 	@Autowired
 	private PhoneNumberRepository phoneNumberRepository;
+
+	@Autowired
+	private RoutineRepository routineRepository;
+
+	@Autowired
+	private RoutineRecordRepository routineRecordRepository;
 
 	public UserRepository userRepository() {
 		return userRepository;
@@ -20,6 +29,14 @@ public class BuilderSupporter {
 
 	public PhoneNumberRepository phoneNumberRepository() {
 		return phoneNumberRepository;
+	}
+
+	public RoutineRepository routineRepository() {
+		return routineRepository;
+	}
+
+	public RoutineRecordRepository routineRecord() {
+		return routineRecordRepository;
 	}
 
 }

--- a/src/test/java/im/toduck/builder/TestFixtureBuilder.java
+++ b/src/test/java/im/toduck/builder/TestFixtureBuilder.java
@@ -3,6 +3,8 @@ package im.toduck.builder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.infra.redis.phonenumber.PhoneNumber;
 
@@ -18,6 +20,14 @@ public class TestFixtureBuilder {
 
 	public PhoneNumber buildPhoneNumber(final PhoneNumber phoneNumber) {
 		return bs.phoneNumberRepository().save(phoneNumber);
+	}
+
+	public Routine buildRoutine(final Routine routine) {
+		return bs.routineRepository().save(routine);
+	}
+
+	public RoutineRecord buildRoutineRecord(final RoutineRecord routineRecord) {
+		return bs.routineRecord().save(routineRecord);
 	}
 
 }

--- a/src/test/java/im/toduck/domain/routine/domain/service/RoutineServiceTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/service/RoutineServiceTest.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,15 +31,16 @@ class RoutineServiceTest extends ServiceTest {
 	@Autowired
 	private RoutineRepository routineRepository;
 
-	private User user;
+	private User USER;
 
 	@BeforeEach
 	void setUp() {
 		// given
-		user = testFixtureBuilder.buildUser(GENERAL_USER());
+		USER = testFixtureBuilder.buildUser(GENERAL_USER());
 	}
 
 	@Nested
+	@DisplayName("루틴 생성시")
 	class CreateTest {
 		private RoutineCreateRequest request;
 
@@ -59,7 +61,7 @@ class RoutineServiceTest extends ServiceTest {
 		@Test
 		void 루틴을_생성할_수_있다() {
 			// when
-			RoutineCreateResponse result = routineService.create(user, request);
+			RoutineCreateResponse result = routineService.create(USER, request);
 
 			// then
 			assertSoftly(softly -> {
@@ -69,7 +71,7 @@ class RoutineServiceTest extends ServiceTest {
 				Routine savedRoutine = routineRepository.findById(result.routineId()).orElse(null);
 				softly.assertThat(savedRoutine).isNotNull();
 				softly.assertThat(savedRoutine.getTitle()).isEqualTo(request.title());
-				softly.assertThat(savedRoutine.getUser()).isEqualTo(user);
+				softly.assertThat(savedRoutine.getUser()).isEqualTo(USER);
 			});
 		}
 	}

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
@@ -1,0 +1,115 @@
+package im.toduck.domain.routine.domain.usecase;
+
+import static im.toduck.fixtures.RoutineFixtures.*;
+import static im.toduck.fixtures.RoutineRecordFixtures.*;
+import static im.toduck.fixtures.UserFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.ServiceTest;
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineReadListResponse;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+
+@Transactional
+class RoutineUseCaseTest extends ServiceTest {
+
+	private User USER;
+
+	@Autowired
+	private RoutineUseCase routineUseCase;
+
+	@MockBean
+	private UserService userService;
+
+	@BeforeEach
+	void setUp() {
+		// given
+		USER = testFixtureBuilder.buildUser(GENERAL_USER());
+	}
+
+	@Nested
+	@DisplayName("루틴 목록 조회시")
+	class ReadMyRoutineListTest {
+		@BeforeEach
+		void setUp() {
+			// given
+			given(userService.getUserById(any(Long.class))).willReturn(Optional.ofNullable(USER));
+		}
+
+		@Test
+		void 루틴_기록이_존재하는_경우에는_해당_기록을_그대로_사용한다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_SYNCED_RECORD(ROUTINE)
+			);
+			LocalDate queryDate = RECORD.getRecordAt().toLocalDate();
+
+			// when
+			MyRoutineReadListResponse responses = routineUseCase.readMyRoutineList(USER.getId(), queryDate);
+
+			// then
+			assertSoftly(softly -> {
+				assertThat(responses.queryDate()).isEqualTo(queryDate);
+				assertThat(responses.routines()).hasSize(1);
+
+				MyRoutineReadListResponse.MyRoutineReadResponse response = responses.routines().get(0);
+				assertThat(response.routineId()).isEqualTo(ROUTINE.getId());
+				assertThat(response.isCompleted()).isEqualTo(RECORD.getIsCompleted());
+				assertThat(response.time()).isEqualTo(RECORD.getRecordAt().toLocalTime());
+			});
+		}
+
+		@Test
+		void 루틴_기록이_존재하지_않는_경우에도_모_루틴을_통해_해당_기록을_조회할_수_있다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			LocalDate queryDate = LocalDate.now()
+				.with(TemporalAdjusters.next(ROUTINE.getCreatedAt().getDayOfWeek()));
+
+			// when
+			MyRoutineReadListResponse responses = routineUseCase.readMyRoutineList(USER.getId(), queryDate);
+
+			// then
+			assertSoftly(softly -> {
+				assertThat(responses.queryDate()).isEqualTo(queryDate);
+				assertThat(responses.routines()).hasSize(1);
+
+				MyRoutineReadListResponse.MyRoutineReadResponse response = responses.routines().get(0);
+				assertThat(response.routineId()).isEqualTo(ROUTINE.getId());
+				assertThat(response.isCompleted()).isFalse();
+				assertThat(response.time()).isEqualTo(ROUTINE.getTime());
+			});
+		}
+
+		@Disabled("추후 테스트 필요")
+		@Test
+		void 루틴_수정으로_인해_동기화되지_않은_루틴_기록을_정상적으로_조회할_수_있다() {
+
+		}
+
+		@Disabled("추후 테스트 필요")
+		@Test
+		void 모_루틴이_Soft_DELETE_된_경우에도_루틴_기록이_존재한다면_정상적으로_조회할_수_있다() {
+
+		}
+	}
+}

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
@@ -4,6 +4,7 @@ import static im.toduck.fixtures.RoutineFixtures.*;
 import static im.toduck.fixtures.RoutineRecordFixtures.*;
 import static im.toduck.fixtures.UserFixtures.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -48,8 +49,11 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 			);
 
 			// then
-			assertThat(records).hasSize(1);
-			assertThat(records).contains(RECORD);
+			assertSoftly(softly -> {
+				assertThat(records).hasSize(1);
+				assertThat(records).contains(RECORD);
+			});
+
 		}
 
 		@Test
@@ -78,13 +82,15 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 			);
 
 			// then
-			assertThat(records).hasSize(4);
-			assertThat(records).containsExactlyInAnyOrder(
-				RECORD_WEEKLY1_1,
-				RECORD_WEEKLY1_2,
-				RECORD_WEEKLY2_1,
-				RECORD_WEEKLY2_2
-			);
+			assertSoftly(softly -> {
+				softly.assertThat(records).hasSize(4);
+				softly.assertThat(records).containsExactlyInAnyOrder(
+					RECORD_WEEKLY1_1,
+					RECORD_WEEKLY1_2,
+					RECORD_WEEKLY2_1,
+					RECORD_WEEKLY2_2
+				);
+			});
 		}
 	}
 }

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
@@ -1,0 +1,90 @@
+package im.toduck.domain.routine.persistence.repository;
+
+import static im.toduck.fixtures.RoutineFixtures.*;
+import static im.toduck.fixtures.RoutineRecordFixtures.*;
+import static im.toduck.fixtures.UserFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import im.toduck.RepositoryTest;
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.user.persistence.entity.User;
+
+class RoutineRecordRepositoryTest extends RepositoryTest {
+
+	@Autowired
+	private RoutineRecordRepository routineRecordRepository;
+
+	private User USER;
+
+	@BeforeEach
+	void setUp() {
+		USER = testFixtureBuilder.buildUser(GENERAL_USER());
+	}
+
+	@Nested
+	@DisplayName("루틴 기록 조회시")
+	class FindRoutineRecordsForUserAndDateTest {
+
+		@Test
+		void 유효한_루틴_기록을_조회할_수_있다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
+			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(COMPLETED_SYNCED_RECORD(ROUTINE));
+
+			// when
+			List<RoutineRecord> records = routineRecordRepository.findRoutineRecordsForUserAndDate(
+				USER,
+				LocalDate.from(RECORD.getRecordAt())
+			);
+
+			// then
+			assertThat(records).hasSize(1);
+			assertThat(records).contains(RECORD);
+		}
+
+		@Test
+		void 여러_루틴_기록을_한번에_조회할_수_있다() {
+			// given
+			Routine ROUTINE_WEEKLY1 = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine ROUTINE_WEEKLY2 = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+
+			RoutineRecord RECORD_WEEKLY1_1 = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_SYNCED_RECORD(ROUTINE_WEEKLY1)
+			);
+			RoutineRecord RECORD_WEEKLY1_2 = testFixtureBuilder.buildRoutineRecord(
+				INCOMPLETED_SYNCED_RECORD(ROUTINE_WEEKLY1)
+			);
+			RoutineRecord RECORD_WEEKLY2_1 = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_SYNCED_RECORD(ROUTINE_WEEKLY2)
+			);
+			RoutineRecord RECORD_WEEKLY2_2 = testFixtureBuilder.buildRoutineRecord(
+				INCOMPLETED_SYNCED_RECORD(ROUTINE_WEEKLY2)
+			);
+
+			// when
+			List<RoutineRecord> records = routineRecordRepository.findRoutineRecordsForUserAndDate(
+				USER,
+				LocalDate.from(RECORD_WEEKLY1_1.getRecordAt())
+			);
+
+			// then
+			assertThat(records).hasSize(4);
+			assertThat(records).containsExactlyInAnyOrder(
+				RECORD_WEEKLY1_1,
+				RECORD_WEEKLY1_2,
+				RECORD_WEEKLY2_1,
+				RECORD_WEEKLY2_2
+			);
+		}
+	}
+}

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
@@ -120,8 +120,6 @@ class RoutineRepositoryTest extends RepositoryTest {
 			Routine WEEKDAY_MORNING_ROUTINE2 = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
 			LocalDate weekday = getNextDayOfWeek(DayOfWeek.MONDAY);
 
-			System.out.println("ㅎㅇ" + WEEKDAY_MORNING_ROUTINE1.getCreatedAt());
-
 			// when
 			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, weekday,
 				List.of());

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
@@ -4,6 +4,7 @@ import static im.toduck.fixtures.RoutineFixtures.*;
 import static im.toduck.fixtures.RoutineRecordFixtures.*;
 import static im.toduck.fixtures.UserFixtures.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -109,8 +110,12 @@ class RoutineRepositoryTest extends RepositoryTest {
 				mondayMorning.toLocalDate(), List.of());
 
 			// then
-			assertThat(sundayRoutines).contains(SUNDAY_NIGHT_ROUTINE).doesNotContain(MONDAY_MORNING_ROUTINE);
-			assertThat(mondayRoutines).contains(MONDAY_MORNING_ROUTINE).doesNotContain(SUNDAY_NIGHT_ROUTINE);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(sundayRoutines).contains(SUNDAY_NIGHT_ROUTINE).doesNotContain(MONDAY_MORNING_ROUTINE);
+				softly.assertThat(mondayRoutines).contains(MONDAY_MORNING_ROUTINE).doesNotContain(SUNDAY_NIGHT_ROUTINE);
+			});
 		}
 
 		@Test

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
@@ -1,0 +1,154 @@
+package im.toduck.domain.routine.persistence.repository;
+
+import static im.toduck.fixtures.RoutineFixtures.*;
+import static im.toduck.fixtures.RoutineRecordFixtures.*;
+import static im.toduck.fixtures.UserFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import im.toduck.RepositoryTest;
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.user.persistence.entity.User;
+
+class RoutineRepositoryTest extends RepositoryTest {
+
+	@Autowired
+	private RoutineRepository routineRepository;
+
+	private User USER;
+
+	@BeforeEach
+	void setUp() {
+		USER = testFixtureBuilder.buildUser(GENERAL_USER());
+	}
+
+	@Nested
+	@DisplayName("기록에 없는 루틴 조회시")
+	class FindUnrecordedRoutinesForDateTest {
+		@Test
+		void 주어진_날짜와_조건에_따라_기록되지_않은_루틴을_올바르게_조회한다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
+			LocalDate monday = getNextDayOfWeek(DayOfWeek.MONDAY);
+
+			// when
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, monday, List.of());
+
+			// then
+			assertThat(unrecordedRoutines).contains(ROUTINE);
+		}
+
+		@Test
+		void 루틴_생성_날짜가_조회_날짜보다_이후인_경우_조회되지_않음을_확인한다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
+			LocalDate monday = getPreviousDayOfWeek(DayOfWeek.MONDAY);
+
+			// when
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, monday, List.of());
+
+			// then
+			assertThat(unrecordedRoutines).doesNotContain(ROUTINE);
+		}
+
+		@Test
+		void 주어진_날짜와_조건에_따라_이미_루틴기록이_있는_루틴을_조회하지_않는다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
+			RoutineRecord ROUTINE_RECORD1 = testFixtureBuilder.buildRoutineRecord(COMPLETED_SYNCED_RECORD(ROUTINE));
+			RoutineRecord ROUTINE_RECORD2 = testFixtureBuilder.buildRoutineRecord(COMPLETED_MODIFIED_RECORD(ROUTINE));
+			LocalDate monday = getNextDayOfWeek(DayOfWeek.MONDAY);
+
+			// when
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, monday,
+				List.of(ROUTINE_RECORD1, ROUTINE_RECORD2));
+
+			// then
+			assertThat(unrecordedRoutines).doesNotContain(ROUTINE);
+		}
+
+		@Test
+		void 매일_반복되는_루틴이_존재할_때_모든_요일에_조회되는지_확인한다() {
+			// given
+			Routine DAILYROUTINE = testFixtureBuilder.buildRoutine(DAILY_EVENING_ROUTINE(USER));
+
+			// when & then
+			for (int i = 1; i <= 7; i++) {
+				LocalDate date = getNextDayOfWeek(DayOfWeek.of(i));
+				List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, date,
+					List.of());
+				assertThat(unrecordedRoutines).contains(DAILYROUTINE);
+			}
+		}
+
+		@Test
+		void 일요일_자정_직전과_월요일_자정_직후_루틴이_올바르게_조회되는지_확인한다() {
+			// given
+			Routine SUNDAY_NIGHT_ROUTINE = testFixtureBuilder.buildRoutine(LAST_DAY_OF_WEEK_NIGHT_ROUTINE(USER));
+			Routine MONDAY_MORNING_ROUTINE = testFixtureBuilder.buildRoutine(FIRST_DAY_OF_WEEK_MORNING_ROUTINE(USER));
+			LocalDateTime sundayNight = getNextDayOfWeek(DayOfWeek.SUNDAY).atTime(23, 59, 59);
+			LocalDateTime mondayMorning = getNextDayOfWeek(DayOfWeek.MONDAY).atTime(0, 0, 1);
+
+			// when
+			List<Routine> sundayRoutines = routineRepository.findUnrecordedRoutinesForDate(USER,
+				sundayNight.toLocalDate(), List.of());
+			List<Routine> mondayRoutines = routineRepository.findUnrecordedRoutinesForDate(USER,
+				mondayMorning.toLocalDate(), List.of());
+
+			// then
+			assertThat(sundayRoutines).contains(SUNDAY_NIGHT_ROUTINE).doesNotContain(MONDAY_MORNING_ROUTINE);
+			assertThat(mondayRoutines).contains(MONDAY_MORNING_ROUTINE).doesNotContain(SUNDAY_NIGHT_ROUTINE);
+		}
+
+		@Test
+		void 동일한_요일_패턴을_가진_여러_루틴이_있을_때_모두_조회되는지_확인한다() {
+			// given
+			Routine WEEKDAY_MORNING_ROUTINE1 = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine WEEKDAY_MORNING_ROUTINE2 = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			LocalDate weekday = getNextDayOfWeek(DayOfWeek.MONDAY);
+
+			System.out.println("ㅎㅇ" + WEEKDAY_MORNING_ROUTINE1.getCreatedAt());
+
+			// when
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, weekday,
+				List.of());
+
+			// then
+			assertThat(unrecordedRoutines).contains(WEEKDAY_MORNING_ROUTINE1, WEEKDAY_MORNING_ROUTINE2);
+		}
+
+		@Disabled("삭제된 루틴에 대한 테스트 케이스 아직 구현되지 않음")
+		@Test
+		void 삭제된_루틴이_조회되지_않음을_확인한다() {
+			// TODO: 삭제된 루틴에 대한 테스트 케이스 구현
+		}
+
+		@Disabled("특정 기간 동안 유효한 루틴에 대한 테스트 케이스 아직 구현되지 않음")
+		@Test
+		void 특정_기간_동안만_유효한_루틴이_해당_기간_내외에서_올바르게_조회되는지_확인한다() {
+			// TODO: 특정 기간 동안 유효한 루틴에 대한 테스트 케이스 구현
+		}
+	}
+
+	private LocalDate getNextDayOfWeek(DayOfWeek dayOfWeek) {
+		return LocalDate.now().with(TemporalAdjusters.next(dayOfWeek));
+	}
+
+	private LocalDate getPreviousDayOfWeek(DayOfWeek dayOfWeek) {
+		return LocalDate.now().with(TemporalAdjusters.previous(dayOfWeek));
+	}
+
+}

--- a/src/test/java/im/toduck/fixtures/RoutineFixtures.java
+++ b/src/test/java/im/toduck/fixtures/RoutineFixtures.java
@@ -1,0 +1,123 @@
+package im.toduck.fixtures;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.vo.PlanCategoryColor;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.helper.DaysOfWeekBitmask;
+
+public class RoutineFixtures {
+
+	private static final LocalTime MORNING_TIME = LocalTime.of(7, 0);
+	private static final LocalTime NOON_TIME = LocalTime.of(12, 0);
+	private static final LocalTime EVENING_TIME = LocalTime.of(19, 0);
+	private static final LocalTime NIGHT_TIME = LocalTime.of(22, 0);
+
+	public static Routine MONDAY_ONLY_MORNING_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("월요일 아침 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.MONDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#FF0000"))
+			.isPublic(true)
+			.build();
+	}
+
+	public static Routine WEEKDAY_MORNING_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("평일 아침 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
+				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+					DayOfWeek.FRIDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#0000FF"))
+			.isPublic(false)
+			.build();
+	}
+
+	public static Routine WEEKEND_NOON_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("주말 점심 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)))
+			.time(NOON_TIME)
+			.color(PlanCategoryColor.from("#00FF00"))
+			.isPublic(true)
+			.build();
+	}
+
+	public static Routine DAILY_EVENING_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("매일 저녁 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(Arrays.asList(DayOfWeek.values())))
+			.time(EVENING_TIME)
+			.color(PlanCategoryColor.from("#FFA500"))
+			.isPublic(true)
+			.build();
+	}
+
+	public static Routine TUESDAY_THURSDAY_SATURDAY_NIGHT_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("화목토 밤 루틴")
+			.daysOfWeekBitmask(
+				DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY)))
+			.time(NIGHT_TIME)
+			.color(PlanCategoryColor.from("#800080"))
+			.isPublic(false)
+			.build();
+	}
+
+	public static Routine WEDNESDAY_FRIDAY_MORNING_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("수금 아침 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#FFA500"))
+			.isPublic(true)
+			.build();
+	}
+
+	public static Routine EVERYDAY_EXCEPT_SUNDAY_NOON_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("일요일 제외 매일 점심 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
+				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY,
+					DayOfWeek.SATURDAY)))
+			.time(NOON_TIME)
+			.color(PlanCategoryColor.from("#008080"))
+			.isPublic(false)
+			.build();
+	}
+
+	public static Routine FIRST_DAY_OF_WEEK_MORNING_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("월요일 아침 주간 시작 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.MONDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#4B0082"))
+			.isPublic(true)
+			.build();
+	}
+
+	public static Routine LAST_DAY_OF_WEEK_NIGHT_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("일요일 밤 주간 마무리 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SUNDAY)))
+			.time(NIGHT_TIME)
+			.color(PlanCategoryColor.from("#006400"))
+			.isPublic(false)
+			.build();
+	}
+}

--- a/src/test/java/im/toduck/fixtures/RoutineRecordFixtures.java
+++ b/src/test/java/im/toduck/fixtures/RoutineRecordFixtures.java
@@ -1,0 +1,72 @@
+package im.toduck.fixtures;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Random;
+
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+
+public class RoutineRecordFixtures {
+
+	private static final Random random = new Random();
+
+	public static RoutineRecord COMPLETED_SYNCED_RECORD(Routine routine) {
+		return createRoutineRecord(routine, true, false);
+	}
+
+	public static RoutineRecord INCOMPLETED_SYNCED_RECORD(Routine routine) {
+		return createRoutineRecord(routine, false, false);
+	}
+
+	public static RoutineRecord COMPLETED_MODIFIED_RECORD(Routine routine) {
+		return createRoutineRecord(routine, true, true);
+	}
+
+	public static RoutineRecord INCOMPLETED_MODIFIED_RECORD(Routine routine) {
+		return createRoutineRecord(routine, false, true);
+	}
+
+	private static RoutineRecord createRoutineRecord(Routine routine, boolean isCompleted, boolean isModified) {
+		LocalDateTime recordedAt = isModified ? calculateModifiedRecordAt(routine) : calculateSyncedRecordAt(routine);
+
+		return RoutineRecord.builder()
+			.routine(routine)
+			.recordAt(recordedAt)
+			.isAllDay(routine.getTime() == null)
+			.isCompleted(isCompleted)
+			.build();
+	}
+
+	private static LocalDateTime calculateSyncedRecordAt(Routine routine) {
+		return calculateRecordAt(routine, routine.getTime(), true);
+	}
+
+	private static LocalDateTime calculateModifiedRecordAt(Routine routine) {
+		return calculateRecordAt(routine, generateDifferentTime(routine.getTime()), false);
+	}
+
+	private static LocalDateTime calculateRecordAt(Routine routine, LocalTime time, boolean shouldIncludeDay) {
+		LocalDate startDate = routine.getCreatedAt().toLocalDate();
+		LocalTime routineTime = time != null ? time : LocalTime.MIDNIGHT;
+
+		while (true) {
+			if (routine.getDaysOfWeekBitmask().includesDayOf(startDate) == shouldIncludeDay) {
+				return LocalDateTime.of(startDate, routineTime);
+			}
+			startDate = startDate.plusDays(1);
+		}
+	}
+
+	private static LocalTime generateDifferentTime(LocalTime originalTime) {
+		LocalTime newTime;
+		do {
+			int hour = random.nextInt(24);
+			int minute = random.nextInt(60);
+			newTime = LocalTime.of(hour, minute);
+		} while (newTime.equals(originalTime));
+
+		return newTime;
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 루틴 목록 조회 API 개발**
자신의 루틴 목록을 날짜를 통해 조회하는 API를 개발했습니다.
가독성과 안정성 향상을 위해 QueryDSL을 사용하여 쿼리를 생성합니다. 

참고 링크: https://kyxxn.notion.site/672e4dbbd5a54bc7bb756cd6f5715b29?pvs=74

 <br/>

**2️⃣ Repository 계층 테스트를 위한 Base 작성**
BuilderSupproter에 Redis 관련 레포지터리도 포함되어 있어, `@DataJpaTest`와 `@DataRedisTest`를 모두 포함시켰습니다.

  <br/>

**3️⃣ 기타 기능 추가 및 수정**
- 테스트용 h2의 비트연산 대응을 위한 캐스팅 추가
참고: https://blog.hoony.me/2023/08/19/use-bitwise-operation-on-jpa

<br/>

## ✅ 리뷰 요구사항
`Routine` 이나 `RoutineRecord`와 같은 Entity의 CreatedAt이나 UpdatedAt이 비즈니스 로직이랑 연관되어 있어 테스트 시 해당 값들을 고정으로 가져가려고 했는데요(Fixture에서), Auditing 설정 때문에 해당 값들을 운영 코드의 수정 없이는 임의로 지정하지 못하는 상황입니다. 다양한 시도를 해보긴 했는데 혹시 좋은 아이디어 있으면 말해주세요!