### PR TITLE
AOP 로 적용된 로그에서 null 에러 해결

### DIFF
--- a/src/main/java/im/toduck/global/aop/log/LocalLogAspect.java
+++ b/src/main/java/im/toduck/global/aop/log/LocalLogAspect.java
@@ -1,5 +1,7 @@
 package im.toduck.global.aop.log;
 
+import java.util.Optional;
+
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
@@ -61,7 +63,7 @@ public class LocalLogAspect {
 			getLogDescription(methodSignature),
 			joinPoint,
 			methodSignature.getName(),
-			result
+			Optional.ofNullable(result)
 		);
 		log.info("성공 {} ", logProperty);
 	}

--- a/src/main/java/im/toduck/global/aop/log/ProdLogAspect.java
+++ b/src/main/java/im/toduck/global/aop/log/ProdLogAspect.java
@@ -1,5 +1,7 @@
 package im.toduck.global.aop.log;
 
+import java.util.Optional;
+
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterThrowing;
@@ -81,7 +83,7 @@ public class ProdLogAspect {
 			getLogDescription(methodSignature),
 			joinPoint,
 			methodSignature.getName(),
-			result
+			Optional.ofNullable(result)
 		);
 
 		long elapsedTime = System.currentTimeMillis() - startTime.get();

--- a/src/main/java/im/toduck/global/log/properties/InfoLogProperty.java
+++ b/src/main/java/im/toduck/global/log/properties/InfoLogProperty.java
@@ -2,6 +2,7 @@ package im.toduck.global.log.properties;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
@@ -21,13 +22,14 @@ public class InfoLogProperty extends LogProperty {
 		);
 	}
 
-	public static InfoLogProperty of(String description, JoinPoint joinPoint, String methodName, Object result) {
+	public static InfoLogProperty of(String description, JoinPoint joinPoint, String methodName,
+		Optional<Object> result) {
 		return new InfoLogProperty(
 			description,
 			joinPoint.getSignature().getDeclaringTypeName(),
 			((MethodSignature)joinPoint.getSignature()).getName(),
 			new Map[] {Map.of(
-				"result", result
+				"result", result.orElseGet(() -> "void")
 			)}
 		);
 	}


### PR DESCRIPTION
## ✨ 작업 내용



**1️⃣  로깅 null 에러 해결 **

- component에 적용되는 로깅이 매게인자와 반환값을 로그로 출력하는 과정에서 반환값이 null 이면 문자열 출력시 에러가 생겼습니다.
- 따라서 해당 부분을 Optional 대체 하였습니다.
![image](https://github.com/user-attachments/assets/72884ff7-843e-4ac4-b56d-99b0030deed8)

  <br/>


## ✅ 리뷰 요구사항(선택)
