### PR TITLE
루틴 삭제 API 개발

### DIFF
--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -93,6 +93,8 @@ public class RoutineMapper {
 			.color(routine.getColorValue())
 			.title(routine.getTitle())
 			.time(routine.getTime())
+			.isPublic(routine.getIsPublic())
+			.isInDeletedState(routine.isInDeletedState())
 			.daysOfWeek(daysOfWeek)
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
@@ -47,4 +47,12 @@ public class RoutineRecordService {
 			})
 			.orElse(false);
 	}
+
+	public void removeIncompletedFuturesByRoutine(final Routine routine) {
+		routineRecordRepository.deleteIncompletedFuturesByRoutine(routine);
+	}
+
+	public void removeAllByRoutine(final Routine routine) {
+		routineRecordRepository.deleteAllByRoutine(routine);
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -37,10 +37,11 @@ public class RoutineService {
 		final LocalDate date,
 		final List<RoutineRecord> routineRecords
 	) {
+		// TODO: 여기에선 삭제되면 조회되면 안됨, 근데 삭제 시점 미래 기준으로는 조회가 안되는거고 과거 시점이면 조회가 되어야함
 		return routineRepository.findUnrecordedRoutinesForDate(user, date, routineRecords);
 	}
 
-	public Optional<Routine> getUserRoutine(final User user, final Long id) {
+	public Optional<Routine> getUserRoutineIncludingDeleted(final User user, final Long id) {
 		return routineRepository.findByIdAndUser(id, user);
 	}
 
@@ -49,6 +50,10 @@ public class RoutineService {
 	}
 
 	public List<Routine> getAvailableRoutine(final User user) {
-		return routineRepository.findAllByUserAndIsPublicTrueOrderByUpdatedAtDesc(user);
+		return routineRepository.findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByUpdatedAtDesc(user);
+	}
+
+	public void remove(final Routine routine) {
+		routineRepository.softDelete(routine);
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -53,7 +53,9 @@ public class RoutineService {
 		return routineRepository.findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByUpdatedAtDesc(user);
 	}
 
+	@Transactional
 	public void remove(final Routine routine) {
-		routineRepository.softDelete(routine);
+		routine.delete();
+		routineRepository.save(routine);
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
+++ b/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
@@ -49,7 +49,6 @@ public class RoutineUseCase {
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
 		List<RoutineRecord> routineRecords = routineRecordService.getRecords(user, date);
-		// TODO: 여기에선 삭제되면 조회되면 안됨, 근데 삭제 시점 미래 기준으로는 조회가 안되는거고 과거 시점이면 조회가 되어야함
 		List<Routine> routines = routineService.getUnrecordedRoutinesForDate(user, date, routineRecords);
 
 		log.info("본인 루틴 기록 목록 조회 - UserId: {}, 조회한 날짜: {}", userId, date);
@@ -64,7 +63,6 @@ public class RoutineUseCase {
 	) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-		// TODO: 여기에선 삭제되었어도 조회되야함
 		Routine routine = routineService.getUserRoutineIncludingDeleted(user, routineId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_ROUTINE));
 
@@ -96,7 +94,6 @@ public class RoutineUseCase {
 	public RoutineDetailResponse readDetail(final Long userId, final Long routineId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-		// TODO: 여기에선 삭제되었어도 조회되야함
 		Routine routine = routineService.getUserRoutineIncludingDeleted(user, routineId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_ROUTINE));
 
@@ -107,7 +104,6 @@ public class RoutineUseCase {
 	public MyRoutineAvailableListResponse readMyAvailableRoutineList(final Long userId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-		// TODO: 여기에선 삭제되면 조회되면 안됨
 		List<Routine> routines = routineService.getAvailableRoutine(user);
 
 		log.info("사용가능한 본인 루틴 목록 조회 - 사용자 Id: {}", userId);
@@ -118,7 +114,6 @@ public class RoutineUseCase {
 	public void deleteRoutine(final Long userId, final Long routineId, final boolean keepRecords) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-		// TODO: 여기에선 삭제되었어도 조회되야함
 		Routine routine = routineService.getUserRoutineIncludingDeleted(user, routineId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_ROUTINE));
 

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -98,4 +98,8 @@ public class Routine extends BaseEntity {
 	public String getMemoValue() {
 		return memo.getValue();
 	}
+
+	public Boolean isInDeletedState() {
+		return deletedAt != null;
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -1,5 +1,6 @@
 package im.toduck.domain.routine.persistence.entity;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import im.toduck.domain.person.persistence.entity.PlanCategory;
@@ -97,6 +98,10 @@ public class Routine extends BaseEntity {
 
 	public String getMemoValue() {
 		return memo.getValue();
+	}
+
+	public void delete() {
+		this.deletedAt = LocalDateTime.now();
 	}
 
 	public Boolean isInDeletedState() {

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepository.java
@@ -3,9 +3,11 @@ package im.toduck.domain.routine.persistence.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.routine.persistence.repository.querydsl.RoutineRecordRepositoryCustom;
 
 @Repository
 public interface RoutineRecordRepository extends JpaRepository<RoutineRecord, Long>, RoutineRecordRepositoryCustom {
+	void deleteAllByRoutine(final Routine routine);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
@@ -14,5 +14,5 @@ import im.toduck.domain.user.persistence.entity.User;
 public interface RoutineRepository extends JpaRepository<Routine, Long>, RoutineRepositoryCustom {
 	Optional<Routine> findByIdAndUser(Long id, User user);
 
-	List<Routine> findAllByUserAndIsPublicTrueOrderByUpdatedAtDesc(User user);
+	List<Routine> findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByUpdatedAtDesc(User user);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface RoutineRecordRepositoryCustom {
 		final Routine routine,
 		final LocalDate date
 	);
+
+	void deleteIncompletedFuturesByRoutine(final Routine routine);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package im.toduck.domain.routine.persistence.repository.querydsl;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,5 +58,17 @@ public class RoutineRecordRepositoryCustomImpl implements RoutineRecordRepositor
 			date.atStartOfDay(),
 			date.plusDays(1).atStartOfDay().minusNanos(1)
 		);
+	}
+
+	@Override
+	public void deleteIncompletedFuturesByRoutine(final Routine routine) {
+		queryFactory
+			.delete(qRecord)
+			.where(
+				qRecord.routine.eq(routine),
+				qRecord.recordAt.after(LocalDateTime.now()),
+				qRecord.isCompleted.isFalse()
+			)
+			.execute();
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface RoutineRepositoryCustom {
 	);
 
 	boolean isActiveForDate(final Routine routine, final LocalDate date);
+
+	void softDelete(final Routine routine);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
@@ -16,5 +16,4 @@ public interface RoutineRepositoryCustom {
 
 	boolean isActiveForDate(final Routine routine, final LocalDate date);
 
-	void softDelete(final Routine routine);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
@@ -69,17 +69,6 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 		return fetchOne != null;
 	}
 
-	@Override
-	public void softDelete(final Routine routine) {
-		queryFactory
-			.update(qRoutine)
-			.set(qRoutine.deletedAt, LocalDateTime.now())
-			.where(
-				qRoutine.eq(routine)
-			)
-			.execute();
-	}
-
 	private BooleanExpression routineNotDeletedOrDeletedAfterDate(
 		final TimePath<LocalTime> timePath,
 		final LocalDate date

--- a/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
@@ -95,7 +95,7 @@ public interface RoutineApi {
 	ResponseEntity<ApiResponse<RoutineDetailResponse>> getMyRoutineDetail(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
 		@Parameter(description = "상세 조회할 루틴의 Id", required = true, example = "1")
-		@PathVariable Long routineId
+		@PathVariable final Long routineId
 	);
 
 	@Operation(
@@ -110,5 +110,25 @@ public interface RoutineApi {
 	)
 	ResponseEntity<ApiResponse<MyRoutineAvailableListResponse>> getMyAvailableRoutineList(
 		@AuthenticationPrincipal final CustomUserDetails userDetails
+	);
+
+	@Operation(
+		summary = "루틴 삭제",
+		description = "루틴을 삭제합니다. keepRecords 파라미터를 통해 이전 기록 유지 여부를 결정할 수 있습니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "루틴 삭제 성공"
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_ROUTINE)
+		}
+	)
+	ResponseEntity<ApiResponse<?>> deleteRoutine(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@Parameter(description = "삭제할 루틴의 Id", required = true, example = "1")
+		@PathVariable final Long routineId,
+		@Parameter(description = "기록 유지 여부 (true: 기록 유지, false: 모두 삭제)", required = true)
+		@RequestParam final Boolean keepRecords
 	);
 }

--- a/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
@@ -6,6 +6,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -94,6 +95,21 @@ public class RoutineController implements RoutineApi {
 	) {
 		return ResponseEntity.ok(
 			ApiResponse.createSuccess(routineUseCase.readMyAvailableRoutineList(userDetails.getUserId()))
+		);
+	}
+
+	@Override
+	@DeleteMapping("/{routineId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> deleteRoutine(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long routineId,
+		@RequestParam final Boolean keepRecords
+	) {
+		routineUseCase.deleteRoutine(userDetails.getUserId(), routineId, keepRecords);
+
+		return ResponseEntity.ok(
+			ApiResponse.createSuccessWithNoContent()
 		);
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/response/RoutineDetailResponse.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/response/RoutineDetailResponse.java
@@ -33,6 +33,12 @@ public record RoutineDetailResponse(
 	@Schema(description = "루틴 시간(null 이면 종일 루틴)", example = "14:30")
 	LocalTime time,
 
+	@Schema(description = "루틴 공개/비공개 여부", example = "true")
+	Boolean isPublic,
+
+	@Schema(description = "이미 삭제된 루틴인지 여부, true 일 경우 이미 모 루틴이 삭제된 상태임", example = "true")
+	Boolean isInDeletedState,
+
 	@JsonSerialize(using = DayOfWeekListSerializer.class)
 	@Schema(description = "반복 요일", example = "[\"MONDAY\",\"TUESDAY\"]")
 	List<DayOfWeek> daysOfWeek,

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
@@ -116,10 +116,31 @@ class RoutineUseCaseTest extends ServiceTest {
 
 		}
 
-		@Disabled("추후 테스트 필요")
 		@Test
 		void 모_루틴이_Soft_DELETE_된_경우에도_루틴_기록이_존재한다면_정상적으로_조회할_수_있다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(DELETED_MONDAY_ONLY_MORNING_ROUTINE(USER,
+				getNextDayOfWeek(DayOfWeek.MONDAY).plusDays(7).atTime(7, 59, 59))
+			);
 
+			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_SYNCED_RECORD(ROUTINE)
+			);
+			LocalDate queryDate = RECORD.getRecordAt().toLocalDate();
+
+			// when
+			MyRoutineRecordReadListResponse responses = routineUseCase.readMyRoutineRecordList(USER.getId(), queryDate);
+
+			// then
+			assertSoftly(softly -> {
+				assertThat(responses.queryDate()).isEqualTo(queryDate);
+				assertThat(responses.routines()).hasSize(1);
+
+				MyRoutineRecordReadListResponse.MyRoutineReadResponse response = responses.routines().get(0);
+				assertThat(response.routineId()).isEqualTo(ROUTINE.getId());
+				assertThat(response.isCompleted()).isEqualTo(RECORD.getIsCompleted());
+				assertThat(response.time()).isEqualTo(RECORD.getRecordAt().toLocalTime());
+			});
 		}
 	}
 

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
@@ -34,8 +34,6 @@ import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadLis
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.exception.CommonException;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 
 ;
 
@@ -43,9 +41,6 @@ import jakarta.persistence.PersistenceContext;
 class RoutineUseCaseTest extends ServiceTest {
 
 	private User USER;
-
-	@PersistenceContext
-	private EntityManager entityManager;
 
 	@Autowired
 	private RoutineUseCase routineUseCase;
@@ -286,7 +281,6 @@ class RoutineUseCaseTest extends ServiceTest {
 
 			// when
 			routineUseCase.deleteRoutine(USER.getId(), routine.getId(), false);
-			entityManager.clear();
 
 			// then
 			List<RoutineRecord> remainingRecords = routineRecordRepository.findAll();
@@ -322,7 +316,6 @@ class RoutineUseCaseTest extends ServiceTest {
 
 			// when
 			routineUseCase.deleteRoutine(USER.getId(), routine.getId(), true);
-			entityManager.clear();
 
 			// then
 			List<RoutineRecord> remainingRecords = routineRecordRepository.findAll();

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
@@ -13,7 +13,6 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -133,16 +132,36 @@ class RoutineRepositoryTest extends RepositoryTest {
 			assertThat(unrecordedRoutines).contains(WEEKDAY_MORNING_ROUTINE1, WEEKDAY_MORNING_ROUTINE2);
 		}
 
-		@Disabled("삭제된 루틴에 대한 테스트 케이스 아직 구현되지 않음")
 		@Test
-		void 삭제된_루틴이_조회되지_않는다() {
-			// TODO: 삭제된 루틴에 대한 테스트 케이스 구현
+		void 루틴이_삭제되었더라면_삭제시점_이후_날짜로_조회시_조회되지_않는다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(
+				DELETED_MONDAY_ONLY_MORNING_ROUTINE(USER,
+					getNextDayOfWeek(DayOfWeek.MONDAY).minusDays(1).atTime(23, 59, 59))
+			);
+			LocalDate monday = getNextDayOfWeek(DayOfWeek.MONDAY);
+
+			// when
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, monday, List.of());
+
+			// then
+			assertThat(unrecordedRoutines).doesNotContain(ROUTINE);
 		}
 
-		@Disabled("특정 기간 동안 유효한 루틴에 대한 테스트 케이스 아직 구현되지 않음")
 		@Test
 		void 특정_기간_동안만_유효한_루틴이_해당_기간_내에서_올바르게_조회된다() {
-			// TODO: 특정 기간 동안 유효한 루틴에 대한 테스트 케이스 구현
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(
+				DELETED_MONDAY_ONLY_MORNING_ROUTINE(USER,
+					getNextDayOfWeek(DayOfWeek.MONDAY).plusDays(7).atTime(7, 59, 59))
+			);
+			LocalDate monday = getNextDayOfWeek(DayOfWeek.MONDAY);
+
+			// when
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, monday, List.of());
+
+			// then
+			assertThat(unrecordedRoutines).contains(ROUTINE);
 		}
 	}
 
@@ -188,16 +207,36 @@ class RoutineRepositoryTest extends RepositoryTest {
 			assertThat(isActive).isFalse();
 		}
 
-		@Disabled
 		@Test
-		void 모_루틴이_삭제된_경우에도_정상적으로_확인한다() {
-			// TODO: 삭제된 루틴에 대한 테스트 케이스 구현
+		void 루틴이_삭제되었더라면_삭제시점_이후_날짜에_대해_정상적으로_확인된다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(
+				DELETED_MONDAY_ONLY_MORNING_ROUTINE(USER,
+					getNextDayOfWeek(DayOfWeek.MONDAY).minusDays(1).atTime(23, 59, 59))
+			);
+			LocalDate monday = getNextDayOfWeek(DayOfWeek.MONDAY);
+
+			// when
+			boolean isActive = routineRepository.isActiveForDate(ROUTINE, monday);
+
+			// then
+			assertThat(isActive).isFalse();
 		}
 
-		@Disabled
 		@Test
-		void 특정_기간_동안만_유효한_루틴이_해당_기간_내에서_확인된다() {
-			// TODO: 특정 기간 동안 유효한 루틴에 대한 테스트 케이스 구현
+		void 특정_기간_동안만_유효한_루틴이_해당_기간_내에서_정상적으로_확인된다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(
+				DELETED_MONDAY_ONLY_MORNING_ROUTINE(USER,
+					getNextDayOfWeek(DayOfWeek.MONDAY).plusDays(7).atTime(7, 59, 59))
+			);
+			LocalDate monday = getNextDayOfWeek(DayOfWeek.MONDAY);
+
+			// when
+			boolean isActive = routineRepository.isActiveForDate(ROUTINE, monday);
+
+			// then
+			assertThat(isActive).isTrue();
 		}
 	}
 
@@ -208,5 +247,4 @@ class RoutineRepositoryTest extends RepositoryTest {
 	private LocalDate getPreviousDayOfWeek(DayOfWeek dayOfWeek) {
 		return LocalDate.now().with(TemporalAdjusters.previous(dayOfWeek));
 	}
-
 }

--- a/src/test/java/im/toduck/fixtures/RoutineFixtures.java
+++ b/src/test/java/im/toduck/fixtures/RoutineFixtures.java
@@ -1,9 +1,12 @@
 package im.toduck.fixtures;
 
 import java.time.DayOfWeek;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
+
+import org.springframework.test.util.ReflectionTestUtils;
 
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.vo.PlanCategoryColor;
@@ -130,5 +133,13 @@ public class RoutineFixtures {
 			.color(PlanCategoryColor.from("#006400"))
 			.isPublic(false)
 			.build();
+
+	}
+
+	public static Routine DELETED_MONDAY_ONLY_MORNING_ROUTINE(User user, LocalDateTime dateTime) {
+		Routine routine = MONDAY_ONLY_MORNING_ROUTINE(user);
+		ReflectionTestUtils.setField(routine, "deletedAt", dateTime);
+
+		return routine;
 	}
 }


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 루틴 삭제 기능 구현**
- Soft Delete 방식으로 구현 (deletedAt 필드 추가)
- 삭제 옵션 제공
  - `keepRecords=true`: 기존 루틴 기록 유지 (단, 미래의 미완료 기록은 삭제)
  - `keepRecords=false`: 모든 루틴 기록 삭제

<br/>

**2️⃣ 삭제된 루틴 접근성 개선**
- 삭제된 루틴도 조회 가능하도록 `getUserRoutineIncludingDeleted()` 메서드 추가
- 삭제 상태 여부를 응답에 포함 (`isInDeletedState` 필드 추가)
- 루틴의 삭제 시점 이전의 기록은 조회 가능하고, 이후의 기록은 조회 불가능하도록 구현

<br/>

**3️⃣ 삭제된 루틴 조회 로직 개선**
- 삭제된 루틴의 경우 삭제 시점 이후의 날짜로는 조회되지 않도록 수정
- Repository 계층에서 `routineNotDeletedOrDeletedAfterDate()` 추가하여 로직 구현

```java
// 날짜+시간이 삭제 시점보다 이전인 경우만 조회되도록 처리
private BooleanExpression routineNotDeletedOrDeletedAfterDate(
    final TimePath<LocalTime> timePath, 
    final LocalDate date 
) {
  return qRoutine.deletedAt.isNull().or(
    Expressions.booleanTemplate(
      "cast(concat({0}, ' ', cast({1} as time)) as timestamp) < {2}",
      date,
      timePath,
      qRoutine.deletedAt
    )
  );
}
```
**1. 해당 조건은 다음 두 가지 경우를 OR로 검사:**
- 루틴이 삭제되지 않은 경우 (`deletedAt is null`)
- 루틴이 삭제되었지만, 주어진 날짜와 시간이 삭제 시점보다 이전인 경우

**2. 삭제 시점 비교 쿼리 설명:**
- `concat({0}, ' ', cast({1} as time))`: 주어진 날짜와 루틴 시간을 결합 (예: "2024-11-28 14:00:00")
- `cast(...as timestamp)`: 결합된 문자열을 timestamp로 변환
- `< {2}`: 변환된 timestamp가 삭제 시점보다 이전인지 확인

이를 통해 루틴이 삭제된 이후 시점의 조회는 제외되고, 삭제 이전 시점의 조회는 가능하도록 구현되었습니다.


<br/>

**🚨 Troubleshooting**

**문제**: QueryDSL 벌크 연산 사용 시 영속성 컨텍스트와 동기화되지 않아 `deletedAt` 필드가 정상 반영되지 않음

**발생 현상**:
- `RoutineRepositoryCustomImpl.softDelete()`에서 벌크 연산으로 `deletedAt` 업데이트
- 이후 조회 시 `deletedAt` 값이 null로 조회됨

**원인**:
1. QueryDSL의 update(), delete() 등 연산이 벌크 연산으로 동작
2. QueryDSL의 벌크 연산은 영속성 컨텍스트를 우회
3. 영속성 컨텍스트의 1차 캐시에는 이전 상태가 유지됨

**해결**:
 JPA의 Dirty Checking을 활용해 엔티티의 상태를 직접 변경하고 명시적으로 저장하도록 함 https://github.com/toduck-App/toduck-backend/pull/30/commits/034968b09c30d0a6763dfcdf5507cfc4c23a3e0b

<br/>

## ✅ 리뷰 요구사항
**1. Soft Delete 구현의 적절성**
- deletedAt 필드를 통한 구현이 적절한지
- 삭제된 루틴의 접근 제어가 적절한지

**2. 레코드 보존/삭제 옵션**
- keepRecords 옵션을 통한 기록 관리 방식이 적절한지
- 미래의 미완료 기록만 삭제하는 로직이 적절한지

**3. 조회 로직**
- 삭제 시점을 기준으로 한 조회 제어 로직이 비즈니스 요구사항에 부합하는지

<br/>

**모든 변경사항에 대한 테스트 코드가 추가되었으니 함께 리뷰 부탁드립니다!**
