### PR TITLE
소셜 게시글과 루틴 연동

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -2,212 +2,212 @@ USE toduck;
 
 CREATE TABLE users
 (
- -- TODO: 3. users 테이블  oauth 사용 시 필요한 사용자 식별값 → oauth 에서 전화번호 수집이 가능한지 다시 확인 필요
- id           BIGINT PRIMARY KEY auto_increment,
- nickname     VARCHAR(100)                               NOT NULL,
- phone_number VARCHAR(50)                                NULL,
- login_id     VARCHAR(100)                               NULL,
- password     VARCHAR(255)                               NULL,
- email        VARCHAR(100)                               NULL,
- role         ENUM ('ADMIN', 'USER')                     NOT NULL,
- provider     ENUM ('KAKAO', 'NAVER', 'GOOGLE', 'APPLE') NULL,
- created_at   DATETIME                                   NOT NULL,
- updated_at   DATETIME                                   NOT NULL,
- deleted_at   DATETIME                                   NULL
-);
-
-CREATE TABLE social
-(
- id           BIGINT PRIMARY KEY auto_increment,
- user_id      BIGINT                             NOT NULL,
- routine_id   BIGINT                             NULL,
- content      VARCHAR(255)                       NOT NULL,
- is_anonymous BOOLEAN                            NOT NULL,
- like_count   int                                NOT NULL DEFAULT 0,
- created_at   DATETIME                           NOT NULL,
- updated_at   DATETIME                           NOT NULL,
- deleted_at   DATETIME                           NULL,
- FOREIGN KEY (user_id) REFERENCES users (id),
- FOREIGN KEY (routine_id) REFERENCES routine (id)
+    -- TODO: 3. users 테이블  oauth 사용 시 필요한 사용자 식별값 → oauth 에서 전화번호 수집이 가능한지 다시 확인 필요
+    id           BIGINT PRIMARY KEY auto_increment,
+    nickname     VARCHAR(100)                               NOT NULL,
+    phone_number VARCHAR(50)                                NULL,
+    login_id     VARCHAR(100)                               NULL,
+    password     VARCHAR(255)                               NULL,
+    email        VARCHAR(100)                               NULL,
+    role         ENUM ('ADMIN', 'USER')                     NOT NULL,
+    provider     ENUM ('KAKAO', 'NAVER', 'GOOGLE', 'APPLE') NULL,
+    created_at   DATETIME                                   NOT NULL,
+    updated_at   DATETIME                                   NOT NULL,
+    deleted_at   DATETIME                                   NULL
 );
 
 CREATE TABLE routine
 (
-id          BIGINT PRIMARY KEY auto_increment,
-user_id     BIGINT                         NOT NULL,
+    id               BIGINT PRIMARY KEY auto_increment,
+    user_id          BIGINT                                              NOT NULL,
 -- TODO: 8. routine 의 이모지 필드 enum 값 필요
-category    ENUM ('STUDY', 'EXERCISE', 'FOOD', 'SLEEP', 'PLAY')  NULL,
+    category         ENUM ('STUDY', 'EXERCISE', 'FOOD', 'SLEEP', 'PLAY') NULL,
 -- TODO: 4. routine 테이블의 color enum 값 필요
-color       VARCHAR(10)                    NULL,
-time        TIME                           NULL,
-days_of_week TINYINT UNSIGNED              NOT NULL,
-title       CHAR(100)                      NOT NULL,
-is_public   BOOLEAN                        NOT NULL,
-reminder_minutes INT UNSIGNED              NULL,
-memo        TEXT                           NULL,
-created_at  DATETIME                       NOT NULL,
-updated_at  DATETIME                       NOT NULL,
-deleted_at  DATETIME                       NULL,
-FOREIGN KEY (user_id) REFERENCES users (id)
+    color            VARCHAR(10)                                         NULL,
+    time             TIME                                                NULL,
+    days_of_week     TINYINT UNSIGNED                                    NOT NULL,
+    title            CHAR(100)                                           NOT NULL,
+    is_public        BOOLEAN                                             NOT NULL,
+    reminder_minutes INT UNSIGNED                                        NULL,
+    memo             TEXT                                                NULL,
+    created_at       DATETIME                                            NOT NULL,
+    updated_at       DATETIME                                            NOT NULL,
+    deleted_at       DATETIME                                            NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE social
+(
+    id           BIGINT PRIMARY KEY auto_increment,
+    user_id      BIGINT       NOT NULL,
+    routine_id   BIGINT       NULL,
+    content      VARCHAR(255) NOT NULL,
+    is_anonymous BOOLEAN      NOT NULL,
+    like_count   int          NOT NULL DEFAULT 0,
+    created_at   DATETIME     NOT NULL,
+    updated_at   DATETIME     NOT NULL,
+    deleted_at   DATETIME     NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (routine_id) REFERENCES routine (id)
 );
 
 CREATE TABLE routine_record
 (
-    id BIGINT PRIMARY KEY AUTO_INCREMENT,
-    routine_id BIGINT NULL,
-    record_at DATETIME NOT NULL,
-    is_all_day BOOLEAN NOT NULL,
-    is_completed BOOLEAN NOT NULL DEFAULT false,
-    created_at DATETIME NOT NULL,
-    updated_at DATETIME NOT NULL,
-    deleted_at DATETIME NULL,
+    id           BIGINT PRIMARY KEY AUTO_INCREMENT,
+    routine_id   BIGINT   NULL,
+    record_at    DATETIME NOT NULL,
+    is_all_day   BOOLEAN  NOT NULL,
+    is_completed BOOLEAN  NOT NULL DEFAULT false,
+    created_at   DATETIME NOT NULL,
+    updated_at   DATETIME NOT NULL,
+    deleted_at   DATETIME NULL,
     FOREIGN KEY (routine_id) REFERENCES routine (id) ON DELETE SET NULL
 );
 
 CREATE TABLE comment
 (
- id         BIGINT PRIMARY KEY AUTO_INCREMENT,
- user_id    BIGINT   NOT NULL,
- social_id  BIGINT   NOT NULL,
- content    TEXT     NOT NULL,
- created_at DATETIME NOT NULL,
- updated_at DATETIME NOT NULL,
- deleted_at DATETIME NULL,
- FOREIGN KEY (user_id) REFERENCES users (id),
- FOREIGN KEY (social_id) REFERENCES social (id)
+    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id    BIGINT   NOT NULL,
+    social_id  BIGINT   NOT NULL,
+    content    TEXT     NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (social_id) REFERENCES social (id)
 );
 
 CREATE TABLE likes
 (
- id         BIGINT PRIMARY KEY auto_increment,
- user_id    BIGINT   NOT NULL,
- social_id  BIGINT   NOT NULL,
- created_at DATETIME NOT NULL,
- updated_at DATETIME NOT NULL,
- deleted_at DATETIME NULL,
- FOREIGN KEY (user_id) REFERENCES users (id),
- FOREIGN KEY (social_id) REFERENCES social (id)
+    id         BIGINT PRIMARY KEY auto_increment,
+    user_id    BIGINT   NOT NULL,
+    social_id  BIGINT   NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (social_id) REFERENCES social (id)
 );
 
 CREATE TABLE shared_routine
 (
- id         BIGINT PRIMARY KEY auto_increment,
- created_at DATETIME NOT NULL,
- updated_at DATETIME NOT NULL,
- deleted_at DATETIME NULL,
- user_id    BIGINT   NOT NULL,
- social_id  BIGINT   NOT NULL,
- FOREIGN KEY (user_id) REFERENCES users (id),
- FOREIGN KEY (social_id) REFERENCES routine (id)
+    id         BIGINT PRIMARY KEY auto_increment,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME NULL,
+    user_id    BIGINT   NOT NULL,
+    social_id  BIGINT   NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (social_id) REFERENCES routine (id)
 );
 
 CREATE TABLE social_category
 (
- id         BIGINT PRIMARY KEY auto_increment,
- name       VARCHAR(20) NOT NULL,
- created_at DATETIME    NOT NULL,
- updated_at DATETIME    NOT NULL,
- deleted_at DATETIME    NULL
+    id         BIGINT PRIMARY KEY auto_increment,
+    name       VARCHAR(20) NOT NULL,
+    created_at DATETIME    NOT NULL,
+    updated_at DATETIME    NOT NULL,
+    deleted_at DATETIME    NULL
 );
 
 CREATE TABLE social_image_file
 (
- id         BIGINT PRIMARY KEY auto_increment,
- social_id  BIGINT        NOT NULL,
- url        VARCHAR(1024) NOT NULL,
- created_at DATETIME      NOT NULL,
- updated_at DATETIME      NOT NULL,
- deleted_at DATETIME      NULL,
- FOREIGN KEY (social_id) REFERENCES social (id)
+    id         BIGINT PRIMARY KEY auto_increment,
+    social_id  BIGINT        NOT NULL,
+    url        VARCHAR(1024) NOT NULL,
+    created_at DATETIME      NOT NULL,
+    updated_at DATETIME      NOT NULL,
+    deleted_at DATETIME      NULL,
+    FOREIGN KEY (social_id) REFERENCES social (id)
 );
 
 CREATE TABLE schedule
 (
- id          BIGINT PRIMARY KEY auto_increment,
- user_id     BIGINT         NOT NULL,
- -- TODO: 8. routine 의 이모지 필드 enum 값 필요
- emoji       ENUM ('SMILE') NOT NULL,
- -- TODO: 4. routine 테이블의 color enum 값 필요
- color       ENUM ('RED')   NOT NULL,
- is_complete BOOLEAN        NOT NULL,
- time        TIME           NULL,
- title       CHAR(100)      NOT NULL,
- location    VARCHAR(255)   NOT NULL,
- routine_day DATE           NULL,
- alarm       ENUM ('10', '30', '60', 'OFF')   NOT NULL,
- memo        CHAR(255)      NOT NULL,
- created_at  DATETIME       NOT NULL,
- updated_at  DATETIME       NOT NULL,
- deleted_at  DATETIME       NULL,
- FOREIGN KEY (user_id) REFERENCES users (id)
+    id          BIGINT PRIMARY KEY auto_increment,
+    user_id     BIGINT                         NOT NULL,
+    -- TODO: 8. routine 의 이모지 필드 enum 값 필요
+    emoji       ENUM ('SMILE')                 NOT NULL,
+    -- TODO: 4. routine 테이블의 color enum 값 필요
+    color       ENUM ('RED')                   NOT NULL,
+    is_complete BOOLEAN                        NOT NULL,
+    time        TIME                           NULL,
+    title       CHAR(100)                      NOT NULL,
+    location    VARCHAR(255)                   NOT NULL,
+    routine_day DATE                           NULL,
+    alarm       ENUM ('10', '30', '60', 'OFF') NOT NULL,
+    memo        CHAR(255)                      NOT NULL,
+    created_at  DATETIME                       NOT NULL,
+    updated_at  DATETIME                       NOT NULL,
+    deleted_at  DATETIME                       NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 CREATE TABLE record
 (
- id         BIGINT PRIMARY KEY auto_increment,
- user_id    BIGINT                                                     NOT NULL,
- time       TIME                                                       NOT NULL,
- diary      VARCHAR(2048)                                              NULL,
- emotion    ENUM ('HAPPY', 'CALM', 'SAD', 'ANGRY', 'ANXIOUS', 'TIRED') NOT NULL,
- created_at DATETIME                                                   NOT NULL,
- updated_at DATETIME                                                   NOT NULL,
- deleted_at DATETIME                                                   NULL,
- FOREIGN KEY (user_id) REFERENCES users (id)
+    id         BIGINT PRIMARY KEY auto_increment,
+    user_id    BIGINT                                                     NOT NULL,
+    time       TIME                                                       NOT NULL,
+    diary      VARCHAR(2048)                                              NULL,
+    emotion    ENUM ('HAPPY', 'CALM', 'SAD', 'ANGRY', 'ANXIOUS', 'TIRED') NOT NULL,
+    created_at DATETIME                                                   NOT NULL,
+    updated_at DATETIME                                                   NOT NULL,
+    deleted_at DATETIME                                                   NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 CREATE TABLE follow
 (
- id          BIGINT PRIMARY KEY auto_increment,
- created_at  DATETIME NOT NULL,
- updated_at  DATETIME NOT NULL,
- deleted_at  DATETIME NULL,
- followed_id BIGINT   NOT NULL,
- follower_id BIGINT   NOT NULL,
- FOREIGN KEY (followed_id) REFERENCES users (id),
- FOREIGN KEY (follower_id) REFERENCES users (id)
+    id          BIGINT PRIMARY KEY auto_increment,
+    created_at  DATETIME NOT NULL,
+    updated_at  DATETIME NOT NULL,
+    deleted_at  DATETIME NULL,
+    followed_id BIGINT   NOT NULL,
+    follower_id BIGINT   NOT NULL,
+    FOREIGN KEY (followed_id) REFERENCES users (id),
+    FOREIGN KEY (follower_id) REFERENCES users (id)
 );
 
 CREATE TABLE social_category_link
 (
- id                 BIGINT PRIMARY KEY auto_increment,
- created_at         DATETIME NOT NULL,
- updated_at         DATETIME NOT NULL,
- deleted_at         DATETIME NULL,
- social_id          BIGINT   NOT NULL,
- social_category_id BIGINT   NOT NULL,
- FOREIGN KEY (social_id) REFERENCES social (id),
- FOREIGN KEY (social_category_id) REFERENCES social_category (id)
+    id                 BIGINT PRIMARY KEY auto_increment,
+    created_at         DATETIME NOT NULL,
+    updated_at         DATETIME NOT NULL,
+    deleted_at         DATETIME NULL,
+    social_id          BIGINT   NOT NULL,
+    social_category_id BIGINT   NOT NULL,
+    FOREIGN KEY (social_id) REFERENCES social (id),
+    FOREIGN KEY (social_category_id) REFERENCES social_category (id)
 );
 
 INSERT INTO social_category (name, created_at, updated_at)
 VALUES ('CONCENTRATION', NOW(), NOW()),
- ('MEMORY', NOW(), NOW()),
- ('IMPULSE', NOW(), NOW()),
- ('ANXIETY', NOW(), NOW()),
- ('SLEEP', NOW(), NOW());
+       ('MEMORY', NOW(), NOW()),
+       ('IMPULSE', NOW(), NOW()),
+       ('ANXIETY', NOW(), NOW()),
+       ('SLEEP', NOW(), NOW());
 
 CREATE TABLE block
 (
- id	            BIGINT	PRIMARY KEY AUTO_INCREMENT,
- blocker_id	    BIGINT	    NOT NULL,
- blocked_id	    BIGINT	    NOT NULL,
- created_at	    DATETIME	NOT NULL,
- updated_at	    DATETIME	NOT NULL,
- deleted_at	    DATETIME	NULL,
- FOREIGN KEY (blocker_id) REFERENCES users (id),
- FOREIGN KEY (blocked_id) REFERENCES users (id)
+    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
+    blocker_id BIGINT   NOT NULL,
+    blocked_id BIGINT   NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (blocker_id) REFERENCES users (id),
+    FOREIGN KEY (blocked_id) REFERENCES users (id)
 );
 
 CREATE TABLE report
 (
-id          BIGINT PRIMARY KEY auto_increment,
-user_id     BIGINT       NOT NULL,
-social_id   BIGINT       NOT NULL,
-report_type ENUM('NOT_RELATED_TO_SERVICE', 'PRIVACY_RISK', 'COMMERCIAL_ADVERTISEMENT', 'INAPPROPRIATE_CONTENT', 'OTHER') NOT NULL,
-reason      VARCHAR(255) NULL,
-created_at  DATETIME     NOT NULL,
-updated_at  DATETIME     NOT NULL,
-deleted_at  DATETIME     NULL,
-FOREIGN KEY (user_id) REFERENCES users (id),
-FOREIGN KEY (social_id) REFERENCES social (id)
+    id          BIGINT PRIMARY KEY auto_increment,
+    user_id     BIGINT                                                                                                        NOT NULL,
+    social_id   BIGINT                                                                                                        NOT NULL,
+    report_type ENUM ('NOT_RELATED_TO_SERVICE', 'PRIVACY_RISK', 'COMMERCIAL_ADVERTISEMENT', 'INAPPROPRIATE_CONTENT', 'OTHER') NOT NULL,
+    reason      VARCHAR(255)                                                                                                  NULL,
+    created_at  DATETIME                                                                                                      NOT NULL,
+    updated_at  DATETIME                                                                                                      NOT NULL,
+    deleted_at  DATETIME                                                                                                      NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (social_id) REFERENCES social (id)
 );

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -20,13 +20,15 @@ CREATE TABLE social
 (
  id           BIGINT PRIMARY KEY auto_increment,
  user_id      BIGINT                             NOT NULL,
+ routine_id   BIGINT                             NULL,
  content      VARCHAR(255)                       NOT NULL,
  is_anonymous BOOLEAN                            NOT NULL,
  like_count   int                                NOT NULL DEFAULT 0,
  created_at   DATETIME                           NOT NULL,
  updated_at   DATETIME                           NOT NULL,
  deleted_at   DATETIME                           NULL,
- FOREIGN KEY (user_id) REFERENCES users (id)
+ FOREIGN KEY (user_id) REFERENCES users (id),
+ FOREIGN KEY (routine_id) REFERENCES routine (id)
 );
 
 CREATE TABLE routine

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -41,6 +41,10 @@ public class RoutineService {
 		return routineRepository.findUnrecordedRoutinesForDate(user, date, routineRecords);
 	}
 
+	public Optional<Routine> getUserRoutine(final User user, final Long id) {
+		return routineRepository.findByIdAndUserAndDeletedAtIsNull(id, user);
+	}
+
 	public Optional<Routine> getUserRoutineIncludingDeleted(final User user, final Long id) {
 		return routineRepository.findByIdAndUser(id, user);
 	}

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
@@ -15,4 +15,6 @@ public interface RoutineRepository extends JpaRepository<Routine, Long>, Routine
 	Optional<Routine> findByIdAndUser(Long id, User user);
 
 	List<Routine> findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByUpdatedAtDesc(User user);
+
+	Optional<Routine> findByIdAndUserAndDeletedAtIsNull(Long id, User user);
 }

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
@@ -2,7 +2,9 @@ package im.toduck.domain.social.common.mapper;
 
 import java.util.List;
 
+import im.toduck.domain.routine.common.mapper.RoutineMapper;
 import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
 import im.toduck.domain.social.persistence.entity.Comment;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
@@ -51,6 +53,7 @@ public class SocialMapper {
 			.owner(getOwner(socialBoard.getUser()))
 			.hasImages(!imageFiles.isEmpty())
 			.images(getImageDtos(imageFiles))
+			.routine(getSocialRoutineDto(socialBoard.getRoutine()))
 			.content(socialBoard.getContent())
 			.likeInfo(getLikeDto(socialBoard, isLiked))
 			.comments(getCommentDtos(comments))
@@ -71,10 +74,18 @@ public class SocialMapper {
 			.content(socialBoard.getContent())
 			.hasImages(!imageFiles.isEmpty())
 			.images(getImageDtos(imageFiles))
+			.routine(getSocialRoutineDto(socialBoard.getRoutine()))
 			.likeInfo(getLikeDto(socialBoard, isLiked))
 			.commentCount(commentCount)
 			.createdAt(socialBoard.getCreatedAt())
 			.build();
+	}
+
+	private static RoutineDetailResponse getSocialRoutineDto(final Routine routine) {
+		if (routine == null) {
+			return null;
+		}
+		return RoutineMapper.toRoutineDetailResponse(routine);
 	}
 
 	private static LikeDto getLikeDto(Social socialBoard, boolean isLiked) {

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
@@ -2,6 +2,7 @@ package im.toduck.domain.social.common.mapper;
 
 import java.util.List;
 
+import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.social.persistence.entity.Comment;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
@@ -20,9 +21,15 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SocialMapper {
-	public static Social toSocial(User user, String content, Boolean isAnonymous) {
+	public static Social toSocial(
+		final User user,
+		final Routine routine,
+		final String content,
+		final Boolean isAnonymous
+	) {
 		return Social.builder()
 			.user(user)
+			.routine(routine)
 			.content(content)
 			.isAnonymous(isAnonymous)
 			.build();

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.social.common.mapper.SocialCategoryLinkMapper;
 import im.toduck.domain.social.common.mapper.SocialImageFileMapper;
 import im.toduck.domain.social.common.mapper.SocialMapper;
@@ -48,8 +49,12 @@ public class SocialBoardService {
 	}
 
 	@Transactional
-	public Social createSocialBoard(User user, SocialCreateRequest request) {
-		Social socialBoard = SocialMapper.toSocial(user, request.content(), request.isAnonymous());
+	public Social createSocialBoard(
+		final User user,
+		final Routine routine,
+		final SocialCreateRequest request
+	) {
+		Social socialBoard = SocialMapper.toSocial(user, routine, request.content(), request.isAnonymous());
 		return socialRepository.save(socialBoard);
 	}
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -111,7 +111,7 @@ public class SocialBoardService {
 			addSocialCategoryLinks(request.socialCategoryIds(), socialCategories, socialBoard);
 		}
 
-		if (request.routineId() != null) {
+		if (request.isRemoveRoutine() || request.routineId() != null) {
 			socialBoard.updateRoutine(routine);
 		}
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -81,7 +81,12 @@ public class SocialBoardService {
 	}
 
 	@Transactional
-	public void updateSocialBoard(User user, Social socialBoard, SocialUpdateRequest request) {
+	public void updateSocialBoard(
+		final User user,
+		final Social socialBoard,
+		final Routine routine,
+		final SocialUpdateRequest request
+	) {
 		if (!isBoardOwner(socialBoard, user)) {
 			log.warn("권한이 없는 유저가 소셜 게시판 수정 시도 - UserId: {}, SocialBoardId: {}", user.getId(), socialBoard.getId());
 			throw CommonException.from(ExceptionCode.UNAUTHORIZED_ACCESS_SOCIAL_BOARD);
@@ -104,6 +109,10 @@ public class SocialBoardService {
 
 			socialCategoryLinkRepository.deleteAllBySocial(socialBoard);
 			addSocialCategoryLinks(request.socialCategoryIds(), socialCategories, socialBoard);
+		}
+
+		if (request.routineId() != null) {
+			socialBoard.updateRoutine(routine);
 		}
 
 		if (request.content() != null) {

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
@@ -71,14 +71,27 @@ public class SocialBoardUseCase {
 	}
 
 	@Transactional
-	public void updateSocialBoard(Long userId, Long socialId, SocialUpdateRequest request) {
+	public void updateSocialBoard(
+		final Long userId,
+		final Long socialId,
+		final SocialUpdateRequest request
+	) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SOCIAL_BOARD));
+		Routine routine = resolveRoutine(user, request.routineId());
 
+		socialBoardService.updateSocialBoard(user, socialBoard, routine, request);
 		log.info("소셜 게시글 수정 - UserId: {}, SocialBoardId: {}", userId, socialId);
-		socialBoardService.updateSocialBoard(user, socialBoard, request);
+	}
+
+	private Routine resolveRoutine(User user, Long routineId) {
+		if (routineId == null || routineId == 0) {
+			return null;
+		}
+		return routineService.getUserRoutine(user, routineId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_ROUTINE));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.springframework.transaction.annotation.Transactional;
 
+import im.toduck.domain.routine.domain.service.RoutineService;
+import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.social.common.mapper.SocialMapper;
 import im.toduck.domain.social.domain.service.SocialBoardService;
 import im.toduck.domain.social.domain.service.SocialInteractionService;
@@ -35,13 +37,20 @@ public class SocialBoardUseCase {
 	private final SocialBoardService socialBoardService;
 	private final SocialInteractionService socialInteractionService;
 	private final UserService userService;
+	private final RoutineService routineService;
 
 	@Transactional
-	public SocialCreateResponse createSocialBoard(Long userId, SocialCreateRequest request) {
+	public SocialCreateResponse createSocialBoard(final Long userId, final SocialCreateRequest request) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
-		Social socialBoard = socialBoardService.createSocialBoard(user, request);
+		Routine routine = null;
+		if (request.routineId() != null) {
+			routine = routineService.getUserRoutine(user, request.routineId())
+				.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_ROUTINE));
+		}
+
+		Social socialBoard = socialBoardService.createSocialBoard(user, routine, request);
 		List<SocialCategory> socialCategories = socialBoardService.findAllSocialCategories(request.socialCategoryIds());
 		socialBoardService.addSocialCategoryLinks(request.socialCategoryIds(), socialCategories, socialBoard);
 		socialBoardService.addSocialImageFiles(request.socialImageUrls(), socialBoard);

--- a/src/main/java/im/toduck/domain/social/persistence/entity/Social.java
+++ b/src/main/java/im/toduck/domain/social/persistence/entity/Social.java
@@ -3,6 +3,7 @@ package im.toduck.domain.social.persistence.entity;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.base.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -35,7 +36,9 @@ public class Social extends BaseEntity {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	// TODO: Routine 추가 (생성자, 정적 팩터리 메소드에도 추가 필요)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "routine_id")
+	private Routine routine;
 
 	@Column(nullable = false, columnDefinition = "int default 0")
 	private int likeCount;
@@ -47,8 +50,9 @@ public class Social extends BaseEntity {
 	private Boolean isAnonymous;
 
 	@Builder
-	private Social(User user, String content, Boolean isAnonymous) {
+	private Social(User user, Routine routine, String content, Boolean isAnonymous) {
 		this.user = user;
+		this.routine = routine;
 		this.content = content;
 		this.isAnonymous = isAnonymous;
 	}

--- a/src/main/java/im/toduck/domain/social/persistence/entity/Social.java
+++ b/src/main/java/im/toduck/domain/social/persistence/entity/Social.java
@@ -69,6 +69,10 @@ public class Social extends BaseEntity {
 		this.isAnonymous = isAnonymous;
 	}
 
+	public void updateRoutine(final Routine routine) {
+		this.routine = routine;
+	}
+
 	public void incrementLikeCount() {
 		this.likeCount++;
 	}
@@ -78,4 +82,5 @@ public class Social extends BaseEntity {
 			this.likeCount--;
 		}
 	}
+
 }

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
@@ -39,6 +39,7 @@ public interface SocialBoardApi {
 		),
 		errors = {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SOCIAL_CATEGORY),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_ROUTINE),
 		}
 	)
 	ResponseEntity<ApiResponse<SocialCreateResponse>> createSocialBoard(
@@ -76,6 +77,7 @@ public interface SocialBoardApi {
 				}<br/><br/>
 				<p>위 예시는 게시글의 내용과 이미지를 변경하는 경우입니다. 익명 여부나 다른 필드를 수정하지 않으려면 해당 필드를 생략할 수 있습니다.</p><br/>
 				<b>주의사항:</b><br/>
+				<p>- 공유할 루틴을 제거하고 싶다면 routineId를 0으로 전송하면 됩니다.</p>
 				<p>- 이미지를 모두 지우고 싶다면 socialImageUrls를 빈 배열( [ ] )로 전송하면 됩니다.</p>
 				<p>- socialCategoryIds는 최소한 하나의 카테고리 ID가 존재해야 합니다. 빈 배열로 전송할 경우 에러가 발생합니다.</p>
 				"""
@@ -89,6 +91,7 @@ public interface SocialBoardApi {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.UNAUTHORIZED_ACCESS_SOCIAL_BOARD),
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SOCIAL_CATEGORY),
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.EMPTY_SOCIAL_CATEGORY_LIST),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_ROUTINE),
 		}
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> updateSocialBoard(

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
@@ -99,7 +99,8 @@ public interface SocialBoardApi {
 
 	@Operation(
 		summary = "게시글 단건 조회",
-		description = "게시글 단건 세부사항을 조회합니다."
+		description = "게시글 단건 세부사항을 조회합니다. </br></br>"
+			+ "공유할 루틴이 존재하지 않는 경우 routine 필드에 null이 반환 됩니다."
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
@@ -118,7 +119,9 @@ public interface SocialBoardApi {
 
 	@Operation(
 		summary = "게시글 목록 조회",
-		description = "게시글을 커서 기반 페이지네이션으로 조회합니다.</br></br>커서 페이지네이션 사용법은 Notion > API 개요 > 페이지네이션을 확인해주세요."
+		description = "게시글을 커서 기반 페이지네이션으로 조회합니다.</br></br>"
+			+ "커서 페이지네이션 사용법은 Notion > API 개요 > 페이지네이션을 확인해주세요.</br></br>"
+			+ "공유할 루틴이 존재하지 않는 경우 routine 필드에 null이 반환 됩니다."
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
@@ -30,7 +30,11 @@ import jakarta.validation.Valid;
 public interface SocialBoardApi {
 	@Operation(
 		summary = "소셜 게시글 생성",
-		description = "소셜 게시글을 작성합니다. 공유할 루틴이 존재하지 않는 경우 routineId 필드에 null을 입력합니다."
+		description = """
+			소셜 게시글을 작성합니다.
+			- 공유할 루틴이 없는 경우: routineId = null
+			- 비공개 루틴은 게시글에 공유할 수 없습니다. (PRIVATE_ROUTINE 예외 발생)
+			"""
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
@@ -40,6 +44,7 @@ public interface SocialBoardApi {
 		errors = {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SOCIAL_CATEGORY),
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_ROUTINE),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.PRIVATE_ROUTINE),
 		}
 	)
 	ResponseEntity<ApiResponse<SocialCreateResponse>> createSocialBoard(
@@ -69,17 +74,29 @@ public interface SocialBoardApi {
 		summary = "소셜 게시글 수정",
 		description =
 			"""
-				<b>게시글 수정 API는 모든 필드를 전송할 필요가 없습니다.</b><br/><br/>
-				<p>소셜 게시글의 특정 필드만 선택적으로 수정할 수 있습니다. 요청 시 수정하고자 하는 필드만 포함하면 됩니다.</p><br/>
+				<b>게시글 수정 API는 변경이 필요한 필드만 포함하여 요청할 수 있습니다.</b><br/><br/>
+				<p>예시 요청:</p><br/>
 				{<br/>
-					"content": "수정된 게시글 내용입니다.",<br/>
-					"socialImageUrls": ["https://cdn.toduck.app/new-image.jpg"]<br/>
+				"content": "수정된 게시글 내용입니다.",<br/>
+				"isRemoveRoutine": false,<br/>
+				"routineId": null,<br/>
+				"isAnonymous": null,<br/>
+				"socialCategoryIds": null,<br/>
+				"socialImageUrls": ["https://cdn.toduck.app/new-image.jpg"]<br/>
 				}<br/><br/>
-				<p>위 예시는 게시글의 내용과 이미지를 변경하는 경우입니다. 익명 여부나 다른 필드를 수정하지 않으려면 해당 필드를 생략할 수 있습니다.</p><br/>
-				<b>주의사항:</b><br/>
-				<p>- 공유할 루틴을 제거하고 싶다면 routineId를 0으로 전송하면 됩니다.</p>
-				<p>- 이미지를 모두 지우고 싶다면 socialImageUrls를 빈 배열( [ ] )로 전송하면 됩니다.</p>
-				<p>- socialCategoryIds는 최소한 하나의 카테고리 ID가 존재해야 합니다. 빈 배열로 전송할 경우 에러가 발생합니다.</p>
+				<p>위 예시는 게시글의 내용과 이미지만 변경하는 경우입니다.</p><br/>
+				<b>필드별 주의사항:</b><br/>
+				<p>- content가 null인 경우 내용을 수정하지 않습니다</p>
+				<p>- isAnonymous가 null인 경우 익명 여부를 수정하지 않습니다</p>
+				<p>- socialCategoryIds가 null인 경우 카테고리를 수정하지 않습니다</p>
+				<p>- socialImageUrls가 null인 경우 이미지를 수정하지 않습니다</p>
+				<p>- 이미지 모두 제거: socialImageUrls를 빈 배열( [ ] )로 전송</p>
+				<p>- 카테고리 수정 시 최소 1개 이상 필수 (빈 배열 불가)</p>
+				<p>- 비공개 루틴은 게시글에 공유할 수 없음</p><br/>
+				<b>루틴 공유 관련 (isRemoveRoutine은 필수값):</b><br/>
+				<p>1. 공유 루틴 제거: isRemoveRoutine = true, routineId = null (routineId가 null이 아닐 경우 예외 발생)</p>
+				<p>2. 공유 루틴 유지: isRemoveRoutine = false, routineId = null</p>
+				<p>3. 공유 루틴 변경: isRemoveRoutine = false, routineId = 변경할 루틴 ID</p>
 				"""
 	)
 	@ApiResponseExplanations(
@@ -92,6 +109,7 @@ public interface SocialBoardApi {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SOCIAL_CATEGORY),
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.EMPTY_SOCIAL_CATEGORY_LIST),
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_ROUTINE),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.PRIVATE_ROUTINE),
 		}
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> updateSocialBoard(

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
@@ -30,7 +30,7 @@ import jakarta.validation.Valid;
 public interface SocialBoardApi {
 	@Operation(
 		summary = "소셜 게시글 생성",
-		description = "소셜 게시글을 작성합니다."
+		description = "소셜 게시글을 작성합니다. 공유할 루틴이 존재하지 않는 경우 routineId 필드에 null을 입력합니다."
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(

--- a/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialCreateRequest.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialCreateRequest.java
@@ -3,6 +3,7 @@ package im.toduck.domain.social.presentation.dto.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -14,6 +15,7 @@ public record SocialCreateRequest(
 	@Schema(description = "게시글 내용", example = "어제 잠들기 전 새로운 루틴을 추가했다👀")
 	String content,
 
+	@Nullable
 	@Schema(description = "공유할 루틴 ID (공유할 루틴이 없으면 필드 제거)", example = "1")
 	Long routineId,
 

--- a/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialCreateRequest.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialCreateRequest.java
@@ -14,6 +14,9 @@ public record SocialCreateRequest(
 	@Schema(description = "게시글 내용", example = "어제 잠들기 전 새로운 루틴을 추가했다👀")
 	String content,
 
+	@Schema(description = "공유할 루틴 ID (공유할 루틴이 없으면 필드 제거)", example = "1")
+	Long routineId,
+
 	@NotNull(message = "익명 여부는 필수 입력 항목입니다.")
 	@Schema(description = "익명 여부", example = "false")
 	Boolean isAnonymous,

--- a/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialUpdateRequest.java
@@ -5,6 +5,8 @@ import java.util.List;
 import im.toduck.global.annotation.valid.ValidCategoryIds;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SocialUpdateRequest(
@@ -12,6 +14,10 @@ public record SocialUpdateRequest(
 	@Size(min = 1, max = 255, message = "내용은 공백일 수 없으며 255자 이하여야 합니다.")
 	@Schema(description = "게시글 수정 내용", example = "덕분에 오늘은 까먹 일 없이 챙김!")
 	String content,
+
+	@NotNull
+	@Schema(description = "공유할 루틴 삭제 여부", example = "true")
+	boolean isRemoveRoutine,
 
 	@Nullable
 	@Schema(description = "공유할 루틴 ID", example = "1")
@@ -30,4 +36,8 @@ public record SocialUpdateRequest(
 	@Schema(description = "수정된 이미지 URL 목록", example = "[\"https://cdn.toduck.app/image2.jpg\"]")
 	List<String> socialImageUrls
 ) {
+	@AssertTrue(message = "루틴 삭제 시에는 routineId가 null이어야 합니다")
+	public boolean isValidRoutineIdWhenRemoved() {
+		return !isRemoveRoutine || routineId == null;
+	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialUpdateRequest.java
@@ -12,7 +12,7 @@ import jakarta.validation.constraints.Size;
 public record SocialUpdateRequest(
 	@Nullable
 	@Size(min = 1, max = 255, message = "내용은 공백일 수 없으며 255자 이하여야 합니다.")
-	@Schema(description = "게시글 수정 내용", example = "덕분에 오늘은 까먹 일 없이 챙김!")
+	@Schema(description = "게시글 수정 내용", example = "덕분에 오늘은 까먹을 일 없이 챙김!")
 	String content,
 
 	@NotNull

--- a/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialUpdateRequest.java
@@ -14,6 +14,10 @@ public record SocialUpdateRequest(
 	String content,
 
 	@Nullable
+	@Schema(description = "공유할 루틴 ID", example = "1")
+	Long routineId,
+
+	@Nullable
 	@Schema(description = "익명 여부 수정", example = "true")
 	Boolean isAnonymous,
 

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialDetailResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialDetailResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
+import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -17,6 +18,9 @@ public record SocialDetailResponse(
 
 	@Schema(description = "작성자 정보")
 	OwnerDto owner,
+
+	@Schema(description = "공유할 루틴 정보")
+	RoutineDetailResponse routine,
 
 	@Schema(description = "게시글 내용", example = "어제 잠들기 전 새로운 루틴을 추가했다👀")
 	String content,

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
+import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -17,6 +18,9 @@ public record SocialResponse(
 
 	@Schema(description = "작성자 정보")
 	OwnerDto owner,
+
+	@Schema(description = "공유할 루틴 정보")
+	RoutineDetailResponse routine,
 
 	@Schema(description = "게시글 내용", example = "어제 잠들기 전 새로운 루틴을 추가했다👀")
 	String content,

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -80,6 +80,8 @@ public enum ExceptionCode {
 	NOT_FOUND_ROUTINE(HttpStatus.NOT_FOUND, 43201, "권한이 없거나 존재하지 않는 루틴입니다."),
 	ROUTINE_INVALID_DATE(HttpStatus.BAD_REQUEST, 43202, "유효하지 않은 루틴 날짜입니다.",
 		"요청된 날짜에 대한 루틴 변경이 불가능합니다. 루틴의 반복 요일과 현재 날짜를 확인하고 올바른 날짜로 다시 요청해 주세요."),
+	PRIVATE_ROUTINE(HttpStatus.FORBIDDEN, 43203, "비공개된 루틴입니다.",
+		"요청하신 루틴은 비공개 상태입니다. 접근 권한이 없는 경우 접근할 수 없습니다."),
 
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.ServiceTest;
 import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.repository.RoutineRepository;
 import im.toduck.domain.social.persistence.entity.Comment;
 import im.toduck.domain.social.persistence.entity.Like;
 import im.toduck.domain.social.persistence.entity.Social;
@@ -67,6 +68,9 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 	@Autowired
 	private CommentRepository commentRepository;
+
+	@Autowired
+	private RoutineRepository routineRepository;
 
 	@BeforeEach
 	public void setUp() {
@@ -158,6 +162,22 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 		}
 
 		@Test
+		void 게시글이_삭제되어도_루틴은_삭제되지_않는다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Social SOCIAL_WITH_ROUTINE = testFixtureBuilder.buildSocial(
+				SINGLE_SOCIAL_WITH_ROUTINE(USER, ROUTINE, false)
+			);
+
+			// when
+			socialBoardUseCase.deleteSocialBoard(USER.getId(), SOCIAL_WITH_ROUTINE.getId());
+
+			// then
+			Optional<Routine> existingRoutine = routineRepository.findById(ROUTINE.getId());
+			assertThat(existingRoutine).isPresent();
+		}
+
+		@Test
 		void 사용자를_조회할_수_없는_경우_게시글_삭제에_실패한다() {
 			// given
 			Long nonExistentUserId = -1L;
@@ -205,6 +225,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 			});
 		}
+
 	}
 
 	@Nested

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -516,6 +516,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 	@DisplayName("게시글 단건 조회시")
 	class GetSocialDetail {
 		Social SOCIAL_BOARD;
+		Routine ROUTINE;
 		Comment COMMENT;
 		Like LIKE;
 		List<SocialImageFile> IMAGE_FILES;
@@ -526,7 +527,8 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@BeforeEach
 		void setUp() {
-			SOCIAL_BOARD = testFixtureBuilder.buildSocial(SINGLE_SOCIAL(USER, false));
+			ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			SOCIAL_BOARD = testFixtureBuilder.buildSocial(SINGLE_SOCIAL_WITH_ROUTINE(USER, ROUTINE, false));
 			COMMENT = testFixtureBuilder.buildComment(SINGLE_COMMENT(USER, SOCIAL_BOARD));
 			LIKE = testFixtureBuilder.buildLike(LIKE(USER, SOCIAL_BOARD));
 			IMAGE_FILES = testFixtureBuilder.buildSocialImageFiles(
@@ -548,6 +550,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			assertSoftly(softly -> {
 				softly.assertThat(response).isNotNull();
 				softly.assertThat(response.id()).isEqualTo(SOCIAL_BOARD.getId());
+				softly.assertThat(response.routine().routineId()).isEqualTo(ROUTINE.getId());
 				softly.assertThat(response.content()).isEqualTo(SOCIAL_BOARD.getContent());
 				softly.assertThat(response.hasImages()).isTrue();
 				softly.assertThat(response.likeInfo().isLiked()).isTrue();

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -84,6 +84,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		SocialCreateRequest request = new SocialCreateRequest(
 			content,
+			null,
 			isAnonymous,
 			categoryIds,
 			imageUrls
@@ -99,7 +100,6 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 				softly.assertThat(response).isNotNull();
 				softly.assertThat(response.socialId()).isNotNull();
 			});
-
 		}
 
 		@Test
@@ -118,7 +118,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			// given
 			List<Long> invalidCategoryIds = List.of(1L, -1L);
 			SocialCreateRequest invalidRequest = new SocialCreateRequest(
-				content, isAnonymous, invalidCategoryIds, imageUrls
+				content,
+				null,
+				isAnonymous,
+				invalidCategoryIds,
+				imageUrls
 			);
 
 			// when & then

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -260,6 +260,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
 				updatedContent,
+				null,
 				updatedIsAnonymous,
 				updatedCategoryIds,
 				updatedImageUrls
@@ -319,6 +320,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			Long nonExistentSocialBoardId = -1L;
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
 				updateContent,
+				null,
 				isAnonymous,
 				validCategoryIds,
 				imageUrls
@@ -337,6 +339,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			User ANOTHER_USER = testFixtureBuilder.buildUser(GENERAL_USER());
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
 				updateContent,
+				null,
 				isAnonymous,
 				validCategoryIds,
 				imageUrls
@@ -354,6 +357,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			// given
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
 				updateContent,
+				null,
 				isAnonymous,
 				invalidCategoryIds,
 				imageUrls
@@ -371,6 +375,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			// given
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
 				updateContent,
+				null,
 				isAnonymous,
 				List.of(),
 				imageUrls

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -137,6 +137,25 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 				.hasMessage(ExceptionCode.NOT_FOUND_SOCIAL_CATEGORY.getMessage());
 		}
 
+		@Test
+		void 루틴이_자신의_소유가_아닌_경우_게시글_생성에_실패한다() {
+			// given
+			User ANOTHER_USER = testFixtureBuilder.buildUser(GENERAL_USER());
+			Routine ANOTHER_USER_ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(ANOTHER_USER));
+			SocialCreateRequest requestWithAnotherUserRoutine = new SocialCreateRequest(
+				content,
+				ANOTHER_USER_ROUTINE.getId(),
+				isAnonymous,
+				categoryIds,
+				imageUrls
+			);
+
+			// when & then
+			assertThatThrownBy(() -> socialBoardUseCase.createSocialBoard(USER.getId(), requestWithAnotherUserRoutine))
+				.isInstanceOf(CommonException.class)
+				.hasMessage(ExceptionCode.NOT_FOUND_ROUTINE.getMessage());
+		}
+
 	}
 
 	@Nested

--- a/src/test/java/im/toduck/fixtures/RoutineFixtures.java
+++ b/src/test/java/im/toduck/fixtures/RoutineFixtures.java
@@ -142,4 +142,17 @@ public class RoutineFixtures {
 
 		return routine;
 	}
+
+	public static Routine PRIVATE_ROUTINE(User user) {
+		return Routine.builder()
+			.user(user)
+			.title("비공개 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SUNDAY)))
+			.time(NIGHT_TIME)
+			.color(PlanCategoryColor.from("#006400"))
+			.isPublic(false)
+			.build();
+
+	}
+
 }

--- a/src/test/java/im/toduck/fixtures/social/SocialFixtures.java
+++ b/src/test/java/im/toduck/fixtures/social/SocialFixtures.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.user.persistence.entity.User;
 
@@ -40,6 +41,15 @@ public class SocialFixtures {
 	public static Social SINGLE_SOCIAL(User user, boolean isAnonymous) {
 		return Social.builder()
 			.user(user)
+			.content(DEFAULT_CONTENT)
+			.isAnonymous(isAnonymous)
+			.build();
+	}
+
+	public static Social SINGLE_SOCIAL_WITH_ROUTINE(User user, Routine routine, boolean isAnonymous) {
+		return Social.builder()
+			.user(user)
+			.routine(routine)
 			.content(DEFAULT_CONTENT)
 			.isAnonymous(isAnonymous)
 			.build();


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 소셜 게시글과 루틴 연동**
```SQL
CREATE TABLE social
(
    ...
    routine_id   BIGINT       NULL,
    ...
    FOREIGN KEY (routine_id) REFERENCES routine (id)
);
```
- 소셜 게시글 생성, 수정, 조회 시 루틴 정보를 연동하도록 기능을 구현

  <br/>

**2️⃣ 데이터베이스 초기화 순서 수정**

**변경 전:**
```SQL
INSERT INTO social (...) VALUES (...);
INSERT INTO routine (...) VALUES (...);
```

**변경 후:**
```SQL
INSERT INTO routine (...) VALUES (...);
INSERT INTO social (...) VALUES (...);
```
  <br/>


## ✅ 리뷰 요구사항

- 루틴 연동 관련 코드 개선이 필요한 부분이 있는지 확인 부탁드립니다.
- 특히, 게시글 수정 시 `routineId`가 `null`인 경우 변경 없음 `0`인 경우 제거, `유효한 Id` 인 경우 루틴 수정 처리가 올바르게 구현되었는지 확인 부탁드립니다.
