### PR TITLE
댓글 좋아요 및 댓글 좋아요 취소 API 개발 

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -2,210 +2,224 @@ USE toduck;
 
 CREATE TABLE users
 (
- -- TODO: 3. users 테이블  oauth 사용 시 필요한 사용자 식별값 → oauth 에서 전화번호 수집이 가능한지 다시 확인 필요
- id           BIGINT PRIMARY KEY auto_increment,
- nickname     VARCHAR(100)                               NOT NULL,
- phone_number VARCHAR(50)                                NULL,
- login_id     VARCHAR(100)                               NULL,
- password     VARCHAR(255)                               NULL,
- email        VARCHAR(100)                               NULL,
- role         ENUM ('ADMIN', 'USER')                     NOT NULL,
- provider     ENUM ('KAKAO', 'NAVER', 'GOOGLE', 'APPLE') NULL,
- created_at   DATETIME                                   NOT NULL,
- updated_at   DATETIME                                   NOT NULL,
- deleted_at   DATETIME                                   NULL
+    -- TODO: 3. users 테이블  oauth 사용 시 필요한 사용자 식별값 → oauth 에서 전화번호 수집이 가능한지 다시 확인 필요
+    id           BIGINT PRIMARY KEY auto_increment,
+    nickname     VARCHAR(100)                               NOT NULL,
+    phone_number VARCHAR(50)                                NULL,
+    login_id     VARCHAR(100)                               NULL,
+    password     VARCHAR(255)                               NULL,
+    email        VARCHAR(100)                               NULL,
+    role         ENUM ('ADMIN', 'USER')                     NOT NULL,
+    provider     ENUM ('KAKAO', 'NAVER', 'GOOGLE', 'APPLE') NULL,
+    created_at   DATETIME                                   NOT NULL,
+    updated_at   DATETIME                                   NOT NULL,
+    deleted_at   DATETIME                                   NULL
 );
 
 CREATE TABLE social
 (
- id           BIGINT PRIMARY KEY auto_increment,
- user_id      BIGINT                             NOT NULL,
- content      VARCHAR(255)                       NOT NULL,
- is_anonymous BOOLEAN                            NOT NULL,
- like_count   int                                NOT NULL DEFAULT 0,
- created_at   DATETIME                           NOT NULL,
- updated_at   DATETIME                           NOT NULL,
- deleted_at   DATETIME                           NULL,
- FOREIGN KEY (user_id) REFERENCES users (id)
+    id           BIGINT PRIMARY KEY auto_increment,
+    user_id      BIGINT       NOT NULL,
+    content      VARCHAR(255) NOT NULL,
+    is_anonymous BOOLEAN      NOT NULL,
+    like_count   int          NOT NULL DEFAULT 0,
+    created_at   DATETIME     NOT NULL,
+    updated_at   DATETIME     NOT NULL,
+    deleted_at   DATETIME     NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 CREATE TABLE routine
 (
-id          BIGINT PRIMARY KEY auto_increment,
-user_id     BIGINT                         NOT NULL,
+    id               BIGINT PRIMARY KEY auto_increment,
+    user_id          BIGINT                                              NOT NULL,
 -- TODO: 8. routine 의 이모지 필드 enum 값 필요
-category    ENUM ('STUDY', 'EXERCISE', 'FOOD', 'SLEEP', 'PLAY')  NULL,
+    category         ENUM ('STUDY', 'EXERCISE', 'FOOD', 'SLEEP', 'PLAY') NULL,
 -- TODO: 4. routine 테이블의 color enum 값 필요
-color       VARCHAR(10)                    NULL,
-time        TIME                           NULL,
-days_of_week TINYINT UNSIGNED              NOT NULL,
-title       CHAR(100)                      NOT NULL,
-is_public   BOOLEAN                        NOT NULL,
-reminder_minutes INT UNSIGNED              NULL,
-memo        TEXT                           NULL,
-created_at  DATETIME                       NOT NULL,
-updated_at  DATETIME                       NOT NULL,
-deleted_at  DATETIME                       NULL,
-FOREIGN KEY (user_id) REFERENCES users (id)
+    color            VARCHAR(10)                                         NULL,
+    time             TIME                                                NULL,
+    days_of_week     TINYINT UNSIGNED                                    NOT NULL,
+    title            CHAR(100)                                           NOT NULL,
+    is_public        BOOLEAN                                             NOT NULL,
+    reminder_minutes INT UNSIGNED                                        NULL,
+    memo             TEXT                                                NULL,
+    created_at       DATETIME                                            NOT NULL,
+    updated_at       DATETIME                                            NOT NULL,
+    deleted_at       DATETIME                                            NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 CREATE TABLE routine_record
 (
-    id BIGINT PRIMARY KEY AUTO_INCREMENT,
-    routine_id BIGINT NULL,
-    record_at DATETIME NOT NULL,
-    is_all_day BOOLEAN NOT NULL,
-    is_completed BOOLEAN NOT NULL DEFAULT false,
-    created_at DATETIME NOT NULL,
-    updated_at DATETIME NOT NULL,
-    deleted_at DATETIME NULL,
+    id           BIGINT PRIMARY KEY AUTO_INCREMENT,
+    routine_id   BIGINT   NULL,
+    record_at    DATETIME NOT NULL,
+    is_all_day   BOOLEAN  NOT NULL,
+    is_completed BOOLEAN  NOT NULL DEFAULT false,
+    created_at   DATETIME NOT NULL,
+    updated_at   DATETIME NOT NULL,
+    deleted_at   DATETIME NULL,
     FOREIGN KEY (routine_id) REFERENCES routine (id) ON DELETE SET NULL
 );
 
 CREATE TABLE comment
 (
- id         BIGINT PRIMARY KEY AUTO_INCREMENT,
- user_id    BIGINT   NOT NULL,
- social_id  BIGINT   NOT NULL,
- content    TEXT     NOT NULL,
- created_at DATETIME NOT NULL,
- updated_at DATETIME NOT NULL,
- deleted_at DATETIME NULL,
- FOREIGN KEY (user_id) REFERENCES users (id),
- FOREIGN KEY (social_id) REFERENCES social (id)
+    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id    BIGINT   NOT NULL,
+    social_id  BIGINT   NOT NULL,
+    content    TEXT     NOT NULL,
+    like_count int      NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (social_id) REFERENCES social (id)
 );
+
+CREATE TABLE comment_likes
+(
+    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id    BIGINT   NOT NULL,
+    comment_id BIGINT   NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (comment_id) REFERENCES comment (id)
+);
+
 
 CREATE TABLE likes
 (
- id         BIGINT PRIMARY KEY auto_increment,
- user_id    BIGINT   NOT NULL,
- social_id  BIGINT   NOT NULL,
- created_at DATETIME NOT NULL,
- updated_at DATETIME NOT NULL,
- deleted_at DATETIME NULL,
- FOREIGN KEY (user_id) REFERENCES users (id),
- FOREIGN KEY (social_id) REFERENCES social (id)
+    id         BIGINT PRIMARY KEY auto_increment,
+    user_id    BIGINT   NOT NULL,
+    social_id  BIGINT   NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (social_id) REFERENCES social (id)
 );
 
 CREATE TABLE shared_routine
 (
- id         BIGINT PRIMARY KEY auto_increment,
- created_at DATETIME NOT NULL,
- updated_at DATETIME NOT NULL,
- deleted_at DATETIME NULL,
- user_id    BIGINT   NOT NULL,
- social_id  BIGINT   NOT NULL,
- FOREIGN KEY (user_id) REFERENCES users (id),
- FOREIGN KEY (social_id) REFERENCES routine (id)
+    id         BIGINT PRIMARY KEY auto_increment,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME NULL,
+    user_id    BIGINT   NOT NULL,
+    social_id  BIGINT   NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (social_id) REFERENCES routine (id)
 );
 
 CREATE TABLE social_category
 (
- id         BIGINT PRIMARY KEY auto_increment,
- name       VARCHAR(20) NOT NULL,
- created_at DATETIME    NOT NULL,
- updated_at DATETIME    NOT NULL,
- deleted_at DATETIME    NULL
+    id         BIGINT PRIMARY KEY auto_increment,
+    name       VARCHAR(20) NOT NULL,
+    created_at DATETIME    NOT NULL,
+    updated_at DATETIME    NOT NULL,
+    deleted_at DATETIME    NULL
 );
 
 CREATE TABLE social_image_file
 (
- id         BIGINT PRIMARY KEY auto_increment,
- social_id  BIGINT        NOT NULL,
- url        VARCHAR(1024) NOT NULL,
- created_at DATETIME      NOT NULL,
- updated_at DATETIME      NOT NULL,
- deleted_at DATETIME      NULL,
- FOREIGN KEY (social_id) REFERENCES social (id)
+    id         BIGINT PRIMARY KEY auto_increment,
+    social_id  BIGINT        NOT NULL,
+    url        VARCHAR(1024) NOT NULL,
+    created_at DATETIME      NOT NULL,
+    updated_at DATETIME      NOT NULL,
+    deleted_at DATETIME      NULL,
+    FOREIGN KEY (social_id) REFERENCES social (id)
 );
 
 CREATE TABLE schedule
 (
- id          BIGINT PRIMARY KEY auto_increment,
- user_id     BIGINT         NOT NULL,
- -- TODO: 8. routine 의 이모지 필드 enum 값 필요
- emoji       ENUM ('SMILE') NOT NULL,
- -- TODO: 4. routine 테이블의 color enum 값 필요
- color       ENUM ('RED')   NOT NULL,
- is_complete BOOLEAN        NOT NULL,
- time        TIME           NULL,
- title       CHAR(100)      NOT NULL,
- location    VARCHAR(255)   NOT NULL,
- routine_day DATE           NULL,
- alarm       ENUM ('10', '30', '60', 'OFF')   NOT NULL,
- memo        CHAR(255)      NOT NULL,
- created_at  DATETIME       NOT NULL,
- updated_at  DATETIME       NOT NULL,
- deleted_at  DATETIME       NULL,
- FOREIGN KEY (user_id) REFERENCES users (id)
+    id          BIGINT PRIMARY KEY auto_increment,
+    user_id     BIGINT                         NOT NULL,
+    -- TODO: 8. routine 의 이모지 필드 enum 값 필요
+    emoji       ENUM ('SMILE')                 NOT NULL,
+    -- TODO: 4. routine 테이블의 color enum 값 필요
+    color       ENUM ('RED')                   NOT NULL,
+    is_complete BOOLEAN                        NOT NULL,
+    time        TIME                           NULL,
+    title       CHAR(100)                      NOT NULL,
+    location    VARCHAR(255)                   NOT NULL,
+    routine_day DATE                           NULL,
+    alarm       ENUM ('10', '30', '60', 'OFF') NOT NULL,
+    memo        CHAR(255)                      NOT NULL,
+    created_at  DATETIME                       NOT NULL,
+    updated_at  DATETIME                       NOT NULL,
+    deleted_at  DATETIME                       NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 CREATE TABLE record
 (
- id         BIGINT PRIMARY KEY auto_increment,
- user_id    BIGINT                                                     NOT NULL,
- time       TIME                                                       NOT NULL,
- diary      VARCHAR(2048)                                              NULL,
- emotion    ENUM ('HAPPY', 'CALM', 'SAD', 'ANGRY', 'ANXIOUS', 'TIRED') NOT NULL,
- created_at DATETIME                                                   NOT NULL,
- updated_at DATETIME                                                   NOT NULL,
- deleted_at DATETIME                                                   NULL,
- FOREIGN KEY (user_id) REFERENCES users (id)
+    id         BIGINT PRIMARY KEY auto_increment,
+    user_id    BIGINT                                                     NOT NULL,
+    time       TIME                                                       NOT NULL,
+    diary      VARCHAR(2048)                                              NULL,
+    emotion    ENUM ('HAPPY', 'CALM', 'SAD', 'ANGRY', 'ANXIOUS', 'TIRED') NOT NULL,
+    created_at DATETIME                                                   NOT NULL,
+    updated_at DATETIME                                                   NOT NULL,
+    deleted_at DATETIME                                                   NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
 CREATE TABLE follow
 (
- id          BIGINT PRIMARY KEY auto_increment,
- created_at  DATETIME NOT NULL,
- updated_at  DATETIME NOT NULL,
- deleted_at  DATETIME NULL,
- followed_id BIGINT   NOT NULL,
- follower_id BIGINT   NOT NULL,
- FOREIGN KEY (followed_id) REFERENCES users (id),
- FOREIGN KEY (follower_id) REFERENCES users (id)
+    id          BIGINT PRIMARY KEY auto_increment,
+    created_at  DATETIME NOT NULL,
+    updated_at  DATETIME NOT NULL,
+    deleted_at  DATETIME NULL,
+    followed_id BIGINT   NOT NULL,
+    follower_id BIGINT   NOT NULL,
+    FOREIGN KEY (followed_id) REFERENCES users (id),
+    FOREIGN KEY (follower_id) REFERENCES users (id)
 );
 
 CREATE TABLE social_category_link
 (
- id                 BIGINT PRIMARY KEY auto_increment,
- created_at         DATETIME NOT NULL,
- updated_at         DATETIME NOT NULL,
- deleted_at         DATETIME NULL,
- social_id          BIGINT   NOT NULL,
- social_category_id BIGINT   NOT NULL,
- FOREIGN KEY (social_id) REFERENCES social (id),
- FOREIGN KEY (social_category_id) REFERENCES social_category (id)
+    id                 BIGINT PRIMARY KEY auto_increment,
+    created_at         DATETIME NOT NULL,
+    updated_at         DATETIME NOT NULL,
+    deleted_at         DATETIME NULL,
+    social_id          BIGINT   NOT NULL,
+    social_category_id BIGINT   NOT NULL,
+    FOREIGN KEY (social_id) REFERENCES social (id),
+    FOREIGN KEY (social_category_id) REFERENCES social_category (id)
 );
 
 INSERT INTO social_category (name, created_at, updated_at)
 VALUES ('CONCENTRATION', NOW(), NOW()),
- ('MEMORY', NOW(), NOW()),
- ('IMPULSE', NOW(), NOW()),
- ('ANXIETY', NOW(), NOW()),
- ('SLEEP', NOW(), NOW());
+       ('MEMORY', NOW(), NOW()),
+       ('IMPULSE', NOW(), NOW()),
+       ('ANXIETY', NOW(), NOW()),
+       ('SLEEP', NOW(), NOW());
 
 CREATE TABLE block
 (
- id	            BIGINT	PRIMARY KEY AUTO_INCREMENT,
- blocker_id	    BIGINT	    NOT NULL,
- blocked_id	    BIGINT	    NOT NULL,
- created_at	    DATETIME	NOT NULL,
- updated_at	    DATETIME	NOT NULL,
- deleted_at	    DATETIME	NULL,
- FOREIGN KEY (blocker_id) REFERENCES users (id),
- FOREIGN KEY (blocked_id) REFERENCES users (id)
+    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
+    blocker_id BIGINT   NOT NULL,
+    blocked_id BIGINT   NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (blocker_id) REFERENCES users (id),
+    FOREIGN KEY (blocked_id) REFERENCES users (id)
 );
 
 CREATE TABLE report
 (
-id          BIGINT PRIMARY KEY auto_increment,
-user_id     BIGINT       NOT NULL,
-social_id   BIGINT       NOT NULL,
-report_type ENUM('NOT_RELATED_TO_SERVICE', 'PRIVACY_RISK', 'COMMERCIAL_ADVERTISEMENT', 'INAPPROPRIATE_CONTENT', 'OTHER') NOT NULL,
-reason      VARCHAR(255) NULL,
-created_at  DATETIME     NOT NULL,
-updated_at  DATETIME     NOT NULL,
-deleted_at  DATETIME     NULL,
-FOREIGN KEY (user_id) REFERENCES users (id),
-FOREIGN KEY (social_id) REFERENCES social (id)
+    id          BIGINT PRIMARY KEY auto_increment,
+    user_id     BIGINT                                                                                                        NOT NULL,
+    social_id   BIGINT                                                                                                        NOT NULL,
+    report_type ENUM ('NOT_RELATED_TO_SERVICE', 'PRIVACY_RISK', 'COMMERCIAL_ADVERTISEMENT', 'INAPPROPRIATE_CONTENT', 'OTHER') NOT NULL,
+    reason      VARCHAR(255)                                                                                                  NULL,
+    created_at  DATETIME                                                                                                      NOT NULL,
+    updated_at  DATETIME                                                                                                      NOT NULL,
+    deleted_at  DATETIME                                                                                                      NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (social_id) REFERENCES social (id)
 );

--- a/src/main/java/im/toduck/domain/social/common/mapper/CommentLikeMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/CommentLikeMapper.java
@@ -24,9 +24,9 @@ public class CommentLikeMapper {
 			.build();
 	}
 
-	public static CommentLikeDto toCommentLikeDto(final Comment comment, final boolean isLiked) {
+	public static CommentLikeDto toCommentLikeDto(final Comment comment, final boolean isLikedByMe) {
 		return CommentLikeDto.builder()
-			.isLiked(isLiked)
+			.isLikedByMe(isLikedByMe)
 			.likeCount(comment.getLikeCount())
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/social/common/mapper/CommentLikeMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/CommentLikeMapper.java
@@ -1,0 +1,33 @@
+package im.toduck.domain.social.common.mapper;
+
+import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentLike;
+import im.toduck.domain.social.presentation.dto.response.CommentLikeCreateResponse;
+import im.toduck.domain.social.presentation.dto.response.CommentLikeDto;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentLikeMapper {
+
+	public static CommentLike toCommentLike(final User user, final Comment comment) {
+		return CommentLike.builder()
+			.user(user)
+			.comment(comment)
+			.build();
+	}
+
+	public static CommentLikeCreateResponse toCommentLikeCreateResponse(final CommentLike commentLike) {
+		return CommentLikeCreateResponse.builder()
+			.commentLikeId(commentLike.getId())
+			.build();
+	}
+
+	public static CommentLikeDto toCommentLikeDto(final Comment comment, final boolean isLiked) {
+		return CommentLikeDto.builder()
+			.isLiked(isLiked)
+			.likeCount(comment.getLikeCount())
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
@@ -44,7 +44,7 @@ public class CommentMapper {
 
 	private static OwnerDto getOwner(User user) {
 		return OwnerDto.builder()
-			.id(user.getId())
+			.ownerId(user.getId())
 			.nickname(user.getNickname())
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
@@ -6,6 +6,7 @@ import im.toduck.domain.social.persistence.vo.CommentContent;
 import im.toduck.domain.social.presentation.dto.request.CommentCreateRequest;
 import im.toduck.domain.social.presentation.dto.response.CommentCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.CommentDto;
+import im.toduck.domain.social.presentation.dto.response.CommentLikeDto;
 import im.toduck.domain.social.presentation.dto.response.OwnerDto;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.AccessLevel;
@@ -27,13 +28,18 @@ public class CommentMapper {
 			.build();
 	}
 
-	public static CommentDto toCommentDto(Comment comment) {
+	public static CommentDto toCommentDto(Comment comment, boolean isCommentLiked) {
 		return CommentDto.builder()
 			.commentId(comment.getId())
 			.owner(getOwner(comment.getUser()))
 			.content(comment.getContent().getValue())
+			.commentLikeInfo(getCommentLikeDto(comment, isCommentLiked))
 			.createdAt(comment.getCreatedAt())
 			.build();
+	}
+
+	private static CommentLikeDto getCommentLikeDto(Comment comment, boolean isCommentLiked) {
+		return CommentLikeMapper.toCommentLikeDto(comment, isCommentLiked);
 	}
 
 	private static OwnerDto getOwner(User user) {

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialCategoryMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialCategoryMapper.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 public class SocialCategoryMapper {
 	public static SocialCategoryDto toSocialCategoryDto(SocialCategory socialCategory) {
 		return SocialCategoryDto.builder()
-			.id(socialCategory.getId())
+			.socialCategoryId(socialCategory.getId())
 			.name(socialCategory.getName())
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialImageFileMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialImageFileMapper.java
@@ -17,7 +17,7 @@ public class SocialImageFileMapper {
 
 	public static SocialImageDto toSocialImageDto(SocialImageFile socialImageFile) {
 		return SocialImageDto.builder()
-			.id(socialImageFile.getId())
+			.socialImageId(socialImageFile.getId())
 			.url(socialImageFile.getUrl())
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialLikeMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialLikeMapper.java
@@ -2,14 +2,14 @@ package im.toduck.domain.social.common.mapper;
 
 import im.toduck.domain.social.persistence.entity.Like;
 import im.toduck.domain.social.persistence.entity.Social;
-import im.toduck.domain.social.presentation.dto.response.LikeCreateResponse;
-import im.toduck.domain.social.presentation.dto.response.LikeDto;
+import im.toduck.domain.social.presentation.dto.response.SocialLikeCreateResponse;
+import im.toduck.domain.social.presentation.dto.response.SocialLikeDto;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class LikeMapper {
+public class SocialLikeMapper {
 	public static Like toLike(User user, Social socialBoard) {
 		return Like.builder()
 			.user(user)
@@ -17,15 +17,15 @@ public class LikeMapper {
 			.build();
 	}
 
-	public static LikeCreateResponse toLikeCreateResponse(Like like) {
-		return LikeCreateResponse.builder()
-			.likeId(like.getId())
+	public static SocialLikeCreateResponse toSocialLikeCreateResponse(Like like) {
+		return SocialLikeCreateResponse.builder()
+			.socialLikeId(like.getId())
 			.build();
 	}
 
-	public static LikeDto toLikeDto(Social socialBoard, boolean isLiked) {
-		return LikeDto.builder()
-			.isLiked(isLiked)
+	public static SocialLikeDto toSocialLikeDto(Social socialBoard, boolean isLiked) {
+		return SocialLikeDto.builder()
+			.isLikedByMe(isLiked)
 			.likeCount(socialBoard.getLikeCount())
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
@@ -2,7 +2,6 @@ package im.toduck.domain.social.common.mapper;
 
 import java.util.List;
 
-import im.toduck.domain.social.persistence.entity.Comment;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
@@ -37,16 +36,17 @@ public class SocialMapper {
 	public static SocialDetailResponse toSocialDetailResponse(
 		Social socialBoard,
 		List<SocialImageFile> imageFiles,
-		List<Comment> comments,
-		boolean isLiked) {
+		List<CommentDto> comments,
+		boolean isSocialBoardLiked
+	) {
 		return SocialDetailResponse.builder()
 			.id(socialBoard.getId())
 			.owner(getOwner(socialBoard.getUser()))
 			.hasImages(!imageFiles.isEmpty())
 			.images(getImageDtos(imageFiles))
 			.content(socialBoard.getContent())
-			.likeInfo(getLikeDto(socialBoard, isLiked))
-			.comments(getCommentDtos(comments))
+			.likeInfo(getLikeDto(socialBoard, isSocialBoardLiked))
+			.comments(comments)
 			.createdAt(socialBoard.getCreatedAt())
 			.build();
 
@@ -77,12 +77,6 @@ public class SocialMapper {
 	private static List<SocialImageDto> getImageDtos(List<SocialImageFile> imageFiles) {
 		return imageFiles.stream()
 			.map(SocialImageFileMapper::toSocialImageDto)
-			.toList();
-	}
-
-	private static List<CommentDto> getCommentDtos(List<Comment> comments) {
-		return comments.stream()
-			.map(CommentMapper::toCommentDto)
 			.toList();
 	}
 

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
@@ -5,13 +5,10 @@ import java.util.List;
 import im.toduck.domain.routine.common.mapper.RoutineMapper;
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
-import im.toduck.domain.social.persistence.entity.Comment;
 import im.toduck.domain.social.persistence.entity.Social;
-import im.toduck.domain.social.persistence.entity.SocialCategory;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
 import im.toduck.domain.social.presentation.dto.response.CommentDto;
 import im.toduck.domain.social.presentation.dto.response.OwnerDto;
-import im.toduck.domain.social.presentation.dto.response.SocialCategoryDto;
 import im.toduck.domain.social.presentation.dto.response.SocialCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialDetailResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialImageDto;
@@ -84,6 +81,8 @@ public class SocialMapper {
 
 	private static SocialLikeDto getSocialLikeDto(Social socialBoard, boolean isLiked) {
 		return SocialLikeMapper.toSocialLikeDto(socialBoard, isLiked);
+	}
+
 	private static RoutineDetailResponse getSocialRoutineDto(final Routine routine) {
 		if (routine == null) {
 			return null;
@@ -91,19 +90,9 @@ public class SocialMapper {
 		return RoutineMapper.toRoutineDetailResponse(routine);
 	}
 
-	private static LikeDto getLikeDto(Social socialBoard, boolean isLiked) {
-		return LikeMapper.toLikeDto(socialBoard, isLiked);
-	}
-
 	private static List<SocialImageDto> getImageDtos(List<SocialImageFile> imageFiles) {
 		return imageFiles.stream()
 			.map(SocialImageFileMapper::toSocialImageDto)
-			.toList();
-	}
-
-	private static List<SocialCategoryDto> getCategoryDtos(List<SocialCategory> categories) {
-		return categories.stream()
-			.map(SocialCategoryMapper::toSocialCategoryDto)
 			.toList();
 	}
 
@@ -113,5 +102,4 @@ public class SocialMapper {
 			.nickname(user.getNickname())
 			.build();
 	}
-
 }

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
@@ -6,12 +6,12 @@ import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
 import im.toduck.domain.social.presentation.dto.response.CommentDto;
-import im.toduck.domain.social.presentation.dto.response.LikeDto;
 import im.toduck.domain.social.presentation.dto.response.OwnerDto;
 import im.toduck.domain.social.presentation.dto.response.SocialCategoryDto;
 import im.toduck.domain.social.presentation.dto.response.SocialCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialDetailResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialImageDto;
+import im.toduck.domain.social.presentation.dto.response.SocialLikeDto;
 import im.toduck.domain.social.presentation.dto.response.SocialResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.AccessLevel;
@@ -40,12 +40,12 @@ public class SocialMapper {
 		boolean isSocialBoardLiked
 	) {
 		return SocialDetailResponse.builder()
-			.id(socialBoard.getId())
+			.socialId(socialBoard.getId())
 			.owner(getOwner(socialBoard.getUser()))
 			.hasImages(!imageFiles.isEmpty())
 			.images(getImageDtos(imageFiles))
 			.content(socialBoard.getContent())
-			.likeInfo(getLikeDto(socialBoard, isSocialBoardLiked))
+			.socialLikeInfo(getSocialLikeDto(socialBoard, isSocialBoardLiked))
 			.comments(comments)
 			.createdAt(socialBoard.getCreatedAt())
 			.build();
@@ -59,19 +59,19 @@ public class SocialMapper {
 		boolean isLiked) {
 
 		return SocialResponse.builder()
-			.id(socialBoard.getId())
+			.socialId(socialBoard.getId())
 			.owner(getOwner(socialBoard.getUser()))
 			.content(socialBoard.getContent())
 			.hasImages(!imageFiles.isEmpty())
 			.images(getImageDtos(imageFiles))
-			.likeInfo(getLikeDto(socialBoard, isLiked))
+			.socialLikeInfo(getSocialLikeDto(socialBoard, isLiked))
 			.commentCount(commentCount)
 			.createdAt(socialBoard.getCreatedAt())
 			.build();
 	}
 
-	private static LikeDto getLikeDto(Social socialBoard, boolean isLiked) {
-		return LikeMapper.toLikeDto(socialBoard, isLiked);
+	private static SocialLikeDto getSocialLikeDto(Social socialBoard, boolean isLiked) {
+		return SocialLikeMapper.toSocialLikeDto(socialBoard, isLiked);
 	}
 
 	private static List<SocialImageDto> getImageDtos(List<SocialImageFile> imageFiles) {
@@ -88,7 +88,7 @@ public class SocialMapper {
 
 	private static OwnerDto getOwner(User user) {
 		return OwnerDto.builder()
-			.id(user.getId())
+			.ownerId(user.getId())
 			.nickname(user.getNickname())
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -46,18 +46,18 @@ public class SocialBoardService {
 	private final LikeRepository likeRepository;
 
 	@Transactional(readOnly = true)
-	public Optional<Social> getSocialById(Long socialId) {
+	public Optional<Social> getSocialById(final Long socialId) {
 		return socialRepository.findById(socialId);
 	}
 
 	@Transactional
-	public Social createSocialBoard(User user, SocialCreateRequest request) {
+	public Social createSocialBoard(final User user, final SocialCreateRequest request) {
 		Social socialBoard = SocialMapper.toSocial(user, request.content(), request.isAnonymous());
 		return socialRepository.save(socialBoard);
 	}
 
 	@Transactional
-	public void deleteSocialBoard(User user, Social socialBoard) {
+	public void deleteSocialBoard(final User user, final Social socialBoard) {
 		if (!isBoardOwner(socialBoard, user)) {
 			log.warn("권한이 없는 유저가 게시글 삭제 시도 - UserId: {}, SocialBoardId: {}", user.getId(), socialBoard.getId());
 			throw CommonException.from(ExceptionCode.UNAUTHORIZED_ACCESS_SOCIAL_BOARD);
@@ -83,7 +83,11 @@ public class SocialBoardService {
 	}
 
 	@Transactional
-	public void updateSocialBoard(User user, Social socialBoard, SocialUpdateRequest request) {
+	public void updateSocialBoard(
+		final User user,
+		final Social socialBoard,
+		final SocialUpdateRequest request
+	) {
 		if (!isBoardOwner(socialBoard, user)) {
 			log.warn("권한이 없는 유저가 소셜 게시판 수정 시도 - UserId: {}, SocialBoardId: {}", user.getId(), socialBoard.getId());
 			throw CommonException.from(ExceptionCode.UNAUTHORIZED_ACCESS_SOCIAL_BOARD);
@@ -123,12 +127,12 @@ public class SocialBoardService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<SocialCategory> findAllSocialCategories(List<Long> socialCategoryIds) {
+	public List<SocialCategory> findAllSocialCategories(final List<Long> socialCategoryIds) {
 		return socialCategoryRepository.findAllById(socialCategoryIds);
 	}
 
 	@Transactional
-	public void addSocialImageFiles(List<String> imageUrls, Social socialBoard) {
+	public void addSocialImageFiles(final List<String> imageUrls, final Social socialBoard) {
 		List<SocialImageFile> socialImageFiles = imageUrls.stream()
 			.map(url -> SocialImageFileMapper.toSocialImageFile(socialBoard, url))
 			.toList();
@@ -136,8 +140,11 @@ public class SocialBoardService {
 	}
 
 	@Transactional
-	public void addSocialCategoryLinks(List<Long> categoryIds, List<SocialCategory> socialCategories,
-		Social socialBoard) {
+	public void addSocialCategoryLinks(
+		final List<Long> categoryIds,
+		final List<SocialCategory> socialCategories,
+		final Social socialBoard
+	) {
 		if (isInvalidCategoryIncluded(categoryIds, socialCategories)) {
 			throw CommonException.from(ExceptionCode.NOT_FOUND_SOCIAL_CATEGORY);
 		}
@@ -150,27 +157,34 @@ public class SocialBoardService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<SocialImageFile> getSocialImagesBySocial(Social socialBoard) {
+	public List<SocialImageFile> getSocialImagesBySocial(final Social socialBoard) {
 		return socialImageFileRepository.findAllBySocial(socialBoard);
 	}
 
 	@Transactional(readOnly = true)
-	public List<Social> getSocials(Long cursor, Integer limit, Long currentUserId) {
+	public List<Social> getSocials(
+		final Long cursor,
+		final Integer limit,
+		final Long currentUserId
+	) {
 		PageRequest pageRequest = PageRequest.of(PaginationUtil.FIRST_PAGE_INDEX, limit);
 		return socialRepository.findByIdBeforeOrderByIdDescExcludingBlocked(cursor, currentUserId, pageRequest);
 	}
 
 	@Transactional(readOnly = true)
-	public List<Social> findLatestSocials(int limit, Long currentUserId) {
+	public List<Social> findLatestSocials(final int limit, final Long currentUserId) {
 		PageRequest pageRequest = PageRequest.of(PaginationUtil.FIRST_PAGE_INDEX, limit);
 		return socialRepository.findLatestSocialsExcludingBlocked(currentUserId, pageRequest);
 	}
 
-	private boolean isBoardOwner(Social socialBoard, User user) {
+	private boolean isBoardOwner(final Social socialBoard, final User user) {
 		return socialBoard.isOwner(user);
 	}
 
-	private boolean isInvalidCategoryIncluded(List<Long> socialCategoryIds, List<SocialCategory> socialCategories) {
+	private boolean isInvalidCategoryIncluded(
+		final List<Long> socialCategoryIds,
+		final List<SocialCategory> socialCategories
+	) {
 		return socialCategories.size() != socialCategoryIds.size();
 	}
 }

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -71,8 +71,7 @@ public class SocialBoardService {
 
 		List<Comment> comments = commentRepository.findAllBySocial(socialBoard);
 		comments.forEach(comment -> {
-			List<CommentLike> commentLikes = commentLikeRepository.findAllByComment(comment);
-			commentLikeRepository.deleteAll(commentLikes);
+			commentLikeRepository.findAllByComment(comment).forEach(CommentLike::softDelete);
 		});
 		comments.forEach(Comment::softDelete);
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -11,11 +11,13 @@ import im.toduck.domain.social.common.mapper.SocialCategoryLinkMapper;
 import im.toduck.domain.social.common.mapper.SocialImageFileMapper;
 import im.toduck.domain.social.common.mapper.SocialMapper;
 import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentLike;
 import im.toduck.domain.social.persistence.entity.Like;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
 import im.toduck.domain.social.persistence.entity.SocialCategoryLink;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
+import im.toduck.domain.social.persistence.repository.CommentLikeRepository;
 import im.toduck.domain.social.persistence.repository.CommentRepository;
 import im.toduck.domain.social.persistence.repository.LikeRepository;
 import im.toduck.domain.social.persistence.repository.SocialCategoryLinkRepository;
@@ -40,6 +42,7 @@ public class SocialBoardService {
 	private final SocialImageFileRepository socialImageFileRepository;
 	private final SocialCategoryLinkRepository socialCategoryLinkRepository;
 	private final CommentRepository commentRepository;
+	private final CommentLikeRepository commentLikeRepository;
 	private final LikeRepository likeRepository;
 
 	@Transactional(readOnly = true)
@@ -67,6 +70,10 @@ public class SocialBoardService {
 		socialCategoryLinks.forEach(SocialCategoryLink::softDelete);
 
 		List<Comment> comments = commentRepository.findAllBySocial(socialBoard);
+		comments.forEach(comment -> {
+			List<CommentLike> commentLikes = commentLikeRepository.findAllByComment(comment);
+			commentLikeRepository.deleteAll(commentLikes);
+		});
 		comments.forEach(Comment::softDelete);
 
 		List<Like> likes = likeRepository.findAllBySocial(socialBoard);

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -68,8 +68,7 @@ public class SocialInteractionService {
 		}
 
 		List<CommentLike> commentLikes = commentLikeRepository.findAllByComment(comment);
-		commentLikes.forEach(CommentLike::softDelete);
-
+		commentLikeRepository.deleteAll(commentLikes);
 		commentRepository.delete(comment);
 	}
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -104,9 +104,15 @@ public class SocialInteractionService {
 	}
 
 	@Transactional(readOnly = true)
-	public boolean getIsLiked(User user, Social socialBoard) {
+	public boolean getSocialBoardIsLiked(User user, Social socialBoard) {
 		Optional<Like> like = likeRepository.findByUserAndSocial(user, socialBoard);
 		return like.isPresent();
+	}
+
+	@Transactional(readOnly = true)
+	public boolean getCommentIsLiked(final User user, final Comment comment) {
+		Optional<CommentLike> commentLike = commentLikeRepository.findCommentLikeByUserAndComment(user, comment);
+		return commentLike.isPresent();
 	}
 
 	@Transactional

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -185,8 +185,8 @@ public class SocialInteractionService {
 
 	@Transactional
 	public void deleteCommentLike(final Comment comment, final CommentLike commentLike) {
-		comment.decrementLikeCount();
 		commentLikeRepository.delete(commentLike);
+		comment.decrementLikeCount();
 	}
 
 }

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -59,6 +59,9 @@ public class SocialInteractionService {
 			throw CommonException.from(ExceptionCode.INVALID_COMMENT_FOR_BOARD);
 		}
 
+		List<CommentLike> commentLikes = commentLikeRepository.findAllByComment(comment);
+		commentLikes.forEach(CommentLike::softDelete);
+
 		commentRepository.delete(comment);
 	}
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -150,5 +150,16 @@ public class SocialInteractionService {
 
 		return commentLikeRepository.save(commentLike);
 	}
+
+	@Transactional(readOnly = true)
+	public Optional<CommentLike> getCommentLikeByUserAndComment(final User user, final Comment comment) {
+		return commentLikeRepository.findCommentLikeByUserAndComment(user, comment);
+	}
+
+	@Transactional
+	public void deleteCommentLike(final User user, final Comment comment, final CommentLike commentLike) {
+		commentLikeRepository.delete(commentLike);
+	}
+
 }
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -8,8 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.domain.social.common.mapper.CommentLikeMapper;
 import im.toduck.domain.social.common.mapper.CommentMapper;
-import im.toduck.domain.social.common.mapper.LikeMapper;
 import im.toduck.domain.social.common.mapper.ReportMapper;
+import im.toduck.domain.social.common.mapper.SocialLikeMapper;
 import im.toduck.domain.social.persistence.entity.Comment;
 import im.toduck.domain.social.persistence.entity.CommentLike;
 import im.toduck.domain.social.persistence.entity.Like;
@@ -74,7 +74,7 @@ public class SocialInteractionService {
 			throw CommonException.from(ExceptionCode.EXISTS_LIKE);
 		}
 
-		Like like = LikeMapper.toLike(user, socialBoard);
+		Like like = SocialLikeMapper.toLike(user, socialBoard);
 		return likeRepository.save(like);
 	}
 

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
@@ -39,7 +39,7 @@ public class SocialBoardUseCase {
 	private final UserService userService;
 
 	@Transactional
-	public SocialCreateResponse createSocialBoard(Long userId, SocialCreateRequest request) {
+	public SocialCreateResponse createSocialBoard(final Long userId, final SocialCreateRequest request) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
@@ -53,7 +53,7 @@ public class SocialBoardUseCase {
 	}
 
 	@Transactional
-	public void deleteSocialBoard(Long userId, Long socialId) {
+	public void deleteSocialBoard(final Long userId, final Long socialId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
@@ -64,7 +64,11 @@ public class SocialBoardUseCase {
 	}
 
 	@Transactional
-	public void updateSocialBoard(Long userId, Long socialId, SocialUpdateRequest request) {
+	public void updateSocialBoard(
+		final Long userId,
+		final Long socialId,
+		final SocialUpdateRequest request
+	) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
@@ -75,7 +79,7 @@ public class SocialBoardUseCase {
 	}
 
 	@Transactional(readOnly = true)
-	public SocialDetailResponse getSocialDetail(Long userId, Long socialId) {
+	public SocialDetailResponse getSocialDetail(final Long userId, final Long socialId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
@@ -104,7 +108,11 @@ public class SocialBoardUseCase {
 	}
 
 	@Transactional(readOnly = true)
-	public CursorPaginationResponse<SocialResponse> getSocials(Long userId, Long cursor, Integer limit) {
+	public CursorPaginationResponse<SocialResponse> getSocials(
+		final Long userId,
+		final Long cursor,
+		final Integer limit
+	) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
@@ -121,14 +129,22 @@ public class SocialBoardUseCase {
 		return PaginationUtil.toCursorPaginationResponse(hasMore, nextCursor, socialResponses);
 	}
 
-	private List<Social> fetchSocialBoards(Long cursor, int fetchLimit, Long currentUserId) {
+	private List<Social> fetchSocialBoards(
+		final Long cursor,
+		final int fetchLimit,
+		final Long currentUserId
+	) {
 		if (cursor == null) {
 			return socialBoardService.findLatestSocials(fetchLimit, currentUserId);
 		}
 		return socialBoardService.getSocials(cursor, fetchLimit, currentUserId);
 	}
 
-	private List<SocialResponse> createSocialResponses(List<Social> socialBoards, User user, int actualLimit) {
+	private List<SocialResponse> createSocialResponses(
+		final List<Social> socialBoards,
+		final User user,
+		final int actualLimit
+	) {
 		return socialBoards.stream()
 			.limit(actualLimit)
 			.map(sb -> {

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
@@ -65,7 +65,6 @@ public class SocialBoardUseCase {
 	}
 
 	@Transactional
-	public void deleteSocialBoard(final Long userId, final Long socialId) {
 	public void updateSocialBoard(
 		final Long userId,
 		final Long socialId,

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
@@ -36,7 +36,11 @@ public class SocialInteractionUseCase {
 	private final UserService userService;
 
 	@Transactional
-	public CommentCreateResponse createComment(Long userId, Long socialId, CommentCreateRequest request) {
+	public CommentCreateResponse createComment(
+		final Long userId,
+		final Long socialId,
+		final CommentCreateRequest request
+	) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
@@ -48,7 +52,11 @@ public class SocialInteractionUseCase {
 	}
 
 	@Transactional
-	public void deleteComment(Long userId, Long socialId, Long commentId) {
+	public void deleteComment(
+		final Long userId,
+		final Long socialId,
+		final Long commentId
+	) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
@@ -61,34 +69,37 @@ public class SocialInteractionUseCase {
 	}
 
 	@Transactional
-	public SocialLikeCreateResponse createLike(Long userId, Long socialId) {
+	public SocialLikeCreateResponse createSocialLike(final Long userId, final Long socialId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SOCIAL_BOARD));
-		Like like = socialInteractionService.createLike(user, socialBoard);
-		socialBoard.incrementLikeCount();
+		Like like = socialInteractionService.createSocialLike(user, socialBoard);
 
 		log.info("소셜 게시글 좋아요 생성 - UserId: {}, SocialBoardId: {}, LikeId: {}", userId, socialId, like.getId());
 		return SocialLikeMapper.toSocialLikeCreateResponse(like);
 	}
 
 	@Transactional
-	public void deleteLike(Long userId, Long socialId) {
+	public void deleteSocialLike(final Long userId, final Long socialId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SOCIAL_BOARD));
 		Like like = socialInteractionService.getLikeByUserAndSocial(user, socialBoard)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_LIKE));
-		socialBoard.decrementLikeCount();
+
+		socialInteractionService.deleteSocialLike(user, socialBoard, like);
 
 		log.info("소셜 게시글 좋아요 삭제 - UserId: {}, SocialBoardId: {}, LikeId: {}", userId, socialId, like.getId());
-		socialInteractionService.deleteLike(user, socialBoard, like);
 	}
 
 	@Transactional
-	public ReportCreateResponse reportSocial(Long userId, Long socialId, ReportCreateRequest request) {
+	public ReportCreateResponse reportSocial(
+		final Long userId,
+		final Long socialId,
+		final ReportCreateRequest request
+	) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
@@ -116,14 +127,14 @@ public class SocialInteractionUseCase {
 		return ReportMapper.toReportCreateResponse(report);
 	}
 
-	private void blockAuthorIfNotAlreadyBlocked(User blocker, User blockedUser) {
+	private void blockAuthorIfNotAlreadyBlocked(final User blocker, final User blockedUser) {
 		if (!userService.isBlockedUser(blocker, blockedUser)) {
 			userService.blockUser(blocker, blockedUser);
 		}
 	}
 
 	@Transactional
-	public CommentLikeCreateResponse createCommentLike(Long userId, Long commentId) {
+	public CommentLikeCreateResponse createCommentLike(final Long userId, final Long commentId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Comment comment = socialInteractionService.getCommentById(commentId)
@@ -136,16 +147,15 @@ public class SocialInteractionUseCase {
 	}
 
 	@Transactional
-	public void deleteCommentLike(Long userId, Long commentId) {
+	public void deleteCommentLike(final Long userId, final Long commentId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Comment comment = socialInteractionService.getCommentById(commentId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_COMMENT));
 		CommentLike commentLike = socialInteractionService.getCommentLikeByUserAndComment(user, comment)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_COMMENT_LIKE));
-		comment.decrementLikeCount();
 
-		socialInteractionService.deleteCommentLike(user, comment, commentLike);
+		socialInteractionService.deleteCommentLike(comment, commentLike);
 		log.info("댓글 좋아요 삭제 - UserId: {}, CommentId: {}, LikeId: {}", userId, commentId, commentLike.getId());
 	}
 }

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
@@ -4,8 +4,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.domain.social.common.mapper.CommentLikeMapper;
 import im.toduck.domain.social.common.mapper.CommentMapper;
-import im.toduck.domain.social.common.mapper.LikeMapper;
 import im.toduck.domain.social.common.mapper.ReportMapper;
+import im.toduck.domain.social.common.mapper.SocialLikeMapper;
 import im.toduck.domain.social.domain.service.SocialBoardService;
 import im.toduck.domain.social.domain.service.SocialInteractionService;
 import im.toduck.domain.social.persistence.entity.Comment;
@@ -17,8 +17,8 @@ import im.toduck.domain.social.presentation.dto.request.CommentCreateRequest;
 import im.toduck.domain.social.presentation.dto.request.ReportCreateRequest;
 import im.toduck.domain.social.presentation.dto.response.CommentCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.CommentLikeCreateResponse;
-import im.toduck.domain.social.presentation.dto.response.LikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.ReportCreateResponse;
+import im.toduck.domain.social.presentation.dto.response.SocialLikeCreateResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.annotation.UseCase;
@@ -61,7 +61,7 @@ public class SocialInteractionUseCase {
 	}
 
 	@Transactional
-	public LikeCreateResponse createLike(Long userId, Long socialId) {
+	public SocialLikeCreateResponse createLike(Long userId, Long socialId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
@@ -70,7 +70,7 @@ public class SocialInteractionUseCase {
 		socialBoard.incrementLikeCount();
 
 		log.info("소셜 게시글 좋아요 생성 - UserId: {}, SocialBoardId: {}, LikeId: {}", userId, socialId, like.getId());
-		return LikeMapper.toLikeCreateResponse(like);
+		return SocialLikeMapper.toSocialLikeCreateResponse(like);
 	}
 
 	@Transactional

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
@@ -2,18 +2,21 @@ package im.toduck.domain.social.domain.usecase;
 
 import org.springframework.transaction.annotation.Transactional;
 
+import im.toduck.domain.social.common.mapper.CommentLikeMapper;
 import im.toduck.domain.social.common.mapper.CommentMapper;
 import im.toduck.domain.social.common.mapper.LikeMapper;
 import im.toduck.domain.social.common.mapper.ReportMapper;
 import im.toduck.domain.social.domain.service.SocialBoardService;
 import im.toduck.domain.social.domain.service.SocialInteractionService;
 import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentLike;
 import im.toduck.domain.social.persistence.entity.Like;
 import im.toduck.domain.social.persistence.entity.Report;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.presentation.dto.request.CommentCreateRequest;
 import im.toduck.domain.social.presentation.dto.request.ReportCreateRequest;
 import im.toduck.domain.social.presentation.dto.response.CommentCreateResponse;
+import im.toduck.domain.social.presentation.dto.response.CommentLikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.LikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.ReportCreateResponse;
 import im.toduck.domain.user.domain.service.UserService;
@@ -118,4 +121,18 @@ public class SocialInteractionUseCase {
 			userService.blockUser(blocker, blockedUser);
 		}
 	}
+
+	@Transactional
+	public CommentLikeCreateResponse createCommentLike(Long userId, Long commentId) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+		Comment comment = socialInteractionService.getCommentById(commentId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_COMMENT));
+
+		CommentLike commentLike = socialInteractionService.createCommentLike(user, comment);
+
+		log.info("댓글 좋아요 생성 - UserId: {}, CommentId: {}, LikeId: {}", userId, commentId, commentLike.getId());
+		return CommentLikeMapper.toCommentLikeCreateResponse(commentLike);
+	}
+
 }

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
@@ -135,4 +135,17 @@ public class SocialInteractionUseCase {
 		return CommentLikeMapper.toCommentLikeCreateResponse(commentLike);
 	}
 
+	@Transactional
+	public void deleteCommentLike(Long userId, Long commentId) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+		Comment comment = socialInteractionService.getCommentById(commentId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_COMMENT));
+		CommentLike commentLike = socialInteractionService.getCommentLikeByUserAndComment(user, comment)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_COMMENT_LIKE));
+		comment.decrementLikeCount();
+
+		socialInteractionService.deleteCommentLike(user, comment, commentLike);
+		log.info("댓글 좋아요 삭제 - UserId: {}, CommentId: {}, LikeId: {}", userId, commentId, commentLike.getId());
+	}
 }

--- a/src/main/java/im/toduck/domain/social/persistence/entity/Comment.java
+++ b/src/main/java/im/toduck/domain/social/persistence/entity/Comment.java
@@ -61,4 +61,8 @@ public class Comment extends BaseEntity {
 	public void softDelete() {
 		this.deletedAt = LocalDateTime.now();
 	}
+
+	public void incrementLikeCount() {
+		this.likeCount++;
+	}
 }

--- a/src/main/java/im/toduck/domain/social/persistence/entity/Comment.java
+++ b/src/main/java/im/toduck/domain/social/persistence/entity/Comment.java
@@ -65,4 +65,10 @@ public class Comment extends BaseEntity {
 	public void incrementLikeCount() {
 		this.likeCount++;
 	}
+
+	public void decrementLikeCount() {
+		if (this.likeCount > 0) {
+			this.likeCount--;
+		}
+	}
 }

--- a/src/main/java/im/toduck/domain/social/persistence/entity/CommentLike.java
+++ b/src/main/java/im/toduck/domain/social/persistence/entity/CommentLike.java
@@ -2,60 +2,50 @@ package im.toduck.domain.social.persistence.entity;
 
 import java.time.LocalDateTime;
 
-import im.toduck.domain.social.persistence.vo.CommentContent;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.base.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "comment")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment extends BaseEntity {
+@Table(name = "comment_likes")
+@NoArgsConstructor
+public class CommentLike extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Embedded
-	private CommentContent content;
-
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	@ManyToOne
-	@JoinColumn(name = "social_id", nullable = false)
-	private Social social;
-
-	@Column(nullable = false, columnDefinition = "int default 0")
-	private int likeCount;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "comment_id", nullable = false)
+	private Comment comment;
 
 	@Builder
-	private Comment(User user, Social social, CommentContent content) {
+	private CommentLike(User user, Comment comment) {
 		this.user = user;
-		this.social = social;
-		this.content = content;
+		this.comment = comment;
 	}
 
-	public boolean isOwner(User requestingUser) {
+	public boolean isOwner(final User requestingUser) {
 		return this.user.getId().equals(requestingUser.getId());
 	}
 
-	public boolean isInSocialBoard(Social socialBoard) {
-		return this.social.getId().equals(socialBoard.getId());
+	public boolean isForComment(final Comment comment) {
+		return this.comment.getId().equals(comment.getId());
 	}
 
 	public void softDelete() {

--- a/src/main/java/im/toduck/domain/social/persistence/entity/CommentLike.java
+++ b/src/main/java/im/toduck/domain/social/persistence/entity/CommentLike.java
@@ -40,14 +40,6 @@ public class CommentLike extends BaseEntity {
 		this.comment = comment;
 	}
 
-	public boolean isOwner(final User requestingUser) {
-		return this.user.getId().equals(requestingUser.getId());
-	}
-
-	public boolean isForComment(final Comment comment) {
-		return this.comment.getId().equals(comment.getId());
-	}
-
 	public void softDelete() {
 		this.deletedAt = LocalDateTime.now();
 	}

--- a/src/main/java/im/toduck/domain/social/persistence/repository/CommentLikeRepository.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/CommentLikeRepository.java
@@ -1,5 +1,6 @@
 package im.toduck.domain.social.persistence.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import im.toduck.domain.user.persistence.entity.User;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
 	Optional<CommentLike> findCommentLikeByUserAndComment(User user, Comment comment);
+
+	List<CommentLike> findAllByComment(Comment comment);
 }

--- a/src/main/java/im/toduck/domain/social/persistence/repository/CommentLikeRepository.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/CommentLikeRepository.java
@@ -1,0 +1,13 @@
+package im.toduck.domain.social.persistence.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentLike;
+import im.toduck.domain.user.persistence.entity.User;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+	Optional<CommentLike> findCommentLikeByUserAndComment(User user, Comment comment);
+}

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
@@ -11,8 +11,8 @@ import im.toduck.domain.social.presentation.dto.request.CommentCreateRequest;
 import im.toduck.domain.social.presentation.dto.request.ReportCreateRequest;
 import im.toduck.domain.social.presentation.dto.response.CommentCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.CommentLikeCreateResponse;
-import im.toduck.domain.social.presentation.dto.response.LikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.ReportCreateResponse;
+import im.toduck.domain.social.presentation.dto.response.SocialLikeCreateResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -71,7 +71,7 @@ public interface SocialInteractionApi {
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
-			responseClass = LikeCreateResponse.class,
+			responseClass = SocialLikeCreateResponse.class,
 			description = "좋아요 성공, 생성된 좋아요의 Id를 반환합니다."
 		),
 		errors = {
@@ -79,7 +79,7 @@ public interface SocialInteractionApi {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SOCIAL_BOARD),
 		}
 	)
-	ResponseEntity<ApiResponse<LikeCreateResponse>> createLike(
+	ResponseEntity<ApiResponse<SocialLikeCreateResponse>> createLike(
 		@PathVariable Long socialId,
 		@AuthenticationPrincipal CustomUserDetails user
 	);

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import im.toduck.domain.social.presentation.dto.request.CommentCreateRequest;
 import im.toduck.domain.social.presentation.dto.request.ReportCreateRequest;
 import im.toduck.domain.social.presentation.dto.response.CommentCreateResponse;
+import im.toduck.domain.social.presentation.dto.response.CommentLikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.LikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.ReportCreateResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
@@ -128,6 +129,25 @@ public interface SocialInteractionApi {
 	ResponseEntity<ApiResponse<ReportCreateResponse>> reportSocialBoard(
 		@RequestBody ReportCreateRequest request,
 		@PathVariable Long socialId,
+		@AuthenticationPrincipal CustomUserDetails user
+	);
+
+	@Operation(
+		summary = "댓글 좋아요",
+		description = "지정된 댓글을 좋아요 합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = CommentCreateResponse.class,
+			description = "댓글 좋아요 성공, 생성된 좋아요의 Id를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.EXISTS_LIKE),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_COMMENT),
+		}
+	)
+	ResponseEntity<ApiResponse<CommentLikeCreateResponse>> createCommentLike(
+		@PathVariable Long commentId,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
 }

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
@@ -142,11 +142,29 @@ public interface SocialInteractionApi {
 			description = "댓글 좋아요 성공, 생성된 좋아요의 Id를 반환합니다."
 		),
 		errors = {
-			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.EXISTS_LIKE),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.EXISTS_COMMENT_LIKE),
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_COMMENT),
 		}
 	)
 	ResponseEntity<ApiResponse<CommentLikeCreateResponse>> createCommentLike(
+		@PathVariable Long commentId,
+		@AuthenticationPrincipal CustomUserDetails user
+	);
+
+	@Operation(
+		summary = "댓글 좋아요 취소",
+		description = "지정된 댓글의 좋아요를 취소합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "댓글 좋아요 취소 성공, 빈 content 객체를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_COMMENT),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_COMMENT_LIKE),
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> deleteCommentLike(
 		@PathVariable Long commentId,
 		@AuthenticationPrincipal CustomUserDetails user
 	);

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
@@ -147,6 +147,7 @@ public interface SocialInteractionApi {
 		}
 	)
 	ResponseEntity<ApiResponse<CommentLikeCreateResponse>> createCommentLike(
+		@PathVariable Long socialId,
 		@PathVariable Long commentId,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
@@ -165,6 +166,7 @@ public interface SocialInteractionApi {
 		}
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> deleteCommentLike(
+		@PathVariable Long socialId,
 		@PathVariable Long commentId,
 		@AuthenticationPrincipal CustomUserDetails user
 	);

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
@@ -79,7 +79,7 @@ public interface SocialInteractionApi {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SOCIAL_BOARD),
 		}
 	)
-	ResponseEntity<ApiResponse<SocialLikeCreateResponse>> createLike(
+	ResponseEntity<ApiResponse<SocialLikeCreateResponse>> createSocialLike(
 		@PathVariable Long socialId,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
@@ -100,7 +100,7 @@ public interface SocialInteractionApi {
 
 		}
 	)
-	ResponseEntity<ApiResponse<Map<String, Object>>> deleteLike(
+	ResponseEntity<ApiResponse<Map<String, Object>>> deleteSocialLike(
 		@PathVariable Long socialId,
 		@AuthenticationPrincipal CustomUserDetails user
 	);

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
@@ -17,6 +17,7 @@ import im.toduck.domain.social.presentation.api.SocialInteractionApi;
 import im.toduck.domain.social.presentation.dto.request.CommentCreateRequest;
 import im.toduck.domain.social.presentation.dto.request.ReportCreateRequest;
 import im.toduck.domain.social.presentation.dto.response.CommentCreateResponse;
+import im.toduck.domain.social.presentation.dto.response.CommentLikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.LikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.ReportCreateResponse;
 import im.toduck.global.presentation.ApiResponse;
@@ -93,5 +94,16 @@ public class SocialInteractionController implements SocialInteractionApi {
 		return ResponseEntity.ok()
 			.body(ApiResponse.createSuccess(
 				socialInteractionUseCase.reportSocial(user.getUserId(), socialId, request)));
+	}
+
+	@Override
+	@PostMapping("/comments/{commentId}/likes")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<CommentLikeCreateResponse>> createCommentLike(
+		@PathVariable Long commentId,
+		@AuthenticationPrincipal CustomUserDetails user
+	) {
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(socialInteractionUseCase.createCommentLike(user.getUserId(), commentId)));
 	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
@@ -106,4 +106,15 @@ public class SocialInteractionController implements SocialInteractionApi {
 		return ResponseEntity.ok()
 			.body(ApiResponse.createSuccess(socialInteractionUseCase.createCommentLike(user.getUserId(), commentId)));
 	}
+
+	@Override
+	@DeleteMapping("/comments/{commentId}/likes")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteCommentLike(
+		@PathVariable Long commentId,
+		@AuthenticationPrincipal CustomUserDetails user
+	) {
+		socialInteractionUseCase.deleteCommentLike(user.getUserId(), commentId);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
@@ -18,8 +18,8 @@ import im.toduck.domain.social.presentation.dto.request.CommentCreateRequest;
 import im.toduck.domain.social.presentation.dto.request.ReportCreateRequest;
 import im.toduck.domain.social.presentation.dto.response.CommentCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.CommentLikeCreateResponse;
-import im.toduck.domain.social.presentation.dto.response.LikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.ReportCreateResponse;
+import im.toduck.domain.social.presentation.dto.response.SocialLikeCreateResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -61,7 +61,7 @@ public class SocialInteractionController implements SocialInteractionApi {
 	@Override
 	@PostMapping("/{socialId}/likes")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<LikeCreateResponse>> createLike(
+	public ResponseEntity<ApiResponse<SocialLikeCreateResponse>> createLike(
 		@PathVariable Long socialId,
 		CustomUserDetails user
 	) {

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
@@ -97,9 +97,10 @@ public class SocialInteractionController implements SocialInteractionApi {
 	}
 
 	@Override
-	@PostMapping("/comments/{commentId}/likes")
+	@PostMapping("/{socialId}/comments/{commentId}/likes")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponse<CommentLikeCreateResponse>> createCommentLike(
+		@PathVariable Long socialId,
 		@PathVariable Long commentId,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
@@ -108,9 +109,10 @@ public class SocialInteractionController implements SocialInteractionApi {
 	}
 
 	@Override
-	@DeleteMapping("/comments/{commentId}/likes")
+	@DeleteMapping("/{socialId}/comments/{commentId}/likes")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteCommentLike(
+		@PathVariable Long socialId,
 		@PathVariable Long commentId,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialInteractionController.java
@@ -61,23 +61,23 @@ public class SocialInteractionController implements SocialInteractionApi {
 	@Override
 	@PostMapping("/{socialId}/likes")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<SocialLikeCreateResponse>> createLike(
+	public ResponseEntity<ApiResponse<SocialLikeCreateResponse>> createSocialLike(
 		@PathVariable Long socialId,
 		CustomUserDetails user
 	) {
 
 		return ResponseEntity.ok()
-			.body(ApiResponse.createSuccess(socialInteractionUseCase.createLike(user.getUserId(), socialId)));
+			.body(ApiResponse.createSuccess(socialInteractionUseCase.createSocialLike(user.getUserId(), socialId)));
 	}
 
 	@Override
 	@DeleteMapping("/{socialId}/likes")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteLike(
+	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteSocialLike(
 		@PathVariable Long socialId,
 		CustomUserDetails user
 	) {
-		socialInteractionUseCase.deleteLike(user.getUserId(), socialId);
+		socialInteractionUseCase.deleteSocialLike(user.getUserId(), socialId);
 
 		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
 	}

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentDto.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentDto.java
@@ -20,6 +20,9 @@ public record CommentDto(
 	@Schema(description = "댓글 내용", example = "루틴 너무 좋네요!")
 	String content,
 
+	@Schema(description = "댓글 좋아요 정보")
+	CommentLikeDto commentLikeInfo,
+
 	@Schema(description = "댓글 작성 시간", type = "string", pattern = "yyyy-MM-dd HH:mm", example = "2024-09-11 10:30")
 	@JsonSerialize(using = LocalDateTimeSerializer.class)
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentLikeCreateResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentLikeCreateResponse.java
@@ -1,0 +1,11 @@
+package im.toduck.domain.social.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record CommentLikeCreateResponse(
+	@Schema(description = "생성된 댓글 좋아요 ID", example = "1")
+	Long commentLikeId
+) {
+}

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentLikeDto.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentLikeDto.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 @Builder
 public record CommentLikeDto(
 	@Schema(description = "사용자가 이 댓글을 좋아요 했는지 여부", example = "true")
-	boolean isLiked,
+	boolean isLikedByMe,
 
 	@Schema(description = "이 댓글의 총 좋아요 수", example = "5")
 	int likeCount

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentLikeDto.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentLikeDto.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.social.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record CommentLikeDto(
+	@Schema(description = "사용자가 이 댓글을 좋아요 했는지 여부", example = "true")
+	boolean isLiked,
+
+	@Schema(description = "이 댓글의 총 좋아요 수", example = "5")
+	int likeCount
+) {
+}

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/OwnerDto.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/OwnerDto.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 @Builder
 public record OwnerDto(
 	@Schema(description = "작성자 ID", example = "1")
-	Long id,
+	Long ownerId,
 
 	@Schema(description = "작성자 닉네임", example = "오리발")
 	String nickname

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialCategoryDto.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialCategoryDto.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 @Builder
 public record SocialCategoryDto(
 	@Schema(description = "소셜 카테고리 ID", example = "1")
-	Long id,
+	Long socialCategoryId,
 
 	@Schema(description = "소셜 카테고리 이름", example = "집중력")
 	String name

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialDetailResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialDetailResponse.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 @Builder
 public record SocialDetailResponse(
 	@Schema(description = "소셜 게시글 ID", example = "1")
-	Long id,
+	Long socialId,
 
 	@Schema(description = "작성자 정보")
 	OwnerDto owner,
@@ -28,7 +28,7 @@ public record SocialDetailResponse(
 	List<SocialImageDto> images,
 
 	@Schema(description = "좋아요 정보")
-	LikeDto likeInfo,
+	SocialLikeDto socialLikeInfo,
 
 	@Schema(description = "댓글 목록")
 	List<CommentDto> comments,

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialImageDto.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialImageDto.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 @Builder
 public record SocialImageDto(
 	@Schema(description = "이미지 Id", example = "1")
-	Long id,
+	Long socialImageId,
 
 	@Schema(description = "이미지 URL", example = "https://cdn.toduck.app/image1.jpg")
 	String url

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialLikeCreateResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialLikeCreateResponse.java
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record LikeCreateResponse(
+public record SocialLikeCreateResponse(
 	@Schema(description = "생성된 좋아요 ID", example = "1")
-	Long likeId
+	Long socialLikeId
 ) {
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialLikeDto.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialLikeDto.java
@@ -4,9 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record LikeDto(
+public record SocialLikeDto(
 	@Schema(description = "사용자가 이 게시글을 좋아요 했는지 여부", example = "true")
-	boolean isLiked,
+	boolean isLikedByMe,
 
 	@Schema(description = "이 게시글의 총 좋아요 수", example = "13")
 	int likeCount

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialResponse.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 @Builder
 public record SocialResponse(
 	@Schema(description = "소셜 게시글 ID", example = "1")
-	Long id,
+	Long socialId,
 
 	@Schema(description = "작성자 정보")
 	OwnerDto owner,
@@ -28,7 +28,7 @@ public record SocialResponse(
 	List<SocialImageDto> images,
 
 	@Schema(description = "좋아요 정보")
-	LikeDto likeInfo,
+	SocialLikeDto socialLikeInfo,
 
 	@Schema(description = "댓글 수", example = "1")
 	int commentCount,

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -75,6 +75,8 @@ public enum ExceptionCode {
 	ALREADY_REPORTED(HttpStatus.CONFLICT, 40413, "이미 신고된 게시글입니다.",
 		"이미 신고한 게시글에 대해 다시 신고를 시도할 때 발생하는 오류입니다."),
 	CANNOT_REPORT_OWN_POST(HttpStatus.FORBIDDEN, 40414, "자신의 게시글은 신고할 수 없습니다."),
+	EXISTS_COMMENT_LIKE(HttpStatus.CONFLICT, 40415, "이미 댓글에 좋아요를 눌렀습니다."),
+	NOT_FOUND_COMMENT_LIKE(HttpStatus.NOT_FOUND, 40416, "해당 댓글 좋아요를 찾을 수 없습니다."),
 
 	/* 432xx */
 	NOT_FOUND_ROUTINE(HttpStatus.NOT_FOUND, 43201, "권한이 없거나 존재하지 않는 루틴입니다."),

--- a/src/test/java/im/toduck/builder/BuilderSupporter.java
+++ b/src/test/java/im/toduck/builder/BuilderSupporter.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 
 import im.toduck.domain.routine.persistence.repository.RoutineRecordRepository;
 import im.toduck.domain.routine.persistence.repository.RoutineRepository;
+import im.toduck.domain.social.persistence.repository.CommentLikeRepository;
 import im.toduck.domain.social.persistence.repository.CommentRepository;
 import im.toduck.domain.social.persistence.repository.LikeRepository;
 import im.toduck.domain.social.persistence.repository.SocialCategoryRepository;
@@ -47,6 +48,9 @@ public class BuilderSupporter {
 	@Autowired
 	private BlockRepository blockRepository;
 
+	@Autowired
+	private CommentLikeRepository commentLikeRepository;
+
 	public UserRepository userRepository() {
 		return userRepository;
 	}
@@ -85,6 +89,10 @@ public class BuilderSupporter {
 
 	public BlockRepository blockRepository() {
 		return blockRepository;
+	}
+
+	public CommentLikeRepository commentLikeRepository() {
+		return commentLikeRepository;
 	}
 
 }

--- a/src/test/java/im/toduck/builder/TestFixtureBuilder.java
+++ b/src/test/java/im/toduck/builder/TestFixtureBuilder.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentLike;
 import im.toduck.domain.social.persistence.entity.Like;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
@@ -64,6 +65,10 @@ public class TestFixtureBuilder {
 
 	public Block buildBlock(final Block block) {
 		return bs.blockRepository().save(block);
+	}
+
+	public CommentLike buildCommentLike(final CommentLike commentLike) {
+		return bs.commentLikeRepository().save(commentLike);
 	}
 
 }

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
@@ -204,12 +204,12 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 
 			// routine1의 미래 미완료 기록 (삭제 대상)
 			RoutineRecord routine1Future = testFixtureBuilder.buildRoutineRecord(
-				OFFSET_INCOMPLETED_SYNCED_RECORD(routine1, 0L)
+				OFFSET_INCOMPLETED_SYNCED_RECORD(routine1, 1L)
 			);
 
 			// routine2의 미래 미완료 기록 (유지되어야 함)
 			RoutineRecord routine2Future = testFixtureBuilder.buildRoutineRecord(
-				OFFSET_INCOMPLETED_SYNCED_RECORD(routine2, 0L)
+				OFFSET_INCOMPLETED_SYNCED_RECORD(routine2, 1L)
 			);
 
 			// when

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -30,6 +30,7 @@ import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
 import im.toduck.domain.social.persistence.entity.SocialCategoryLink;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
+import im.toduck.domain.social.persistence.repository.CommentLikeRepository;
 import im.toduck.domain.social.persistence.repository.CommentRepository;
 import im.toduck.domain.social.persistence.repository.SocialCategoryLinkRepository;
 import im.toduck.domain.social.persistence.repository.SocialImageFileRepository;
@@ -65,6 +66,9 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 	@Autowired
 	private CommentRepository commentRepository;
+
+	@Autowired
+	private CommentLikeRepository commentLikeRepository;
 
 	@BeforeEach
 	public void setUp() {

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -419,10 +419,10 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			// then
 			assertSoftly(softly -> {
 				softly.assertThat(response).isNotNull();
-				softly.assertThat(response.id()).isEqualTo(SOCIAL_BOARD.getId());
+				softly.assertThat(response.socialId()).isEqualTo(SOCIAL_BOARD.getId());
 				softly.assertThat(response.content()).isEqualTo(SOCIAL_BOARD.getContent());
 				softly.assertThat(response.hasImages()).isTrue();
-				softly.assertThat(response.likeInfo().isLiked()).isTrue();
+				softly.assertThat(response.socialLikeInfo().isLikedByMe()).isTrue();
 				softly.assertThat(response.images())
 					.hasSize(IMAGE_FILES.size())
 					.extracting(SocialImageDto::url)

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCaseTest.java
@@ -244,7 +244,8 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 			int beforeLikeCount = SOCIAL_BOARD.getLikeCount();
 
 			// when
-			SocialLikeCreateResponse response = socialInteractionUseCase.createLike(USER.getId(), SOCIAL_BOARD.getId());
+			SocialLikeCreateResponse response = socialInteractionUseCase.createSocialLike(USER.getId(),
+				SOCIAL_BOARD.getId());
 
 			// then
 			Like createdLike = likeRepository.findByUserAndSocial(USER, SOCIAL_BOARD).orElseThrow();
@@ -262,10 +263,11 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 		@Test
 		void 이미_좋아요를_누른_경우_예외를_발생시킨다() {
 			// given
-			SocialLikeCreateResponse response = socialInteractionUseCase.createLike(USER.getId(), SOCIAL_BOARD.getId());
+			SocialLikeCreateResponse response = socialInteractionUseCase.createSocialLike(USER.getId(),
+				SOCIAL_BOARD.getId());
 
 			// when & then
-			assertThatThrownBy(() -> socialInteractionUseCase.createLike(USER.getId(), SOCIAL_BOARD.getId()))
+			assertThatThrownBy(() -> socialInteractionUseCase.createSocialLike(USER.getId(), SOCIAL_BOARD.getId()))
 				.isInstanceOf(CommonException.class)
 				.hasMessage(ExceptionCode.EXISTS_LIKE.getMessage());
 		}
@@ -276,7 +278,7 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 			Long nonExistentSocialId = -1L;
 
 			// when & then
-			assertThatThrownBy(() -> socialInteractionUseCase.createLike(USER.getId(), nonExistentSocialId))
+			assertThatThrownBy(() -> socialInteractionUseCase.createSocialLike(USER.getId(), nonExistentSocialId))
 				.isInstanceOf(CommonException.class)
 				.hasMessage(ExceptionCode.NOT_FOUND_SOCIAL_BOARD.getMessage());
 		}
@@ -298,7 +300,7 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 			Like LIKE = testFixtureBuilder.buildLike(LIKE(USER, SOCIAL_BOARD));
 
 			// when
-			socialInteractionUseCase.deleteLike(USER.getId(), SOCIAL_BOARD.getId());
+			socialInteractionUseCase.deleteSocialLike(USER.getId(), SOCIAL_BOARD.getId());
 
 			// then
 			assertThat(likeRepository.findByUserAndSocial(USER, SOCIAL_BOARD)).isNotPresent();
@@ -309,7 +311,7 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 		void 좋아요가_존재하지_않는_경우_예외를_발생시킨다() {
 
 			// when & then
-			assertThatThrownBy(() -> socialInteractionUseCase.deleteLike(USER.getId(), SOCIAL_BOARD.getId()))
+			assertThatThrownBy(() -> socialInteractionUseCase.deleteSocialLike(USER.getId(), SOCIAL_BOARD.getId()))
 				.isInstanceOf(CommonException.class)
 				.hasMessage(ExceptionCode.NOT_FOUND_LIKE.getMessage());
 		}
@@ -320,7 +322,7 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 			Long nonExistentSocialId = -1L;
 
 			// when & then
-			assertThatThrownBy(() -> socialInteractionUseCase.deleteLike(USER.getId(), nonExistentSocialId))
+			assertThatThrownBy(() -> socialInteractionUseCase.deleteSocialLike(USER.getId(), nonExistentSocialId))
 				.isInstanceOf(CommonException.class)
 				.hasMessage(ExceptionCode.NOT_FOUND_SOCIAL_BOARD.getMessage());
 		}

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCaseTest.java
@@ -31,8 +31,8 @@ import im.toduck.domain.social.presentation.dto.request.CommentCreateRequest;
 import im.toduck.domain.social.presentation.dto.request.ReportCreateRequest;
 import im.toduck.domain.social.presentation.dto.response.CommentCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.CommentLikeCreateResponse;
-import im.toduck.domain.social.presentation.dto.response.LikeCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.ReportCreateResponse;
+import im.toduck.domain.social.presentation.dto.response.SocialLikeCreateResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.fixtures.user.UserFixtures;
 import im.toduck.global.exception.CommonException;
@@ -244,14 +244,14 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 			int beforeLikeCount = SOCIAL_BOARD.getLikeCount();
 
 			// when
-			LikeCreateResponse response = socialInteractionUseCase.createLike(USER.getId(), SOCIAL_BOARD.getId());
+			SocialLikeCreateResponse response = socialInteractionUseCase.createLike(USER.getId(), SOCIAL_BOARD.getId());
 
 			// then
 			Like createdLike = likeRepository.findByUserAndSocial(USER, SOCIAL_BOARD).orElseThrow();
 			Optional<Social> afterSocialBoard = socialRepository.findById(SOCIAL_BOARD.getId());
 			assertSoftly(softly -> {
 				assertThat(createdLike).isNotNull();
-				assertThat(response.likeId()).isNotNull();
+				assertThat(response.socialLikeId()).isNotNull();
 				afterSocialBoard.ifPresent(
 					social -> softly.assertThat(social.getLikeCount()).isEqualTo(beforeLikeCount + 1)
 				);
@@ -262,7 +262,7 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 		@Test
 		void 이미_좋아요를_누른_경우_예외를_발생시킨다() {
 			// given
-			LikeCreateResponse response = socialInteractionUseCase.createLike(USER.getId(), SOCIAL_BOARD.getId());
+			SocialLikeCreateResponse response = socialInteractionUseCase.createLike(USER.getId(), SOCIAL_BOARD.getId());
 
 			// when & then
 			assertThatThrownBy(() -> socialInteractionUseCase.createLike(USER.getId(), SOCIAL_BOARD.getId()))

--- a/src/test/java/im/toduck/fixtures/social/CommentLikeFixtures.java
+++ b/src/test/java/im/toduck/fixtures/social/CommentLikeFixtures.java
@@ -1,0 +1,22 @@
+package im.toduck.fixtures.social;
+
+import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentLike;
+import im.toduck.domain.user.persistence.entity.User;
+
+public class CommentLikeFixtures {
+
+	/**
+	 * CommentLike 엔티티를 생성합니다.
+	 *
+	 * @param user       좋아요를 누른 사용자
+	 * @param comment    좋아요가 달린 댓글
+	 * @return 생성된 CommentLike 엔티티
+	 */
+	public static CommentLike COMMENT_LIKE(User user, Comment comment) {
+		return CommentLike.builder()
+			.user(user)
+			.comment(comment)
+			.build();
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 댓글 좋아요 erd 생성**
```SQL
CREATE TABLE comment_likes
(
    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
    user_id    BIGINT   NOT NULL,
    comment_id BIGINT   NOT NULL,
    ...
    FOREIGN KEY (user_id) REFERENCES users (id),
    FOREIGN KEY (comment_id) REFERENCES comment (id)
);
```
  <br/>

**2️⃣ 댓글 좋아요 생성 및 삭제 API 개발**
- 댓글 좋아요: `POST ~/v1/socials/{socialId}/comments/{commentId}/likes`
- 댓글 좋아요 취소: `DELETE ~/v1/socials/{socialId}/comments/{commentId}/likes`
  <br/>


**3️⃣ 게시글 상세 조회시 댓글 좋아요 정보 추가**
```JSON
{
  "commentLikeInfo": {
    "isLikedByMe": false, 
    "likeCount": 13
  }
}
```

  <br/>

**4️⃣ 게시글 삭제 및 댓글 삭제시 댓글 좋아요 처리**
**게시글 삭제 처리 (Soft Delete):**
게시글 삭제 시 해당 게시글에 속한 댓글 및 댓글 좋아요 정보는 **Soft delte** 됩니다.

**댓글 삭제 처리 (Hard Delete):**
댓글 삭제 시 해당 댓글과 연관된 댓글 좋아요 정보도 모두 **Hard delete**됩니다.

  <br/>

## ✅ 리뷰 요구사항
- 리팩토링을 조금 추가한다는게 너무 많이 추가 되버렸네요.. 
- 리팩토링 부분을 제외한 부분을 중점으로 검토해주시면 될 것 같습니다!
    1. **1️⃣ 댓글 좋아요 erd 생성** 
    2. **4️⃣ 게시글 삭제 및 댓글 삭제시 댓글 좋아요 처리**
        - `SocialBoardService`의 `deleteSocialBoard`
        - `SocialInteractionService` 의 `deleteComment`
  

