### PR TITLE
S3 Prsigned Url 발급 api 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,10 @@ dependencies {
 
     /* p6spy */
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.2'
+
+    /* AWS S3 */
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
 }
 
 // QueryDSL 설정

--- a/src/main/java/im/toduck/global/config/s3/S3Config.java
+++ b/src/main/java/im/toduck/global/config/s3/S3Config.java
@@ -1,0 +1,35 @@
+package im.toduck.global.config.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+class S3Config {
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region}")
+	private String region;
+
+	@Bean
+	public BasicAWSCredentials awsCredentialsProvider() {
+		return new BasicAWSCredentials(accessKey, secretKey);
+	}
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -88,7 +88,9 @@ public enum ExceptionCode {
 
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),
-	METHOD_FORBIDDEN(HttpStatus.METHOD_NOT_ALLOWED, 49902, "지원하지 않는 HTTP 메서드를 사용합니다.");
+	METHOD_FORBIDDEN(HttpStatus.METHOD_NOT_ALLOWED, 49902, "지원하지 않는 HTTP 메서드를 사용합니다."),
+	INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, 49903, "지원되지 않는 이미지 파일 확장자입니다.",
+		"이미지 파일 업로드에 허용되지 않는 파일 형식입니다.");
 
 	private final HttpStatus httpStatus;
 	private final int errorCode;

--- a/src/main/java/im/toduck/infra/s3/common/S3Mapper.java
+++ b/src/main/java/im/toduck/infra/s3/common/S3Mapper.java
@@ -1,0 +1,18 @@
+package im.toduck.infra.s3.common;
+
+import java.net.URL;
+
+import im.toduck.infra.s3.presentation.dto.response.FileUrlDto;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class S3Mapper {
+
+	public static FileUrlDto toFileUrlDto(final URL presignedUrl, final String fileUrl) {
+		return FileUrlDto.builder()
+			.presignedUrl(presignedUrl)
+			.fileUrl(fileUrl)
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/infra/s3/domain/service/S3Service.java
+++ b/src/main/java/im/toduck/infra/s3/domain/service/S3Service.java
@@ -16,6 +16,7 @@ import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 
+import im.toduck.infra.s3.presentation.dto.ImageExtension;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -57,15 +58,14 @@ public class S3Service {
 		return String.join(PATH_DELIMITER, endPoint, objectKey);
 	}
 
-	public URL generatePresignedUrl(final String objectKey) {
+	public URL generatePresignedUrl(final String objectKey, final String extension) {
+		String mimeType = ImageExtension.findMimeType(extension.toLowerCase());
+
 		GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, objectKey)
 			.withMethod(HttpMethod.PUT)
-			.withExpiration(calculateExpirationDate());
-
-		request.addRequestParameter(
-			Headers.S3_CANNED_ACL,
-			CannedAccessControlList.PublicRead.toString()
-		);
+			.withExpiration(calculateExpirationDate())
+			.withContentType(mimeType);
+		request.addRequestParameter(Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
 
 		return amazonS3.generatePresignedUrl(request);
 	}

--- a/src/main/java/im/toduck/infra/s3/domain/service/S3Service.java
+++ b/src/main/java/im/toduck/infra/s3/domain/service/S3Service.java
@@ -1,0 +1,78 @@
+package im.toduck.infra.s3.domain.service;
+
+import java.net.URL;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+	private static final long PRESIGNED_URL_EXPIRATION_MINUTES = 2;
+	private static final String PATH_DELIMITER = "/";
+	private static final String USER_DIRECTORY_PREFIX = "users";
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	@Value("${cloud.aws.s3.endpoint}")
+	private String endPoint;
+
+	private final AmazonS3 amazonS3;
+
+	public String createObjectKey(final String fileName, final Long userId, final LocalDate createdAt) {
+		String directoryPath = createDirectoryPath(userId, createdAt);
+		String uniqueFileName = createUniqueFileName(fileName);
+		return String.join(PATH_DELIMITER, directoryPath, uniqueFileName);
+	}
+
+	private String createDirectoryPath(final Long userId, final LocalDate createdAt) {
+		return String.format("%s/%s/%d/%d/%d",
+			USER_DIRECTORY_PREFIX,
+			userId,
+			createdAt.getYear(),
+			createdAt.getMonthValue(),
+			createdAt.getDayOfMonth()
+		);
+	}
+
+	private String createUniqueFileName(final String originalFileName) {
+		return String.format("%s_%s", UUID.randomUUID(), originalFileName);
+	}
+
+	public String generateFileUrl(final String objectKey) {
+		return String.join(PATH_DELIMITER, endPoint, objectKey);
+	}
+
+	public URL generatePresignedUrl(final String objectKey) {
+		GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, objectKey)
+			.withMethod(HttpMethod.PUT)
+			.withExpiration(calculateExpirationDate());
+
+		request.addRequestParameter(
+			Headers.S3_CANNED_ACL,
+			CannedAccessControlList.PublicRead.toString()
+		);
+
+		return amazonS3.generatePresignedUrl(request);
+	}
+
+	private Date calculateExpirationDate() {
+		return Date.from(
+			Instant.now().plus(PRESIGNED_URL_EXPIRATION_MINUTES, ChronoUnit.MINUTES)
+		);
+	}
+}

--- a/src/main/java/im/toduck/infra/s3/domain/usecase/S3UseCase.java
+++ b/src/main/java/im/toduck/infra/s3/domain/usecase/S3UseCase.java
@@ -30,7 +30,7 @@ public class S3UseCase {
 			.toList();
 
 		log.info("presigned URL 생성 - UserId: {}, File 개수: {}", userId, request.fileNameDtos().size());
-		return new PreSignedUrlResponse(fileUrlDtos);
+		return PreSignedUrlResponse.from(fileUrlDtos);
 	}
 
 	private FileUrlDto generateFileUrl(final String fileName, final Long userId, final LocalDate currentDate) {

--- a/src/main/java/im/toduck/infra/s3/domain/usecase/S3UseCase.java
+++ b/src/main/java/im/toduck/infra/s3/domain/usecase/S3UseCase.java
@@ -5,8 +5,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 import im.toduck.global.annotation.UseCase;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
 import im.toduck.infra.s3.common.S3Mapper;
 import im.toduck.infra.s3.domain.service.S3Service;
+import im.toduck.infra.s3.presentation.dto.ImageExtension;
 import im.toduck.infra.s3.presentation.dto.request.PreSignedUrlRequest;
 import im.toduck.infra.s3.presentation.dto.response.FileUrlDto;
 import im.toduck.infra.s3.presentation.dto.response.PreSignedUrlResponse;
@@ -17,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 @UseCase
 @RequiredArgsConstructor
 public class S3UseCase {
+	private static final String NO_EXTENSION = "";
+	private static final char EXTENSION_SEPARATOR = '.';
 
 	private final S3Service s3Service;
 
@@ -34,10 +39,24 @@ public class S3UseCase {
 	}
 
 	private FileUrlDto generateFileUrl(final String fileName, final Long userId, final LocalDate currentDate) {
+		String extension = extractExtension(fileName);
+
+		if (!ImageExtension.isSupportedExtension(extension)) {
+			throw CommonException.from(ExceptionCode.INVALID_IMAGE_EXTENSION);
+		}
+
 		String objectKey = s3Service.createObjectKey(fileName, userId, currentDate);
-		URL presignedUrl = s3Service.generatePresignedUrl(objectKey);
+		URL presignedUrl = s3Service.generatePresignedUrl(objectKey, extension);
 		String fileUrl = s3Service.generateFileUrl(objectKey);
 
 		return S3Mapper.toFileUrlDto(presignedUrl, fileUrl);
+	}
+
+	private String extractExtension(final String fileName) {
+		int lastDotIndex = fileName.lastIndexOf(EXTENSION_SEPARATOR);
+		if (lastDotIndex == -1) {
+			return NO_EXTENSION;
+		}
+		return fileName.substring(lastDotIndex + 1);
 	}
 }

--- a/src/main/java/im/toduck/infra/s3/domain/usecase/S3UseCase.java
+++ b/src/main/java/im/toduck/infra/s3/domain/usecase/S3UseCase.java
@@ -1,0 +1,43 @@
+package im.toduck.infra.s3.domain.usecase;
+
+import java.net.URL;
+import java.time.LocalDate;
+import java.util.List;
+
+import im.toduck.global.annotation.UseCase;
+import im.toduck.infra.s3.common.S3Mapper;
+import im.toduck.infra.s3.domain.service.S3Service;
+import im.toduck.infra.s3.presentation.dto.request.PreSignedUrlRequest;
+import im.toduck.infra.s3.presentation.dto.response.FileUrlDto;
+import im.toduck.infra.s3.presentation.dto.response.PreSignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class S3UseCase {
+
+	private final S3Service s3Service;
+
+	public PreSignedUrlResponse generatePresignedUrl(
+		final PreSignedUrlRequest request,
+		final Long userId,
+		final LocalDate currentDate
+	) {
+		List<FileUrlDto> fileUrlDtos = request.fileNameDtos().stream()
+			.map(fileNameDto -> generateFileUrl(fileNameDto.fileName(), userId, currentDate))
+			.toList();
+
+		log.info("presigned URL 생성 - UserId: {}, File 개수: {}", userId, request.fileNameDtos().size());
+		return new PreSignedUrlResponse(fileUrlDtos);
+	}
+
+	private FileUrlDto generateFileUrl(final String fileName, final Long userId, final LocalDate currentDate) {
+		String objectKey = s3Service.createObjectKey(fileName, userId, currentDate);
+		URL presignedUrl = s3Service.generatePresignedUrl(objectKey);
+		String fileUrl = s3Service.generateFileUrl(objectKey);
+
+		return S3Mapper.toFileUrlDto(presignedUrl, fileUrl);
+	}
+}

--- a/src/main/java/im/toduck/infra/s3/presentation/api/S3ControllerApi.java
+++ b/src/main/java/im/toduck/infra/s3/presentation/api/S3ControllerApi.java
@@ -1,0 +1,33 @@
+package im.toduck.infra.s3.presentation.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import im.toduck.global.annotation.swagger.ApiResponseExplanations;
+import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import im.toduck.infra.s3.presentation.dto.request.PreSignedUrlRequest;
+import im.toduck.infra.s3.presentation.dto.response.PreSignedUrlResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "AWS S3")
+public interface S3ControllerApi {
+	@Operation(
+		summary = "파일 업로드를 위한 pre-signed URL 발급",
+		description = "S3에 파일을 업로드하기 위한 pre-signed URL을 발급합니다. URL의 유효시간은 2분입니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = PreSignedUrlResponse.class,
+			description = "pre-signed URL 발급 성공. URL과 파일 접근 경로를 반환합니다."
+		)
+	)
+	ResponseEntity<ApiResponse<PreSignedUrlResponse>> getPresignedUrl(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid PreSignedUrlRequest request
+	);
+}

--- a/src/main/java/im/toduck/infra/s3/presentation/api/S3ControllerApi.java
+++ b/src/main/java/im/toduck/infra/s3/presentation/api/S3ControllerApi.java
@@ -18,7 +18,18 @@ import jakarta.validation.Valid;
 public interface S3ControllerApi {
 	@Operation(
 		summary = "파일 업로드를 위한 pre-signed URL 발급",
-		description = "S3에 파일을 업로드하기 위한 pre-signed URL을 발급합니다. URL의 유효시간은 2분입니다."
+		description = """
+			S3에 파일을 업로드하기 위한 pre-signed URL을 발급합니다.<br>
+			발급된 URL의 유효시간은 2분입니다.
+
+			**Content-Type 주의사항**
+			- 서버에서 pre-signed URL을 생성할 때 특정 Content-Type(예: "image/png")을 기대하면,<br>
+			실제 PUT 업로드 시에도 **동일한 Content-Type** 헤더를 지정해야 합니다.<br><br>
+			**단, jpg, jpeg의 Content-Type은 image/jpeg로 동일합니다.**
+
+			**자세한 사용 방법과 Swift 예제**는 노션 문서에서 확인하세요:<br>
+			[➡️ API 문서 바로가기](https://www.notion.so/kyxxn/API-e775e161efa6459583a0ee0d586c4d19?pvs=97#8fd87c48767741158067eda8a2cc4ad2)
+			"""
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(

--- a/src/main/java/im/toduck/infra/s3/presentation/controller/S3Controller.java
+++ b/src/main/java/im/toduck/infra/s3/presentation/controller/S3Controller.java
@@ -17,13 +17,13 @@ import im.toduck.infra.s3.presentation.dto.response.PreSignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/v1/presigned")
 @RequiredArgsConstructor
 public class S3Controller implements S3ControllerApi {
 	private final S3UseCase s3UseCase;
 
 	@Override
-	@PostMapping("/presigned")
+	@PostMapping
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponse<PreSignedUrlResponse>> getPresignedUrl(
 		CustomUserDetails userDetails,

--- a/src/main/java/im/toduck/infra/s3/presentation/controller/S3Controller.java
+++ b/src/main/java/im/toduck/infra/s3/presentation/controller/S3Controller.java
@@ -1,0 +1,36 @@
+package im.toduck.infra.s3.presentation.controller;
+
+import java.time.LocalDate;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import im.toduck.infra.s3.domain.usecase.S3UseCase;
+import im.toduck.infra.s3.presentation.api.S3ControllerApi;
+import im.toduck.infra.s3.presentation.dto.request.PreSignedUrlRequest;
+import im.toduck.infra.s3.presentation.dto.response.PreSignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class S3Controller implements S3ControllerApi {
+	private final S3UseCase s3UseCase;
+
+	@Override
+	@PostMapping("/presigned")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<PreSignedUrlResponse>> getPresignedUrl(
+		CustomUserDetails userDetails,
+		PreSignedUrlRequest request
+	) {
+		return ResponseEntity.ok().body(
+			ApiResponse.createSuccess(
+				s3UseCase.generatePresignedUrl(request, userDetails.getUserId(), LocalDate.now())));
+	}
+}

--- a/src/main/java/im/toduck/infra/s3/presentation/dto/ImageExtension.java
+++ b/src/main/java/im/toduck/infra/s3/presentation/dto/ImageExtension.java
@@ -1,0 +1,41 @@
+package im.toduck.infra.s3.presentation.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Getter;
+
+@Getter
+public enum ImageExtension {
+	JPG("jpg", "image/jpeg"),
+	JPEG("jpeg", "image/jpeg"),
+	PNG("png", "image/png"),
+	GIF("gif", "image/gif"),
+	BMP("bmp", "image/bmp"),
+	WEBP("webp", "image/webp");
+
+	private final String extension;
+	private final String mimeType;
+
+	private static final Map<String, ImageExtension> EXTENSION_MAP = new HashMap<>();
+
+	static {
+		for (ImageExtension ie : ImageExtension.values()) {
+			EXTENSION_MAP.put(ie.extension, ie);
+		}
+	}
+
+	ImageExtension(final String extension, final String mimeType) {
+		this.extension = extension;
+		this.mimeType = mimeType;
+	}
+
+	public static boolean isSupportedExtension(final String ext) {
+		return EXTENSION_MAP.containsKey(ext.toLowerCase());
+	}
+
+	public static String findMimeType(final String ext) {
+		ImageExtension imageExt = EXTENSION_MAP.get(ext.toLowerCase());
+		return (imageExt == null) ? null : imageExt.getMimeType();
+	}
+}

--- a/src/main/java/im/toduck/infra/s3/presentation/dto/request/FileNameDto.java
+++ b/src/main/java/im/toduck/infra/s3/presentation/dto/request/FileNameDto.java
@@ -1,0 +1,13 @@
+package im.toduck.infra.s3.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record FileNameDto(
+	@NotBlank(message = "파일 이름을 입력해주세요.")
+	@Pattern(regexp = ".*\\.[^\\.]+$", message = "파일 이름에는 확장자가 포함되어야 합니다.")
+	@Schema(description = "파일 이름", example = "profile.jpg")
+	String fileName
+) {
+}

--- a/src/main/java/im/toduck/infra/s3/presentation/dto/request/PreSignedUrlRequest.java
+++ b/src/main/java/im/toduck/infra/s3/presentation/dto/request/PreSignedUrlRequest.java
@@ -1,0 +1,8 @@
+package im.toduck.infra.s3.presentation.dto.request;
+
+import java.util.List;
+
+public record PreSignedUrlRequest(
+	List<FileNameDto> fileNameDtos
+) {
+}

--- a/src/main/java/im/toduck/infra/s3/presentation/dto/response/FileUrlDto.java
+++ b/src/main/java/im/toduck/infra/s3/presentation/dto/response/FileUrlDto.java
@@ -1,0 +1,22 @@
+package im.toduck.infra.s3.presentation.dto.response;
+
+import java.net.URL;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record FileUrlDto(
+	@Schema(
+		description = "파일 업로드를 위한 pre-signed URL",
+		example = "https://toduck-uploads.s3.ap-northeast-2.amazonaws.com/users/1/2025/1/15/917c5d17-..."
+	)
+	URL presignedUrl,
+
+	@Schema(
+		description = "업로드 완료 후 파일 접근 URL",
+		example = "https://cdn.toduck.app/users/1/2025/1/15/917c5d17-9a69-4438-91d1-400651f45b81_test2.png"
+	)
+	String fileUrl
+) {
+}

--- a/src/main/java/im/toduck/infra/s3/presentation/dto/response/PreSignedUrlResponse.java
+++ b/src/main/java/im/toduck/infra/s3/presentation/dto/response/PreSignedUrlResponse.java
@@ -1,0 +1,14 @@
+package im.toduck.infra.s3.presentation.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record PreSignedUrlResponse(
+	List<FileUrlDto> fileUrlsDtos
+) {
+	public static PreSignedUrlResponse from(List<FileUrlDto> fileUrlDtos) {
+		return new PreSignedUrlResponse(fileUrlDtos);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,13 @@ decorator:
   datasource:
     p6spy:
       enable-logging: false
+cloud:
+  aws:
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+      endpoint: ${AWS_S3_ENDPOINT}
+    region: ${AWS_REGION}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+

--- a/src/test/java/im/toduck/infra/s3/domain/usecase/S3UseCaseTest.java
+++ b/src/test/java/im/toduck/infra/s3/domain/usecase/S3UseCaseTest.java
@@ -18,6 +18,7 @@ import im.toduck.ServiceTest;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.fixtures.user.UserFixtures;
 import im.toduck.infra.s3.domain.service.S3Service;
+import im.toduck.infra.s3.presentation.dto.ImageExtension;
 import im.toduck.infra.s3.presentation.dto.request.FileNameDto;
 import im.toduck.infra.s3.presentation.dto.request.PreSignedUrlRequest;
 import im.toduck.infra.s3.presentation.dto.response.PreSignedUrlResponse;
@@ -53,7 +54,7 @@ class S3UseCaseTest extends ServiceTest {
 		void setUp() throws Exception {
 			presignedUrl = new URL("https://www.testPresignedUrl.com");
 
-			given(s3Service.generatePresignedUrl(anyString()))
+			given(s3Service.generatePresignedUrl(anyString(), eq(ImageExtension.JPG.getExtension())))
 				.willReturn(presignedUrl);
 		}
 

--- a/src/test/java/im/toduck/infra/s3/domain/usecase/S3UseCaseTest.java
+++ b/src/test/java/im/toduck/infra/s3/domain/usecase/S3UseCaseTest.java
@@ -1,0 +1,81 @@
+package im.toduck.infra.s3.domain.usecase;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import im.toduck.ServiceTest;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.fixtures.user.UserFixtures;
+import im.toduck.infra.s3.presentation.dto.request.FileNameDto;
+import im.toduck.infra.s3.presentation.dto.request.PreSignedUrlRequest;
+import im.toduck.infra.s3.presentation.dto.response.PreSignedUrlResponse;
+
+class S3UseCaseTest extends ServiceTest {
+
+	@Autowired
+	private S3UseCase s3UseCase;
+
+	private User USER;
+	private LocalDate currentDate;
+	private String fileName1;
+	private String fileName2;
+
+	@BeforeEach
+	void setUp() {
+		USER = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+		currentDate = LocalDate.now();
+		fileName1 = "test1.jpg";
+		fileName2 = "test2.png";
+
+	}
+
+	@Nested
+	class GeneratePresignedUrlTest {
+
+		@Test
+		void 파일_이름으로_PreSigned_URL을_생성할_수_있다() {
+			// given
+			PreSignedUrlRequest request = new PreSignedUrlRequest(
+				List.of(
+					new FileNameDto(fileName1),
+					new FileNameDto(fileName2)
+				)
+			);
+
+			// when
+			PreSignedUrlResponse response = s3UseCase.generatePresignedUrl(request, USER.getId(), currentDate);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(response.fileUrlsDtos()).hasSize(2);
+				response.fileUrlsDtos().forEach(fileUrlDto -> {
+					softly.assertThat(fileUrlDto.presignedUrl()).isNotNull();
+					softly.assertThat(fileUrlDto.fileUrl())
+						.isNotNull()
+						.startsWith("https://cdn.toduck.app");
+				});
+			});
+		}
+
+		@Test
+		void 빈_파일_리스트에_대한_PreSigned_URL_생성시_빈_응답을_반환한다() {
+			// given
+			PreSignedUrlRequest request = new PreSignedUrlRequest(List.of());
+
+			// when
+			PreSignedUrlResponse response = s3UseCase.generatePresignedUrl(request, USER.getId(), currentDate);
+
+			// then
+			assertThat(response.fileUrlsDtos()).isEmpty();
+		}
+	}
+
+}


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ S3 Presigned Url 발급 api 개발**

**Request**
- 한 번에 여러 파일을 처리 가능
```JSON
 {
  "fileNameDtos": [
    {
      "fileName": "example1.png"
    },
    {
      "fileName": "example2.jpg"
    }
  ]
}
```

**Response**
```JSON
 {
  "fileUrlsDtos": [
    {
      "presignedUrl": "https://${BUCKET_NAME}.s3.ap-northeast-2.amazonaws.com/users/1/2025/1/15/...",
      "fileUrl": "https://cdn.toduck.app/users/${USER_ID}/${YEAR}/${MONTH}/${DAY}/${UUID}_example1.png"
    },
    {
      "presignedUrl": "https://${BUCKET_NAME}.s3.ap-northeast-2.amazonaws.com/users/1/2025/1/15/...",
      "fileUrl": "https://cdn.toduck.app/users/${USER_ID}/${YEAR}/${MONTH}/${DAY}/${UUID}_example2.jpg"
    }
  ]
}
```
  <br/>

**2️⃣ CloudFront CDN 도입**

**CloudFront 배포 설정**

- CloudFront를 S3 버킷에 연결
- `cdn.toduck.app` 을 도메인 이름으로 사용하도록 설정 (Route 53 및 SSL 인증서 설정 포함).

**CDN 적용 결과**
- Before:
`https://${BUCKET_NAME}.s3.ap-northeast-2.amazonaws.com/users/${USER_ID}/${YEAR}/${MONTH}/${DAY}/${UUID}_${FILE_NAME}`

- After:
`https://cdn.toduck.app/users/${USER_ID}/${YEAR}/${MONTH}/${DAY}/${UUID}_${FILE_NAME}`
