### PR TITLE
대댓글 기능 개발

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -70,13 +70,15 @@ CREATE TABLE comment
     id         BIGINT PRIMARY KEY AUTO_INCREMENT,
     user_id    BIGINT   NOT NULL,
     social_id  BIGINT   NOT NULL,
+    parent_id  BIGINT   NULL,
     content    TEXT     NOT NULL,
     like_count int      NOT NULL DEFAULT 0,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
     deleted_at DATETIME NULL,
     FOREIGN KEY (user_id) REFERENCES users (id),
-    FOREIGN KEY (social_id) REFERENCES social (id)
+    FOREIGN KEY (social_id) REFERENCES social (id),
+    FOREIGN KEY (parent_id) REFERENCES comment (id)
 );
 
 CREATE TABLE comment_likes

--- a/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentMapper {
-	private static final long BLOCKED_USER_ID = 0L;
+	private static final Long BLOCKED_USER_ID = 0L;
 	private static final String BLOCKED_USER_NICKNAME = "차단된 사용자";
 	private static final String BLOCKED_MESSAGE_CONTENT = "차단한 작성자의 댓글입니다.";
 

--- a/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
@@ -14,10 +14,16 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentMapper {
-	public static Comment toComment(User user, Social socialBoard, CommentCreateRequest request) {
+	public static Comment toComment(
+		final User user,
+		final Social socialBoard,
+		final Comment parentComment,
+		final CommentCreateRequest request
+	) {
 		return Comment.builder()
 			.user(user)
 			.social(socialBoard)
+			.parent(parentComment)
 			.content(CommentContent.from(request.content()))
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
@@ -14,6 +14,10 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentMapper {
+	private static final long BLOCKED_USER_ID = 0L;
+	private static final String BLOCKED_USER_NICKNAME = "차단된 사용자";
+	private static final String BLOCKED_MESSAGE_CONTENT = "차단한 작성자의 댓글입니다.";
+
 	public static Comment toComment(
 		final User user,
 		final Social socialBoard,
@@ -28,30 +32,61 @@ public class CommentMapper {
 			.build();
 	}
 
-	public static CommentCreateResponse toCommentCreateResponse(Comment comment) {
+	public static CommentCreateResponse toCommentCreateResponse(final Comment comment) {
 		return CommentCreateResponse.builder()
 			.commentId(comment.getId())
 			.build();
 	}
 
-	public static CommentDto toCommentDto(Comment comment, boolean isCommentLiked) {
+	public static CommentDto toCommentDto(
+		final Comment comment,
+		final boolean isCommentLiked,
+		final boolean isBlocked
+	) {
 		return CommentDto.builder()
 			.commentId(comment.getId())
-			.owner(getOwner(comment.getUser()))
-			.content(comment.getContent().getValue())
+			.parentCommentId(getParentCommentId(comment))
+			.owner(getOwner(comment, isBlocked))
+			.content(getContent(comment, isBlocked))
 			.commentLikeInfo(getCommentLikeDto(comment, isCommentLiked))
+			.isReply(isReply(comment))
 			.createdAt(comment.getCreatedAt())
 			.build();
 	}
 
-	private static CommentLikeDto getCommentLikeDto(Comment comment, boolean isCommentLiked) {
+	private static Long getParentCommentId(final Comment comment) {
+		if (comment.getParent() == null) {
+			return null;
+		}
+		return comment.getParent().getId();
+	}
+
+	private static OwnerDto getOwner(final Comment comment, final boolean isBlocked) {
+		if (isBlocked) {
+			return OwnerDto.builder()
+				.ownerId(BLOCKED_USER_ID)
+				.nickname(BLOCKED_USER_NICKNAME)
+				.build();
+		}
+
+		return OwnerDto.builder()
+			.ownerId(comment.getUser().getId())
+			.nickname(comment.getUser().getNickname())
+			.build();
+	}
+
+	private static String getContent(final Comment comment, final boolean isBlocked) {
+		if (isBlocked) {
+			return BLOCKED_MESSAGE_CONTENT;
+		}
+		return comment.getContent().getValue();
+	}
+
+	private static CommentLikeDto getCommentLikeDto(final Comment comment, final boolean isCommentLiked) {
 		return CommentLikeMapper.toCommentLikeDto(comment, isCommentLiked);
 	}
 
-	private static OwnerDto getOwner(User user) {
-		return OwnerDto.builder()
-			.ownerId(user.getId())
-			.nickname(user.getNickname())
-			.build();
+	private static boolean isReply(final Comment comment) {
+		return comment.getParent() != null;
 	}
 }

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -113,8 +113,8 @@ public class SocialInteractionService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<Comment> getCommentsBySocial(final Social socialBoard, final Long userId) {
-		return commentRepository.findAllBySocialExcludingBlocked(socialBoard, userId);
+	public List<Comment> getCommentsBySocial(final Social socialBoard) {
+		return commentRepository.findCommentsBySocial(socialBoard);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -40,9 +40,10 @@ public class SocialInteractionService {
 	public Comment createComment(
 		final User user,
 		final Social socialBoard,
+		final Comment parentComment,
 		final CommentCreateRequest request
 	) {
-		Comment comment = CommentMapper.toComment(user, socialBoard, request);
+		Comment comment = CommentMapper.toComment(user, socialBoard, parentComment, request);
 		return commentRepository.save(comment);
 	}
 

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
@@ -147,13 +147,14 @@ public class SocialBoardUseCase {
 		}
 
 		List<SocialImageFile> imageFiles = socialBoardService.getSocialImagesBySocial(socialBoard);
-		List<Comment> comments = socialInteractionService.getCommentsBySocial(socialBoard, user.getId());
+		List<Comment> comments = socialInteractionService.getCommentsBySocial(socialBoard);
 		boolean isSocialBoardLiked = socialInteractionService.getSocialBoardIsLiked(user, socialBoard);
 
 		List<CommentDto> commentDtos = comments.stream()
 			.map((comment) -> {
 				boolean isCommentLike = socialInteractionService.getCommentIsLiked(user, comment);
-				return CommentMapper.toCommentDto(comment, isCommentLike);
+				boolean isBlocked = userService.isBlockedUser(user, comment.getUser());
+				return CommentMapper.toCommentDto(comment, isCommentLike, isBlocked);
 			})
 			.toList();
 
@@ -214,7 +215,7 @@ public class SocialBoardUseCase {
 			.limit(actualLimit)
 			.map(sb -> {
 				List<SocialImageFile> imageFiles = socialBoardService.getSocialImagesBySocial(sb);
-				List<Comment> comments = socialInteractionService.getCommentsBySocial(sb, user.getId());
+				List<Comment> comments = socialInteractionService.getCommentsBySocial(sb);
 				boolean isSocialBoardLiked = socialInteractionService.getSocialBoardIsLiked(user, sb);
 				return SocialMapper.toSocialResponse(sb, imageFiles, comments.size(), isSocialBoardLiked);
 			})

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
@@ -45,10 +45,21 @@ public class SocialInteractionUseCase {
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Social socialBoard = socialBoardService.getSocialById(socialId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SOCIAL_BOARD));
-		Comment comment = socialInteractionService.createComment(user, socialBoard, request);
+		Comment parentComment = getParentComment(request.parentId());
+
+		Comment comment = socialInteractionService.createComment(user, socialBoard, parentComment, request);
 
 		log.info("소셜 게시글 댓글 생성 - UserId: {}, SocialBoardId: {}, CommentId: {}", userId, socialId, comment.getId());
 		return CommentMapper.toCommentCreateResponse(comment);
+	}
+
+	private Comment getParentComment(final Long parentId) {
+		if (parentId == null) {
+			return null;
+		}
+
+		return socialInteractionService.getCommentById(parentId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_PARENT_COMMENT));
 	}
 
 	@Transactional

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
@@ -57,9 +57,14 @@ public class SocialInteractionUseCase {
 		if (parentId == null) {
 			return null;
 		}
-
-		return socialInteractionService.getCommentById(parentId)
+		Comment parentComment = socialInteractionService.getCommentById(parentId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_PARENT_COMMENT));
+
+		if (parentComment.isReply()) {
+			throw CommonException.from(ExceptionCode.INVALID_PARENT_COMMENT);
+		}
+
+		return parentComment;
 	}
 
 	@Transactional

--- a/src/main/java/im/toduck/domain/social/persistence/entity/Comment.java
+++ b/src/main/java/im/toduck/domain/social/persistence/entity/Comment.java
@@ -40,21 +40,31 @@ public class Comment extends BaseEntity {
 	@JoinColumn(name = "social_id", nullable = false)
 	private Social social;
 
+	@ManyToOne
+	@JoinColumn(name = "parent_id")
+	private Comment parent;
+
 	@Column(nullable = false, columnDefinition = "int default 0")
 	private int likeCount;
 
 	@Builder
-	private Comment(User user, Social social, CommentContent content) {
+	private Comment(
+		final User user,
+		final Social social,
+		final Comment parent,
+		final CommentContent content
+	) {
 		this.user = user;
 		this.social = social;
+		this.parent = parent;
 		this.content = content;
 	}
 
-	public boolean isOwner(User requestingUser) {
+	public boolean isOwner(final User requestingUser) {
 		return this.user.getId().equals(requestingUser.getId());
 	}
 
-	public boolean isInSocialBoard(Social socialBoard) {
+	public boolean isInSocialBoard(final Social socialBoard) {
 		return this.social.getId().equals(socialBoard.getId());
 	}
 

--- a/src/main/java/im/toduck/domain/social/persistence/entity/Comment.java
+++ b/src/main/java/im/toduck/domain/social/persistence/entity/Comment.java
@@ -68,6 +68,10 @@ public class Comment extends BaseEntity {
 		return this.social.getId().equals(socialBoard.getId());
 	}
 
+	public boolean isReply() {
+		return this.parent != null;
+	}
+
 	public void softDelete() {
 		this.deletedAt = LocalDateTime.now();
 	}

--- a/src/main/java/im/toduck/domain/social/persistence/repository/CommentRepository.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/CommentRepository.java
@@ -11,13 +11,11 @@ import io.lettuce.core.dynamic.annotation.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 	@Query("SELECT c FROM Comment c "
-		+ "WHERE c.social = :socialBoard "
-		+ "AND c.user.id NOT IN ("
-		+ "  SELECT b.blocked.id FROM Block b WHERE b.blocker.id = :userId"
-		+ ")")
-	List<Comment> findAllBySocialExcludingBlocked(
-		@Param("socialBoard") Social socialBoard,
-		@Param("userId") Long userId);
+		+ "WHERE c.social = :social "
+		+ "ORDER BY "
+		+ "CASE WHEN c.parent IS NULL THEN c.id ELSE c.parent.id END ASC, "
+		+ "CASE WHEN c.parent IS NOT NULL THEN c.id ELSE 0 END ASC")
+	List<Comment> findCommentsBySocial(@Param("social") Social social);
 
 	List<Comment> findAllBySocial(Social socialBoard);
 }

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialInteractionApi.java
@@ -27,7 +27,7 @@ import jakarta.validation.Valid;
 public interface SocialInteractionApi {
 	@Operation(
 		summary = "게시글 댓글 생성",
-		description = "게시글 댓글을 작성합니다."
+		description = "게시글 댓글을 작성합니다. 대댓글이 아닐시 parentId는 null"
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
@@ -36,6 +36,7 @@ public interface SocialInteractionApi {
 		),
 		errors = {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SOCIAL_BOARD),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_PARENT_COMMENT),
 		}
 	)
 	ResponseEntity<ApiResponse<CommentCreateResponse>> createComment(

--- a/src/main/java/im/toduck/domain/social/presentation/dto/request/CommentCreateRequest.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/request/CommentCreateRequest.java
@@ -1,11 +1,16 @@
 package im.toduck.domain.social.presentation.dto.request;
 
+import io.micrometer.common.lang.Nullable;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record CommentCreateRequest(
 	@NotBlank(message = "내용을 입력해주세요.")
 	@Schema(description = "댓글 내용", example = "루틴 너무 좋네요!")
-	String content
+	String content,
+
+	@Nullable
+	@Schema(description = "부모 댓글 comment id, 대댓글이 아닐시 null", nullable = true, example = "1")
+	Long parentId
 ) {
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentDto.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentDto.java
@@ -11,8 +11,11 @@ import lombok.Builder;
 
 @Builder
 public record CommentDto(
-	@Schema(description = "댓글 ID", example = "1")
+	@Schema(description = "댓글 ID", example = "2")
 	Long commentId,
+
+	@Schema(description = "부모 댓글 ID, 대댓글이 아닐시 null", example = "1")
+	Long parentCommentId,
 
 	@Schema(description = "작성자 정보")
 	OwnerDto owner,
@@ -22,6 +25,9 @@ public record CommentDto(
 
 	@Schema(description = "댓글 좋아요 정보")
 	CommentLikeDto commentLikeInfo,
+
+	@Schema(description = "답글 여부", example = "true")
+	boolean isReply,
 
 	@Schema(description = "댓글 작성 시간", type = "string", pattern = "yyyy-MM-dd HH:mm", example = "2024-09-11 10:30")
 	@JsonSerialize(using = LocalDateTimeSerializer.class)

--- a/src/main/java/im/toduck/domain/user/presentation/controller/UserBlockController.java
+++ b/src/main/java/im/toduck/domain/user/presentation/controller/UserBlockController.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1/users")
 public class UserBlockController implements UserBlockApi {
-	private UserBlockUseCase userBlockUseCase;
+	private final UserBlockUseCase userBlockUseCase;
 
 	@Override
 	@PostMapping("/{blockedUserId}/block")

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -78,6 +78,7 @@ public enum ExceptionCode {
 	EXISTS_COMMENT_LIKE(HttpStatus.CONFLICT, 40415, "이미 댓글에 좋아요를 눌렀습니다."),
 	NOT_FOUND_COMMENT_LIKE(HttpStatus.NOT_FOUND, 40416, "해당 댓글 좋아요를 찾을 수 없습니다."),
 	INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, 40417, "검색 키워드는 null일 수 없습니다."),
+	NOT_FOUND_PARENT_COMMENT(HttpStatus.NOT_FOUND, 40418, "부모 댓글을 찾을 수 없습니다."),
 
 	/* 432xx */
 	NOT_FOUND_ROUTINE(HttpStatus.NOT_FOUND, 43201, "권한이 없거나 존재하지 않는 루틴입니다."),

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -79,6 +79,7 @@ public enum ExceptionCode {
 	NOT_FOUND_COMMENT_LIKE(HttpStatus.NOT_FOUND, 40416, "해당 댓글 좋아요를 찾을 수 없습니다."),
 	INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, 40417, "검색 키워드는 null일 수 없습니다."),
 	NOT_FOUND_PARENT_COMMENT(HttpStatus.NOT_FOUND, 40418, "부모 댓글을 찾을 수 없습니다."),
+	INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, 40419, "답글은 부모 댓글이 될 수 없습니다."),
 
 	/* 432xx */
 	NOT_FOUND_ROUTINE(HttpStatus.NOT_FOUND, 43201, "권한이 없거나 존재하지 않는 루틴입니다."),

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -50,6 +50,7 @@ import im.toduck.domain.social.presentation.dto.response.SocialDetailResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialImageDto;
 import im.toduck.domain.social.presentation.dto.response.SocialResponse;
 import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.fixtures.social.CommentFixtures;
 import im.toduck.fixtures.social.SocialFixtures;
 import im.toduck.fixtures.social.SocialImageFileFixtures;
 import im.toduck.fixtures.user.UserFixtures;
@@ -701,7 +702,6 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			IMAGE_FILES = testFixtureBuilder.buildSocialImageFiles(
 				SocialImageFileFixtures.MULTIPLE_IMAGE_FILES(SOCIAL_BOARD, imageUrls)
 			);
-
 			BLOCK_USER = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
 			testFixtureBuilder.buildBlock(BLOCK_USER(USER, BLOCK_USER));
 			BLOCKED_USER_SOCIAL = testFixtureBuilder.buildSocial(SINGLE_SOCIAL(BLOCK_USER, false));
@@ -735,6 +735,53 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 				softly.assertThat(response.comments())
 					.extracting(CommentDto::commentId)
 					.contains(COMMENT.getId());
+			});
+		}
+
+		@Test
+		void 댓글_정렬_테스트() {
+			Social SOCIAL_BOARD_FOR_COMMENT = testFixtureBuilder.buildSocial(
+				SINGLE_SOCIAL_WITH_ROUTINE(USER, ROUTINE, false)
+			);
+
+			Comment parent1 = testFixtureBuilder.buildComment(
+				CommentFixtures.SINGLE_COMMENT(USER, SOCIAL_BOARD_FOR_COMMENT));
+			Comment parent2 = testFixtureBuilder.buildComment(
+				CommentFixtures.SINGLE_COMMENT(USER, SOCIAL_BOARD_FOR_COMMENT));
+
+			Comment replyToParent1_1 = testFixtureBuilder.buildComment(
+				CommentFixtures.REPLY_COMMENT(USER, SOCIAL_BOARD_FOR_COMMENT, parent1));
+			Comment replyToParent1_2 = testFixtureBuilder.buildComment(
+				CommentFixtures.REPLY_COMMENT(USER, SOCIAL_BOARD_FOR_COMMENT, parent1));
+
+			Comment blockParent = testFixtureBuilder.buildComment(
+				CommentFixtures.SINGLE_COMMENT(BLOCK_USER, SOCIAL_BOARD_FOR_COMMENT));
+
+			Comment replyToBlockParent = testFixtureBuilder.buildComment(
+				CommentFixtures.REPLY_COMMENT(USER, SOCIAL_BOARD_FOR_COMMENT, blockParent));
+
+			Comment parent3 = testFixtureBuilder.buildComment(
+				CommentFixtures.SINGLE_COMMENT(USER, SOCIAL_BOARD_FOR_COMMENT));
+
+			Comment replyToParent3 = testFixtureBuilder.buildComment(
+				CommentFixtures.REPLY_COMMENT(USER, SOCIAL_BOARD_FOR_COMMENT, parent3));
+
+			SocialDetailResponse response = socialBoardUseCase.getSocialDetail(
+				USER.getId(),
+				SOCIAL_BOARD_FOR_COMMENT.getId()
+			);
+
+			assertSoftly(softly -> {
+				softly.assertThat(response.comments())
+					.extracting(CommentDto::commentId)
+					.containsExactly(
+						parent1.getId(), replyToParent1_1.getId(), replyToParent1_2.getId(),
+						parent2.getId(),
+						blockParent.getId(), replyToBlockParent.getId(),
+						parent3.getId(), replyToParent3.getId());
+				softly.assertThat(response.comments().get(4).owner().ownerId()).isEqualTo(0L);
+				softly.assertThat(response.comments().get(4).owner().nickname()).isEqualTo("차단된 사용자");
+				softly.assertThat(response.comments().get(4).content()).isEqualTo("차단한 작성자의 댓글입니다.");
 			});
 		}
 

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -729,12 +729,10 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 					);
 
 				softly.assertThat(response.comments())
+					.hasSize(2)
 					.extracting(CommentDto::commentId)
-					.doesNotContain(BLOCKED_USER_COMMENT.getId());
+					.containsExactly(COMMENT.getId(), BLOCKED_USER_COMMENT.getId());
 
-				softly.assertThat(response.comments())
-					.extracting(CommentDto::commentId)
-					.contains(COMMENT.getId());
 			});
 		}
 

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCaseTest.java
@@ -34,6 +34,7 @@ import im.toduck.domain.social.presentation.dto.response.CommentLikeCreateRespon
 import im.toduck.domain.social.presentation.dto.response.ReportCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialLikeCreateResponse;
 import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.fixtures.social.CommentFixtures;
 import im.toduck.fixtures.user.UserFixtures;
 import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
@@ -162,6 +163,26 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 				() -> socialInteractionUseCase.createComment(USER.getId(), SOCIAL_BOARD.getId(), whitespaceRequest))
 				.isInstanceOf(VoException.class)
 				.hasMessage("댓글 내용은 비어 있을 수 없습니다.");
+		}
+
+		@Test
+		void 대댓글을_부모_댓글로_사용하려는_경우_댓글_생성에_실패한다() {
+			// given
+			Comment parentComment = testFixtureBuilder.buildComment(
+				CommentFixtures.SINGLE_COMMENT(USER, SOCIAL_BOARD));
+			Comment replyToParent = testFixtureBuilder.buildComment(
+				CommentFixtures.REPLY_COMMENT(USER, SOCIAL_BOARD, parentComment));
+
+			CommentCreateRequest invalidParentRequest = new CommentCreateRequest(commentContent, replyToParent.getId());
+
+			// when & then
+			assertThatThrownBy(() -> socialInteractionUseCase.createComment(
+				USER.getId(),
+				SOCIAL_BOARD.getId(),
+				invalidParentRequest
+			))
+				.isInstanceOf(CommonException.class)
+				.hasMessage(ExceptionCode.INVALID_PARENT_COMMENT.getMessage());
 		}
 	}
 

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCaseTest.java
@@ -42,6 +42,8 @@ import im.toduck.global.exception.VoException;
 public class SocialInteractionUseCaseTest extends ServiceTest {
 
 	private User USER;
+	private Social SOCIAL_BOARD;
+	private Comment PARENT_COMMENT;
 
 	@Autowired
 	private SocialInteractionUseCase socialInteractionUseCase;
@@ -61,6 +63,8 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 	@BeforeEach
 	public void setUp() {
 		USER = testFixtureBuilder.buildUser(GENERAL_USER());
+		SOCIAL_BOARD = testFixtureBuilder.buildSocial(SINGLE_SOCIAL(USER, false));
+		PARENT_COMMENT = testFixtureBuilder.buildComment(SINGLE_COMMENT(USER, SOCIAL_BOARD));
 	}
 
 	@Nested
@@ -69,7 +73,7 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 		Social SOCIAL_BOARD;
 		String commentContent = "This is a test comment.";
 
-		CommentCreateRequest request = new CommentCreateRequest(commentContent);
+		CommentCreateRequest request = new CommentCreateRequest(commentContent, null);
 
 		@BeforeEach
 		public void setUp() {
@@ -86,6 +90,27 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 			assertSoftly(softly -> {
 				softly.assertThat(response).isNotNull();
 				softly.assertThat(response.commentId()).isNotNull();
+			});
+		}
+
+		@Test
+		void 주어진_요청에_따라_대댓글을_생성할_수_있다() {
+			// given
+			CommentCreateRequest replyCommentRequest = new CommentCreateRequest(commentContent, PARENT_COMMENT.getId());
+
+			// when
+			CommentCreateResponse response = socialInteractionUseCase.createComment(
+				USER.getId(),
+				SOCIAL_BOARD.getId(),
+				replyCommentRequest
+			);
+
+			// then
+			Comment savedReplyComment = commentRepository.findById(response.commentId()).orElseThrow();
+			assertSoftly(softly -> {
+				softly.assertThat(response).isNotNull();
+				softly.assertThat(response.commentId()).isNotNull();
+				softly.assertThat(savedReplyComment.getParent().getId()).isEqualTo(PARENT_COMMENT.getId());
 			});
 		}
 
@@ -117,7 +142,7 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 		void 댓글_내용이_빈_경우_댓글_생성에_실패한다() {
 			// given
 			String emptyContent = "";
-			CommentCreateRequest emptyRequest = new CommentCreateRequest(emptyContent);
+			CommentCreateRequest emptyRequest = new CommentCreateRequest(emptyContent, null);
 
 			// when & then
 			assertThatThrownBy(
@@ -130,7 +155,7 @@ public class SocialInteractionUseCaseTest extends ServiceTest {
 		void 댓글_내용이_공백인_경우_댓글_생성에_실패한다() {
 			// given
 			String whitespaceContent = "   ";
-			CommentCreateRequest whitespaceRequest = new CommentCreateRequest(whitespaceContent);
+			CommentCreateRequest whitespaceRequest = new CommentCreateRequest(whitespaceContent, null);
 
 			// when & then
 			assertThatThrownBy(

--- a/src/test/java/im/toduck/fixtures/social/CommentFixtures.java
+++ b/src/test/java/im/toduck/fixtures/social/CommentFixtures.java
@@ -26,4 +26,21 @@ public class CommentFixtures {
 			.content(CommentContent.from(DEFAULT_COMMENT_CONTENT))
 			.build();
 	}
+
+	/**
+	 * 답글 Comment 엔티티를 생성
+	 *
+	 * @param user    답글 작성자
+	 * @param social  댓글이 속한 게시글
+	 * @param parent  부모 댓글
+	 * @return 생성된 답글 Comment 엔티티
+	 */
+	public static Comment REPLY_COMMENT(User user, Social social, Comment parent) {
+		return Comment.builder()
+			.user(user)
+			.social(social)
+			.parent(parent)
+			.content(CommentContent.from(DEFAULT_COMMENT_CONTENT))
+			.build();
+	}
 }


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ Comment 테이블에 parent_id 필드 추가**
```SQL
CREATE TABLE comment
(
    ... 
    parent_id  BIGINT   NULL,
    ...
    FOREIGN KEY (parent_id) REFERENCES comment (id)
);
```

- 댓글 생성 요청시 parentId 포함 (대댓글이 아닐시 null)
```JAVA
public record CommentCreateRequest(
	@NotBlank(message = "내용을 입력해주세요.")
	@Schema(description = "댓글 내용", example = "루틴 너무 좋네요!")
	String content,

	@Nullable
	@Schema(description = "부모 댓글 comment id, 대댓글이 아닐시 null", nullable = true, example = "1")
	Long parentId
) {
}

```

  <br/>

**2️⃣ 게시글 댓글 조회 Query 수정**
```JAVA
@Query("SELECT c FROM Comment c "
+ "WHERE c.social = :social "
+ "ORDER BY "
+ "CASE WHEN c.parent IS NULL THEN c.id ELSE c.parent.id END ASC, "
+ "CASE WHEN c.parent IS NOT NULL THEN c.id ELSE 0 END ASC")
List<Comment> findCommentsBySocial(@Param("social") Social social);
```

- **예시 DB 저장 데이터**

| **id** | **parent_id** | **social_id** | **내용** |
|--------|---------------|---------------|----------|
| 1      | NULL          | 10            | 부모 댓글 1 |
| 2      | NULL          | 10            | 부모 댓글 2 |
| 3      | 1             | 10            | 답글 1-1 |
| 4      | 1             | 10            | 답글 1-2 |
| 5      | NULL          | 10            | 부모 댓글 3 |
| 6      | 5             | 10            | 답글 3-1 |


- **쿼리 결과**

id | parent_id | **social_id** | 정렬 기준 설명
-- | -- | -- | --
1 | NULL | 10            | 부모 댓글 1
3 | 1 | 10            | 답글 1-1 (부모 댓글 1의 답글)
4 | 1 | 10            | 답글 1-2 (부모 댓글 1의 답글)
2 | NULL | 10            | 부모 댓글 2
5 | NULL | 10            | 부모 댓글 3
6 | 5 | 10            | 답글 3-1 (부모 댓글 3의 답글)

  <br/>


## ✅ 리뷰 요구사항

- 궁금한 점이 있다면 댓글 남겨주세요!
