### PR TITLE
루틴 수정 기능 개발

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -32,6 +32,7 @@ CREATE TABLE routine
     is_public        BOOLEAN                                             NOT NULL,
     reminder_minutes INT UNSIGNED                                        NULL,
     memo             TEXT                                                NULL,
+    schedule_modified_at DATETIME                                        NOT NULL,
     shared_count     INT UNSIGNED       DEFAULT 0                        NOT NULL,
     created_at       DATETIME                                            NOT NULL,
     updated_at       DATETIME                                            NOT NULL,

--- a/src/main/java/im/toduck/domain/person/persistence/entity/PlanCategory.java
+++ b/src/main/java/im/toduck/domain/person/persistence/entity/PlanCategory.java
@@ -1,6 +1,5 @@
 package im.toduck.domain.person.persistence.entity;
 
-//TODO : 임의 데이터 변경 필요
 public enum PlanCategory {
 	COMPUTER,  // 컴퓨터
 	FOOD,      // 밥

--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -116,6 +116,7 @@ public class RoutineMapper {
 		return MyRoutineAvailableListResponse.MyRoutineAvailableResponse.builder()
 			.routineId(routine.getId())
 			.category(routine.getCategory())
+			.color(routine.getColorValue())
 			.title(routine.getTitle())
 			.memo(routine.getMemoValue())
 			.build();

--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -76,6 +76,7 @@ public class RoutineMapper {
 		return MyRoutineRecordReadListResponse.MyRoutineReadResponse.builder()
 			.routineId(routine.getId())
 			.color(routine.getColorValue())
+			.category(routine.getCategory())
 			.time(routine.getTime())
 			.title(routine.getTitle())
 			.isCompleted(isCompleted)

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
@@ -51,6 +51,7 @@ public class RoutineRecordService {
 			.orElse(false);
 	}
 
+	@Transactional
 	public void removeIncompletedFuturesByRoutine(final Routine routine, final LocalDateTime targetDateTime) {
 		routineRecordRepository.deleteIncompletedFuturesByRoutine(routine, targetDateTime);
 	}

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
@@ -1,7 +1,10 @@
 package im.toduck.domain.routine.domain.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,11 +51,26 @@ public class RoutineRecordService {
 			.orElse(false);
 	}
 
-	public void removeIncompletedFuturesByRoutine(final Routine routine) {
-		routineRecordRepository.deleteIncompletedFuturesByRoutine(routine);
+	public void removeIncompletedFuturesByRoutine(final Routine routine, final LocalDateTime targetDateTime) {
+		routineRecordRepository.deleteIncompletedFuturesByRoutine(routine, targetDateTime);
 	}
 
 	public void removeAllByRoutine(final Routine routine) {
 		routineRecordRepository.deleteAllByRoutine(routine);
+	}
+
+	public Set<LocalDate> getExistingRecordDates(
+		final Routine routine,
+		final LocalDateTime startTime,
+		final LocalDateTime endTime
+	) {
+		return routineRecordRepository.findAllByRoutineAndRecordAtBetween(routine, startTime, endTime)
+			.stream()
+			.map(record -> record.getRecordAt().toLocalDate())
+			.collect(Collectors.toSet());
+	}
+
+	public void saveAll(final List<RoutineRecord> newRecords) {
+		routineRecordRepository.saveAll(newRecords);
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -14,6 +14,7 @@ import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.routine.persistence.repository.RoutineRepository;
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
+import im.toduck.domain.routine.presentation.dto.request.RoutineUpdateRequest;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -81,6 +82,12 @@ public class RoutineService {
 	@Transactional(readOnly = true)
 	public Optional<Routine> findAvailablePublicRoutineById(final Long routineId) {
 		return routineRepository.findByIdAndIsPublicTrueAndDeletedAtIsNull(routineId);
+	}
+
+	@Transactional
+	public void updateFields(final Routine routine, final RoutineUpdateRequest request) {
+		routine.updateFromRequest(request);
+		routineRepository.save(routine);
 	}
 
 	@Transactional

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -1,6 +1,8 @@
 package im.toduck.domain.routine.domain.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,8 +39,15 @@ public class RoutineService {
 		final LocalDate date,
 		final List<RoutineRecord> routineRecords
 	) {
-		// TODO: 여기에선 삭제되면 조회되면 안됨, 근데 삭제 시점 미래 기준으로는 조회가 안되는거고 과거 시점이면 조회가 되어야함
-		return routineRepository.findUnrecordedRoutinesForDate(user, date, routineRecords);
+		List<Routine> routines = routineRepository.findUnrecordedRoutinesForDate(user, date, routineRecords);
+
+		return routines.stream().filter(routine -> {
+			LocalDateTime compareTime = routine.isAllDay()
+				? date.minusDays(1).atTime(LocalTime.MAX)
+				: date.atTime(routine.getTime());
+
+			return !routine.getScheduleModifiedAt().isAfter(compareTime);
+		}).toList();
 	}
 
 	public Optional<Routine> getUserRoutine(final User user, final Long id) {

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -59,7 +59,15 @@ public class RoutineService {
 	}
 
 	public boolean canCreateRecordForDate(final Routine routine, final LocalDate date) {
-		return routineRepository.isActiveForDate(routine, date);
+		if (routineRepository.isActiveForDate(routine, date)) {
+			LocalDateTime compareTime = routine.isAllDay()
+				? date.minusDays(1).atTime(LocalTime.MAX)
+				: date.atTime(routine.getTime());
+
+			return !routine.getScheduleModifiedAt().isAfter(compareTime);
+		}
+
+		return false;
 	}
 
 	public List<Routine> getAvailableRoutine(final User user) {

--- a/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
+++ b/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
@@ -77,7 +77,6 @@ public class RoutineUseCase {
 			return;
 		}
 
-		// TODO: 이때는 루틴이 삭제 상태인 경우 삭제시점 이전 데이터만 반복 가능
 		if (!routineService.canCreateRecordForDate(routine, date)) {
 			log.info("루틴 상태 변경 실패 - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}", userId, routineId, date);
 			throw CommonException.from(ExceptionCode.ROUTINE_INVALID_DATE);
@@ -110,6 +109,7 @@ public class RoutineUseCase {
 		return RoutineMapper.toMyRoutineAvailableListResponse(routines);
 	}
 
+	// TODO: 수정 필요
 	@Transactional
 	public void deleteRoutine(final Long userId, final Long routineId, final boolean keepRecords) {
 		User user = userService.getUserById(userId)

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -69,10 +69,6 @@ public class Routine extends BaseEntity {
 	@Column(name = "days_of_week", nullable = false)
 	private DaysOfWeekBitmask daysOfWeekBitmask;
 
-	@Column(name = "shared_count", nullable = false)
-	@ColumnDefault("0")
-	private Integer sharedCount = 0;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
@@ -131,4 +127,7 @@ public class Routine extends BaseEntity {
 		return deletedAt != null;
 	}
 
+	public Boolean isAllDay() {
+		return time == null;
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -33,7 +33,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "routine")
 @NoArgsConstructor
-// TODO: SQLRestriction 등 Soft delete 를 위한 설정 및 어노테이션 필요
 public class Routine extends BaseEntity {
 
 	@Id
@@ -62,6 +61,9 @@ public class Routine extends BaseEntity {
 
 	@Column
 	private LocalTime time;
+
+	@Column(name = "schedule_modified_at")
+	private LocalDateTime scheduleModifiedAt;
 
 	@Convert(converter = DaysOfWeekBitmaskConverter.class)
 	@Column(name = "days_of_week", nullable = false)
@@ -96,6 +98,7 @@ public class Routine extends BaseEntity {
 		this.time = time;
 		this.daysOfWeekBitmask = daysOfWeekBitmask;
 		this.user = user;
+		this.scheduleModifiedAt = LocalDateTime.now();
 	}
 
 	public String getColorValue() {
@@ -105,6 +108,20 @@ public class Routine extends BaseEntity {
 	public String getMemoValue() {
 		return memo.getValue();
 	}
+
+	// public void updateTime(LocalTime newTime) {
+	// 	if (!newTime.equals(this.time)) {
+	// 		this.time = newTime;
+	// 		this.scheduleModifiedAt = LocalDateTime.now();
+	// 	}
+	// }
+	//
+	// public void updateDaysOfWeek(DaysOfWeekBitmask newDaysOfWeek) {
+	// 	if (!newDaysOfWeek.equals(this.daysOfWeekBitmask)) {
+	// 		this.daysOfWeekBitmask = newDaysOfWeek;
+	// 		this.scheduleModifiedAt = LocalDateTime.now();
+	// 	}
+	// }
 
 	public void delete() {
 		this.deletedAt = LocalDateTime.now();

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -2,6 +2,7 @@ package im.toduck.domain.routine.persistence.entity;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Objects;
 
 import org.hibernate.annotations.ColumnDefault;
 
@@ -9,6 +10,7 @@ import im.toduck.domain.person.persistence.entity.PlanCategory;
 import im.toduck.domain.routine.common.converter.DaysOfWeekBitmaskConverter;
 import im.toduck.domain.routine.persistence.vo.PlanCategoryColor;
 import im.toduck.domain.routine.persistence.vo.RoutineMemo;
+import im.toduck.domain.routine.presentation.dto.request.RoutineUpdateRequest;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.base.entity.BaseEntity;
 import im.toduck.global.helper.DaysOfWeekBitmask;
@@ -102,22 +104,50 @@ public class Routine extends BaseEntity {
 	}
 
 	public String getMemoValue() {
+		if (memo == null) {
+			return null;
+		}
 		return memo.getValue();
 	}
 
-	// public void updateTime(LocalTime newTime) {
-	// 	if (!newTime.equals(this.time)) {
-	// 		this.time = newTime;
-	// 		this.scheduleModifiedAt = LocalDateTime.now();
-	// 	}
-	// }
-	//
-	// public void updateDaysOfWeek(DaysOfWeekBitmask newDaysOfWeek) {
-	// 	if (!newDaysOfWeek.equals(this.daysOfWeekBitmask)) {
-	// 		this.daysOfWeekBitmask = newDaysOfWeek;
-	// 		this.scheduleModifiedAt = LocalDateTime.now();
-	// 	}
-	// }
+	public void updateFromRequest(RoutineUpdateRequest request) {
+		if (request.isTitleChanged()) {
+			this.title = request.title();
+		}
+
+		if (request.isCategoryChanged()) {
+			this.category = request.category();
+		}
+
+		if (request.isColorChanged()) {
+			this.color = PlanCategoryColor.from(request.color());
+		}
+
+		if (request.isTimeChanged() && !Objects.equals(this.time, request.time())) {
+			this.time = request.time();
+			this.scheduleModifiedAt = LocalDateTime.now();
+		}
+
+		if (request.isPublicChanged()) {
+			this.isPublic = request.isPublic();
+		}
+
+		if (request.isDaysOfWeekChanged()) {
+			DaysOfWeekBitmask newDaysOfWeek = DaysOfWeekBitmask.createByDayOfWeek(request.daysOfWeek());
+			if (!newDaysOfWeek.equals(this.daysOfWeekBitmask)) {
+				this.daysOfWeekBitmask = newDaysOfWeek;
+				this.scheduleModifiedAt = LocalDateTime.now();
+			}
+		}
+
+		if (request.isReminderMinutesChanged()) {
+			this.reminderMinutes = request.reminderMinutes();
+		}
+
+		if (request.isMemoChanged()) {
+			this.memo = RoutineMemo.from(request.memo());
+		}
+	}
 
 	public void delete() {
 		this.deletedAt = LocalDateTime.now();

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -71,6 +71,10 @@ public class Routine extends BaseEntity {
 	@Column(name = "days_of_week", nullable = false)
 	private DaysOfWeekBitmask daysOfWeekBitmask;
 
+	@Column(name = "shared_count", nullable = false)
+	@ColumnDefault("0")
+	private Integer sharedCount = 0;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustom.java
@@ -1,6 +1,7 @@
 package im.toduck.domain.routine.persistence.repository.querydsl;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,5 +17,11 @@ public interface RoutineRecordRepositoryCustom {
 		final LocalDate date
 	);
 
-	void deleteIncompletedFuturesByRoutine(final Routine routine);
+	void deleteIncompletedFuturesByRoutine(final Routine routine, final LocalDateTime targetDateTime);
+
+	List<RoutineRecord> findAllByRoutineAndRecordAtBetween(
+		final Routine routine,
+		final LocalDateTime startTime,
+		final LocalDateTime endTime
+	);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
@@ -61,14 +61,30 @@ public class RoutineRecordRepositoryCustomImpl implements RoutineRecordRepositor
 	}
 
 	@Override
-	public void deleteIncompletedFuturesByRoutine(final Routine routine) {
+	public void deleteIncompletedFuturesByRoutine(final Routine routine, final LocalDateTime targetDateTime) {
 		queryFactory
 			.delete(qRecord)
 			.where(
 				qRecord.routine.eq(routine),
-				qRecord.recordAt.after(LocalDateTime.now()),
+				qRecord.recordAt.after(targetDateTime),
 				qRecord.isCompleted.isFalse()
 			)
 			.execute();
+	}
+
+	@Override
+	public List<RoutineRecord> findAllByRoutineAndRecordAtBetween(
+		final Routine routine,
+		final LocalDateTime startTime,
+		final LocalDateTime endTime
+	) {
+		return queryFactory
+			.selectFrom(qRecord)
+			.where(
+				qRecord.routine.eq(routine),
+				qRecord.recordAt.after(startTime),
+				qRecord.recordAt.before(endTime)
+			)
+			.fetch();
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
@@ -35,10 +35,11 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 			.selectFrom(qRoutine)
 			.where(
 				qRoutine.user.eq(user),
-				routineCreatedOnOrBeforeDate(date),
+				scheduleModifiedOnOrBeforeDate(date),
 				routineNotRecorded(routineRecords),
 				routineMatchesDate(date),
-				routineNotDeletedOrDeletedAfterDate(qRoutine.time, date))
+				routineNotDeleted()
+			)
 			.fetch();
 	}
 
@@ -69,6 +70,10 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 		return fetchOne != null;
 	}
 
+	private BooleanExpression routineNotDeleted() {
+		return qRoutine.deletedAt.isNull();
+	}
+
 	private BooleanExpression routineNotDeletedOrDeletedAfterDate(
 		final TimePath<LocalTime> timePath,
 		final LocalDate date
@@ -86,6 +91,11 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 	private BooleanExpression routineCreatedOnOrBeforeDate(final LocalDate date) {
 		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 		return qRoutine.createdAt.loe(endOfDay);
+	}
+
+	private BooleanExpression scheduleModifiedOnOrBeforeDate(final LocalDate date) {
+		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+		return qRoutine.scheduleModifiedAt.loe(endOfDay);
 	}
 
 	private BooleanExpression routineMatchesDate(final LocalDate date) {

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
@@ -61,9 +61,9 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 			.from(qRoutine)
 			.where(
 				qRoutine.eq(routine),
-				routineCreatedOnOrBeforeDate(date),
+				scheduleModifiedOnOrBeforeDate(date),
 				routineMatchesDate(date),
-				routineNotDeletedOrDeletedAfterDate(qRoutine.time, date)
+				routineNotDeleted()
 			)
 			.fetchFirst();
 

--- a/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
 import im.toduck.domain.routine.presentation.dto.request.RoutinePutCompletionRequest;
+import im.toduck.domain.routine.presentation.dto.request.RoutineUpdateRequest;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineAvailableListResponse;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadListResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
@@ -110,6 +111,30 @@ public interface RoutineApi {
 	)
 	ResponseEntity<ApiResponse<MyRoutineAvailableListResponse>> getMyAvailableRoutineList(
 		@AuthenticationPrincipal final CustomUserDetails userDetails
+	);
+
+	@Operation(
+		summary = "루틴 수정",
+		description = """
+			루틴의 내용을 수정합니다.
+			1. 모든 필드는 수정 여부와 관계없이 항상 전체 데이터를 전송해야 합니다.
+			2. 각 필드의 변경 여부는 is{FieldName}Changed 필드를 통해 명시적으로 표시해야 합니다.
+			3. null 값은 유효한 데이터로 취급될 수 있으며(예: 카테고리 삭제), 변경 여부 필드를 통해 의도적인 수정인지 구분합니다.
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "루틴 수정 성공"
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_ROUTINE)
+		}
+	)
+	ResponseEntity<ApiResponse<?>> putRoutine(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@Parameter(description = "수정할 루틴의 Id", required = true, example = "1")
+		@PathVariable final Long routineId,
+		@RequestBody @Valid final RoutineUpdateRequest request
 	);
 
 	@Operation(

--- a/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
@@ -20,6 +20,7 @@ import im.toduck.domain.routine.domain.usecase.RoutineUseCase;
 import im.toduck.domain.routine.presentation.api.RoutineApi;
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
 import im.toduck.domain.routine.presentation.dto.request.RoutinePutCompletionRequest;
+import im.toduck.domain.routine.presentation.dto.request.RoutineUpdateRequest;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineAvailableListResponse;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadListResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
@@ -95,6 +96,21 @@ public class RoutineController implements RoutineApi {
 	) {
 		return ResponseEntity.ok(
 			ApiResponse.createSuccess(routineUseCase.readMyAvailableRoutineList(userDetails.getUserId()))
+		);
+	}
+
+	@Override
+	@PutMapping("/{routineId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> putRoutine(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long routineId,
+		@RequestBody @Valid final RoutineUpdateRequest request
+	) {
+		routineUseCase.updateRoutine(userDetails.getUserId(), routineId, request);
+
+		return ResponseEntity.ok(
+			ApiResponse.createSuccessWithNoContent()
 		);
 	}
 

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/request/RoutineCreateRequest.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/request/RoutineCreateRequest.java
@@ -27,8 +27,9 @@ public record RoutineCreateRequest(
 	@Schema(description = "루틴 제목", example = "아침 운동")
 	String title,
 
-	@Schema(description = "루틴 카테고리 (카테고리 없으면 null)", example = "EXERCISE")
-	PlanCategory category, // TODO: 확정 필요
+	@NotBlank(message = "카테고리는 비어있을 수 없습니다. (지정하지 않으려면 NONE)")
+	@Schema(description = "루틴 카테고리", example = "COMPUTER")
+	PlanCategory category,
 
 	@Schema(description = "루틴 색상 (색상 없으면 null)", example = "#FF5733")
 	@Pattern(regexp = HEX_COLOR_CODE_REGEX, message = "색상은 유효한 Hex code 여야 합니다.")

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/request/RoutineUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/request/RoutineUpdateRequest.java
@@ -1,0 +1,92 @@
+package im.toduck.domain.routine.presentation.dto.request;
+
+import static im.toduck.global.regex.PlanRegex.*;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
+
+import im.toduck.domain.person.persistence.entity.PlanCategory;
+import im.toduck.global.serializer.DayOfWeekListDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "루틴 수정 요청 DTO")
+public record RoutineUpdateRequest(
+	@NotBlank(message = "제목은 비어있을 수 없습니다.")
+	@Size(max = 20, message = "제목은 40자를 초과할 수 없습니다.") // TODO: 확정 필요
+	@Schema(description = "루틴 제목", example = "아침 운동")
+	String title,
+
+	@Schema(description = "루틴 카테고리 (카테고리 없으면 null)", example = "EXERCISE")
+	PlanCategory category, // TODO: 확정 필요
+
+	@Schema(description = "루틴 색상 (색상 없으면 null)", example = "#FF5733")
+	@Pattern(regexp = HEX_COLOR_CODE_REGEX, message = "색상은 유효한 Hex code 여야 합니다.")
+	String color,
+
+	@JsonDeserialize(using = LocalTimeDeserializer.class)
+	@JsonFormat(pattern = "HH:mm")
+	@Schema(description = "루틴 시간 (종일 루틴이면 null)", example = "07:00")
+	LocalTime time,
+
+	@NotNull(message = "공개 여부는 null 일 수 없습니다.")
+	@Schema(description = "공개 여부", example = "true")
+	Boolean isPublic,
+
+	@JsonDeserialize(using = DayOfWeekListDeserializer.class)
+	@NotNull(message = "반복 요일은 null 일 수 없습니다.")
+	@NotEmpty(message = "반 복 요일은 최소 하나 이상 선택되어야 합니다.")
+	@Schema(description = "반복 요일", example = "[\"MONDAY\",\"TUESDAY\"]")
+	List<DayOfWeek> daysOfWeek,
+
+	@PositiveOrZero(message = "분은 양수여야 합니다.")
+	@Schema(description = "알림 시간 (분 단위, null 이면 알림을 보내지 않음)", example = "30")
+	Integer reminderMinutes,
+
+	@Schema(description = "메모", example = "30분 동안 조깅하기")
+	@Size(max = 40, message = "메모는 40자를 넘을 수 없습니다.")
+	String memo,
+
+	@Schema(description = "제목 변경 여부", example = "true")
+	@NotNull(message = "제목 변경 여부는 null일 수 없습니다.")
+	Boolean isTitleChanged,
+
+	@Schema(description = "카테고리 변경 여부", example = "true")
+	@NotNull(message = "카테고리 변경 여부는 null일 수 없습니다.")
+	Boolean isCategoryChanged,
+
+	@Schema(description = "색상 변경 여부", example = "true")
+	@NotNull(message = "색상 변경 여부는 null일 수 없습니다.")
+	Boolean isColorChanged,
+
+	@Schema(description = "시간 변경 여부", example = "true")
+	@NotNull(message = "시간 변경 여부는 null일 수 없습니다.")
+	Boolean isTimeChanged,
+
+	@Schema(description = "공개 여부 변경 상태", example = "true")
+	@NotNull(message = "공개 여부 변경 상태는 null일 수 없습니다.")
+	Boolean isPublicChanged,
+
+	@Schema(description = "반복 요일 변경 여부", example = "true")
+	@NotNull(message = "반복 요일 변경 여부는 null일 수 없습니다.")
+	Boolean isDaysOfWeekChanged,
+
+	@Schema(description = "알림 시간 변경 여부", example = "true")
+	@NotNull(message = "알림 시간 변경 여부는 null일 수 없습니다.")
+	Boolean isReminderMinutesChanged,
+
+	@Schema(description = "메모 변경 여부", example = "true")
+	@NotNull(message = "메모 변경 여부는 null일 수 없습니다.")
+	Boolean isMemoChanged
+) {
+}

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/request/RoutineUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/request/RoutineUpdateRequest.java
@@ -27,8 +27,9 @@ public record RoutineUpdateRequest(
 	@Schema(description = "루틴 제목", example = "아침 운동")
 	String title,
 
-	@Schema(description = "루틴 카테고리 (카테고리 없으면 null)", example = "EXERCISE")
-	PlanCategory category, // TODO: 확정 필요
+	@NotBlank(message = "카테고리는 비어있을 수 없습니다. (지정하지 않으려면 NONE)")
+	@Schema(description = "루틴 카테고리", example = "COMPUTER")
+	PlanCategory category,
 
 	@Schema(description = "루틴 색상 (색상 없으면 null)", example = "#FF5733")
 	@Pattern(regexp = HEX_COLOR_CODE_REGEX, message = "색상은 유효한 Hex code 여야 합니다.")

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineAvailableListResponse.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineAvailableListResponse.java
@@ -22,6 +22,9 @@ public record MyRoutineAvailableListResponse(
 		@Schema(description = "루틴 카테고리", example = "PENCIL")
 		PlanCategory category,
 
+		@Schema(description = "루틴 색상(null 이면 없는 색상)", example = "#FCDCDF")
+		String color,
+
 		@Schema(description = "루틴 제목", example = "기상 후 이부자리 정리!")
 		String title,
 

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineRecordReadListResponse.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineRecordReadListResponse.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 
+import im.toduck.domain.person.persistence.entity.PlanCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -29,6 +30,9 @@ public record MyRoutineRecordReadListResponse(
 	public record MyRoutineReadResponse(
 		@Schema(description = "루틴 Id", example = "1")
 		Long routineId,
+
+		@Schema(description = "루틴 카테고리", example = "COMPUTER")
+		PlanCategory category,
 
 		@Schema(description = "루틴 색상(null 이면 없는 색상)", example = "#FCDCDF")
 		String color,

--- a/src/main/java/im/toduck/global/helper/DaysOfWeekBitmask.java
+++ b/src/main/java/im/toduck/global/helper/DaysOfWeekBitmask.java
@@ -8,6 +8,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -73,6 +74,22 @@ public class DaysOfWeekBitmask {
 
 	public static byte getDayBitmask(DayOfWeek day) {
 		return (byte)(1 << (day.getValue() - 1));
+	}
+
+	/**
+	 * 주어진 시작일과 종료일 사이에서 이 비트마스크에 포함된 요일에 해당하는 날짜들의 스트림을 반환합니다.
+	 *
+	 * @param startDate 시작일 (포함)
+	 * @param endDate 종료일 (포함)
+	 * @return 해당 요일에 맞는 날짜들의 스트림
+	 */
+	public Stream<LocalDate> streamMatchingDatesInRange(LocalDate startDate, LocalDate endDate) {
+		if (startDate.isAfter(endDate)) {
+			return Stream.empty();
+		}
+
+		return startDate.datesUntil(endDate.plusDays(1))
+			.filter(this::includesDayOf);
 	}
 
 	public byte getValue() {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
     password: abcd1234@
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
     password: abcd1234@
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     properties:
       hibernate:
         show_sql: true

--- a/src/test/java/im/toduck/architecture/test/fixtures/FixturesRulesTest.java
+++ b/src/test/java/im/toduck/architecture/test/fixtures/FixturesRulesTest.java
@@ -3,24 +3,45 @@ package im.toduck.architecture.test.fixtures;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-@AnalyzeClasses(packages = "im.toduck.fixtures", importOptions = ImportOption.OnlyIncludeTests.class)
+@AnalyzeClasses(
+	packages = "im.toduck.fixtures",
+	importOptions = {
+		ImportOption.OnlyIncludeTests.class,
+		FixturesRulesTest.ExcludeClass.class
+	}
+)
 public class FixturesRulesTest {
 
 	@ArchTest
 	public static final ArchRule Fixture의_public_메서드는_대문자와_언더바_조합이다 =
 		methods()
 			.that().arePublic()
+			.and().areDeclaredInClassesThat().areTopLevelClasses()
 			.should().haveNameMatching("[A-Z_]+");
 
 	@ArchTest
-	public static final ArchRule Fixture의_모든_메서드는_static이다 = methods().should().beStatic();
+	public static final ArchRule Fixture의_모든_메서드는_static이다 =
+		methods()
+			.that().areDeclaredInClassesThat().areTopLevelClasses()
+			.should().beStatic();
 
 	@ArchTest
 	public static final ArchRule 모든_Fixture_클래스명은_Fixtures로끝난다 =
-		classes().should()
-			.haveSimpleNameEndingWith("Fixtures");
+		classes()
+			.that().areTopLevelClasses()
+			.should().haveSimpleNameEndingWith("Fixtures");
+
+	public static class ExcludeClass implements ImportOption {
+		// 예외 클래스 아래에 추가
+		@Override
+		public boolean includes(Location location) {
+			return !location.contains("RoutineWithAuditInfo");
+		}
+	}
 }
+

--- a/src/test/java/im/toduck/builder/TestFixtureBuilder.java
+++ b/src/test/java/im/toduck/builder/TestFixtureBuilder.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
@@ -19,6 +20,7 @@ import im.toduck.domain.social.persistence.entity.SocialImageFile;
 import im.toduck.domain.user.persistence.entity.Block;
 import im.toduck.domain.user.persistence.entity.Follow;
 import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.fixtures.routine.RoutineWithAuditInfo;
 import im.toduck.infra.redis.phonenumber.PhoneNumber;
 
 @Component
@@ -37,6 +39,21 @@ public class TestFixtureBuilder {
 
 	public Routine buildRoutine(final Routine routine) {
 		return bs.routineRepository().save(routine);
+	}
+
+	public Routine buildRoutineAndUpdateAuditFields(final RoutineWithAuditInfo routineWithAuditInfo) {
+		Routine savedRoutine = bs.routineRepository().save(routineWithAuditInfo.getRoutine());
+
+		if (routineWithAuditInfo.requiresAudit()) {
+			ReflectionTestUtils.setField(savedRoutine, "createdAt", routineWithAuditInfo.getCreatedAt());
+			ReflectionTestUtils.setField(savedRoutine, "scheduleModifiedAt",
+				routineWithAuditInfo.getScheduleModifiedAt());
+			ReflectionTestUtils.setField(savedRoutine, "deletedAt", routineWithAuditInfo.getDeletedAt());
+		}
+
+		return bs.routineRepository()
+			.findById(savedRoutine.getId())
+			.orElseThrow(() -> new RuntimeException("루틴을 찾을 수 없음"));
 	}
 
 	public RoutineRecord buildRoutineRecord(final RoutineRecord routineRecord) {

--- a/src/test/java/im/toduck/domain/routine/domain/service/RoutineRecordServiceTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/service/RoutineRecordServiceTest.java
@@ -45,7 +45,11 @@ class RoutineRecordServiceTest extends ServiceTest {
 
 		@BeforeEach
 		void setUp() {
-			ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
+			ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 		}
 
 		@Test
@@ -100,7 +104,7 @@ class RoutineRecordServiceTest extends ServiceTest {
 
 		@Test
 		void 기록이_존재하지_않는_경우에_변경이_이루어지지_않는다() {
-			// when
+			// when2
 			LocalDate unrecordedDate = LocalDate.now();
 			final boolean isUpdated = routineRecordService.updateIfPresent(ROUTINE, unrecordedDate, true);
 

--- a/src/test/java/im/toduck/domain/routine/domain/service/RoutineRecordServiceTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/service/RoutineRecordServiceTest.java
@@ -46,7 +46,7 @@ class RoutineRecordServiceTest extends ServiceTest {
 		@BeforeEach
 		void setUp() {
 			ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-11-29 01:00:00")
 					.build()
 			);
@@ -78,13 +78,21 @@ class RoutineRecordServiceTest extends ServiceTest {
 
 		@BeforeEach
 		void setUp() {
-			ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
+			// given
+			ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ALLDAY_ROUTINE(USER)
+					.createdAt("2024-12-01 01:00:00")
+					.scheduleModifiedAt("2024-12-16 00:01:00")
+					.build()
+			);
 		}
 
 		@Test
 		void 기록이_존재하는_경우에_정상적으로_변경된다() {
 			// given
-			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(COMPLETED_SYNCED_RECORD(ROUTINE));
+			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(ROUTINE).recordAt("2024-12-12 07:00:00").build()
+			);
 			final LocalDate date = LocalDate.from(RECORD.getRecordAt());
 
 			// when
@@ -104,7 +112,7 @@ class RoutineRecordServiceTest extends ServiceTest {
 
 		@Test
 		void 기록이_존재하지_않는_경우에_변경이_이루어지지_않는다() {
-			// when2
+			// when
 			LocalDate unrecordedDate = LocalDate.now();
 			final boolean isUpdated = routineRecordService.updateIfPresent(ROUTINE, unrecordedDate, true);
 

--- a/src/test/java/im/toduck/domain/routine/domain/service/RoutineRecordServiceTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/service/RoutineRecordServiceTest.java
@@ -1,7 +1,7 @@
 package im.toduck.domain.routine.domain.service;
 
-import static im.toduck.fixtures.RoutineFixtures.*;
-import static im.toduck.fixtures.RoutineRecordFixtures.*;
+import static im.toduck.fixtures.routine.RoutineFixtures.*;
+import static im.toduck.fixtures.routine.RoutineRecordFixtures.*;
 import static im.toduck.fixtures.user.UserFixtures.*;
 import static org.assertj.core.api.SoftAssertions.*;
 

--- a/src/test/java/im/toduck/domain/routine/domain/service/RoutineServiceTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/service/RoutineServiceTest.java
@@ -86,7 +86,7 @@ class RoutineServiceTest extends ServiceTest {
 		void 종일_루틴의_경우_수정_시각과_관계없이_당일_수정된_루틴은_조회되지_않는다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(USER)
+				PUBLIC_MONDAY_ALLDAY_ROUTINE(USER)
 					.createdAt("2024-12-01 01:00:00")
 					.scheduleModifiedAt("2024-12-16 00:01:00")
 					.build()
@@ -104,7 +104,7 @@ class RoutineServiceTest extends ServiceTest {
 		void 특정_시간_루틴의_경우_해당_시간_이후_수정된_루틴은_조회되지_않는다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(USER) //아침 7시 루틴
+				PUBLIC_MONDAY_ALLDAY_ROUTINE(USER) //아침 7시 루틴
 					.createdAt("2024-12-01 01:00:00")
 					.scheduleModifiedAt("2024-12-16 06:00:00") // 아침 6시 수정
 					.build()

--- a/src/test/java/im/toduck/domain/routine/domain/service/RoutineServiceTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/service/RoutineServiceTest.java
@@ -1,9 +1,12 @@
 package im.toduck.domain.routine.domain.service;
 
+import static im.toduck.fixtures.routine.RoutineFixtures.*;
 import static im.toduck.fixtures.user.UserFixtures.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
 import static org.assertj.core.api.SoftAssertions.*;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -73,6 +76,46 @@ class RoutineServiceTest extends ServiceTest {
 				softly.assertThat(savedRoutine.getTitle()).isEqualTo(request.title());
 				softly.assertThat(savedRoutine.getUser()).isEqualTo(USER);
 			});
+		}
+	}
+
+	@Nested
+	@DisplayName("기록되지 않은 루틴 목록 조회 시")
+	class GetUnrecordedRoutinesForDateTest {
+		@Test
+		void 종일_루틴의_경우_수정_시각과_관계없이_당일_수정된_루틴은_조회되지_않는다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(USER)
+					.createdAt("2024-12-01 01:00:00")
+					.scheduleModifiedAt("2024-12-16 00:01:00")
+					.build()
+			);
+			LocalDate monday = LocalDate.parse("2024-12-16");
+
+			// when
+			List<Routine> unrecordedRoutines = routineService.getUnrecordedRoutinesForDate(USER, monday, List.of());
+
+			// then
+			assertThat(unrecordedRoutines).doesNotContain(ROUTINE);
+		}
+
+		@Test
+		void 특정_시간_루틴의_경우_해당_시간_이후_수정된_루틴은_조회되지_않는다() {
+			// given
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(USER) //아침 7시 루틴
+					.createdAt("2024-12-01 01:00:00")
+					.scheduleModifiedAt("2024-12-16 06:00:00") // 아침 6시 수정
+					.build()
+			);
+			LocalDate monday = LocalDate.parse("2024-12-16");
+
+			// when
+			List<Routine> unrecordedRoutines = routineService.getUnrecordedRoutinesForDate(USER, monday, List.of());
+
+			// then
+			assertThat(unrecordedRoutines).doesNotContain(ROUTINE);
 		}
 	}
 }

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
@@ -93,13 +93,13 @@ class RoutineUseCaseTest extends ServiceTest {
 
 			// then
 			assertSoftly(softly -> {
-				assertThat(responses.queryDate()).isEqualTo(queryDate);
-				assertThat(responses.routines()).hasSize(1);
+				softly.assertThat(responses.queryDate()).isEqualTo(queryDate);
+				softly.assertThat(responses.routines()).hasSize(1);
 
 				MyRoutineRecordReadListResponse.MyRoutineReadResponse response = responses.routines().get(0);
-				assertThat(response.routineId()).isEqualTo(WEEKDAY_MORNING_ROUTINE.getId());
-				assertThat(response.isCompleted()).isEqualTo(ROUTINE_RECORD.getIsCompleted());
-				assertThat(response.time()).isEqualTo(ROUTINE_RECORD.getRecordAt().toLocalTime());
+				softly.assertThat(response.routineId()).isEqualTo(WEEKDAY_MORNING_ROUTINE.getId());
+				softly.assertThat(response.isCompleted()).isEqualTo(ROUTINE_RECORD.getIsCompleted());
+				softly.assertThat(response.time()).isEqualTo(ROUTINE_RECORD.getRecordAt().toLocalTime());
 			});
 		}
 
@@ -118,13 +118,13 @@ class RoutineUseCaseTest extends ServiceTest {
 
 			// then
 			assertSoftly(softly -> {
-				assertThat(responses.queryDate()).isEqualTo(queryDate);
-				assertThat(responses.routines()).hasSize(1);
+				softly.assertThat(responses.queryDate()).isEqualTo(queryDate);
+				softly.assertThat(responses.routines()).hasSize(1);
 
 				MyRoutineRecordReadListResponse.MyRoutineReadResponse response = responses.routines().get(0);
-				assertThat(response.routineId()).isEqualTo(WEEKDAY_ROUTINE.getId());
-				assertThat(response.isCompleted()).isFalse();
-				assertThat(response.time()).isEqualTo(WEEKDAY_ROUTINE.getTime());
+				softly.assertThat(response.routineId()).isEqualTo(WEEKDAY_ROUTINE.getId());
+				softly.assertThat(response.isCompleted()).isFalse();
+				softly.assertThat(response.time()).isEqualTo(WEEKDAY_ROUTINE.getTime());
 			});
 		}
 
@@ -132,7 +132,7 @@ class RoutineUseCaseTest extends ServiceTest {
 		void 루틴_수정으로_인해_동기화되지_않은_루틴_기록을_정상적으로_조회할_수_있다() {
 			// given
 			Routine WEEKDAY_ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER) // 월요일
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER) // 월요일
 					.createdAt("2024-11-29 01:00:00")
 					.scheduleModifiedAt("2024-12-05 00:01:00")
 					.build()
@@ -148,13 +148,13 @@ class RoutineUseCaseTest extends ServiceTest {
 
 			// then
 			assertSoftly(softly -> {
-				assertThat(responses.queryDate()).isEqualTo(queryDate);
-				assertThat(responses.routines()).hasSize(1);
+				softly.assertThat(responses.queryDate()).isEqualTo(queryDate);
+				softly.assertThat(responses.routines()).hasSize(1);
 
 				MyRoutineRecordReadListResponse.MyRoutineReadResponse response = responses.routines().get(0);
-				assertThat(response.routineId()).isEqualTo(WEEKDAY_ROUTINE.getId());
-				assertThat(response.isCompleted()).isTrue();
-				assertThat(response.time()).isEqualTo(ROUTINE_RECORD.getRecordAt().toLocalTime());
+				softly.assertThat(response.routineId()).isEqualTo(WEEKDAY_ROUTINE.getId());
+				softly.assertThat(response.isCompleted()).isTrue();
+				softly.assertThat(response.time()).isEqualTo(ROUTINE_RECORD.getRecordAt().toLocalTime());
 			});
 		}
 
@@ -162,7 +162,7 @@ class RoutineUseCaseTest extends ServiceTest {
 		void 모_루틴이_Soft_DELETE_된_경우에도_루틴_기록이_존재한다면_정상적으로_조회할_수_있다() {
 			// given
 			Routine WEEKDAY_ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER) // 월요일
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER) // 월요일
 					.createdAt("2024-11-29 01:00:00")
 					.scheduleModifiedAt("2024-12-05 00:01:00")
 					.deletedAt("2024-12-06 00:01:00")
@@ -178,13 +178,13 @@ class RoutineUseCaseTest extends ServiceTest {
 
 			// then
 			assertSoftly(softly -> {
-				assertThat(responses.queryDate()).isEqualTo(queryDate);
-				assertThat(responses.routines()).hasSize(1);
+				softly.assertThat(responses.queryDate()).isEqualTo(queryDate);
+				softly.assertThat(responses.routines()).hasSize(1);
 
 				MyRoutineRecordReadListResponse.MyRoutineReadResponse response = responses.routines().get(0);
-				assertThat(response.routineId()).isEqualTo(WEEKDAY_ROUTINE.getId());
-				assertThat(response.isCompleted()).isEqualTo(ROUTINE_RECORD.getIsCompleted());
-				assertThat(response.time()).isEqualTo(ROUTINE_RECORD.getRecordAt().toLocalTime());
+				softly.assertThat(response.routineId()).isEqualTo(WEEKDAY_ROUTINE.getId());
+				softly.assertThat(response.isCompleted()).isEqualTo(ROUTINE_RECORD.getIsCompleted());
+				softly.assertThat(response.time()).isEqualTo(ROUTINE_RECORD.getRecordAt().toLocalTime());
 			});
 		}
 	}
@@ -201,9 +201,16 @@ class RoutineUseCaseTest extends ServiceTest {
 		@Test
 		void 기존_기록이_존재하는_경우에_완료_상태_변경이_성공한다() {
 			// given
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(
-				COMPLETED_SYNCED_RECORD(ROUTINE)
+				COMPLETED_RECORD(ROUTINE)
+					.recordAt("2024-12-02 07:00:00") // 월요일 아침
+					.allDay(ROUTINE.getTime() == null)
+					.build()
 			);
 			RoutinePutCompletionRequest request =
 				new RoutinePutCompletionRequest(RECORD.getRecordAt().toLocalDate(), !RECORD.getIsCompleted());
@@ -222,9 +229,17 @@ class RoutineUseCaseTest extends ServiceTest {
 		@Test
 		void 기존_기록이_존재하는_경우에_모_루틴의_반복요일에_변경이_있더라도_변경이_성공한다() {
 			// given
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
 			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(
-				INCOMPLETED_MODIFIED_RECORD(ROUTINE)
+				INCOMPLETED_RECORD(ROUTINE)
+					.recordAt("2024-12-07 10:00:00") // 토요일 (평일 루틴이 아닌 날짜로 설정)
+					.allDay(ROUTINE.getTime() == null)
+					.build()
 			);
 
 			RoutinePutCompletionRequest request =
@@ -244,7 +259,11 @@ class RoutineUseCaseTest extends ServiceTest {
 		@Test
 		void 기존_기록이_존재하지_않는_경우에_완료_상태_변경이_성공한다() {
 			// given
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 
 			RoutinePutCompletionRequest request =
 				new RoutinePutCompletionRequest(getNextDayOfWeek(DayOfWeek.MONDAY), true);
@@ -263,7 +282,11 @@ class RoutineUseCaseTest extends ServiceTest {
 		@Test
 		void 루틴기록의_일자가_모_루틴의_반복_규칙과_상이한_경우에_예외를_반환한다() {
 			// given
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 
 			RoutinePutCompletionRequest request =
 				new RoutinePutCompletionRequest(getNextDayOfWeek(DayOfWeek.SATURDAY), true);
@@ -492,7 +515,7 @@ class RoutineUseCaseTest extends ServiceTest {
 		void 종일_루틴을_특정_시간_루틴으로_변경할_수_있다() {
 			// given
 			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(USER)
+				PUBLIC_MONDAY_ALLDAY_ROUTINE(USER)
 					.createdAt("2024-11-29 01:00:00")
 					.build()
 			);
@@ -529,7 +552,7 @@ class RoutineUseCaseTest extends ServiceTest {
 		void 특정_시간_루틴을_종일_루틴으로_변경할_수_있다() {
 			// given
 			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-11-29 01:00:00")
 					.build()
 			);
@@ -594,7 +617,7 @@ class RoutineUseCaseTest extends ServiceTest {
 		void 삭제된_루틴을_수정하려고_하면_예외가_발생한다() {
 			// given
 			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-11-29 01:00:00")
 					.deletedAt("2024-12-01 01:00:00")
 					.build()

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
@@ -12,6 +12,7 @@ import static org.mockito.BDDMockito.*;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Optional;
@@ -28,11 +29,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.ServiceTest;
+import im.toduck.domain.person.persistence.entity.PlanCategory;
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.routine.persistence.repository.RoutineRecordRepository;
 import im.toduck.domain.routine.persistence.repository.RoutineRepository;
 import im.toduck.domain.routine.presentation.dto.request.RoutinePutCompletionRequest;
+import im.toduck.domain.routine.presentation.dto.request.RoutineUpdateRequest;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadListResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
@@ -287,6 +290,394 @@ class RoutineUseCaseTest extends ServiceTest {
 		@Test
 		void 모_루틴이_Soft_DELETE_된_경우에도_상태_변경이_가능하다() {
 
+		}
+	}
+
+	@Nested
+	@DisplayName("루틴 수정시")
+	class UpdateRoutineTest {
+		@BeforeEach
+		void setUp() {
+			given(userService.getUserById(any(Long.class))).willReturn(Optional.ofNullable(USER));
+		}
+
+		@Test
+		void 기본_정보_수정이_성공한다() {
+			// given
+			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+			LocalDateTime originalScheduleModifiedAt = routine.getScheduleModifiedAt();
+
+			RoutineUpdateRequest request = new RoutineUpdateRequest(
+				"수정된 제목",
+				PlanCategory.EXERCISE,
+				"#FF0000",
+				routine.getTime(),
+				false,
+				routine.getDaysOfWeekBitmask().getDaysOfWeek().stream().toList(),
+				30,
+				"수정된 메모",
+				true,   // isTitleChanged
+				true,   // isCategoryChanged
+				true,   // isColorChanged
+				false,  // isTimeChanged
+				true,   // isPublicChanged
+				false,  // isDaysOfWeekChanged
+				true,   // isReminderMinutesChanged
+				true    // isMemoChanged
+			);
+
+			// when
+			routineUseCase.updateRoutine(USER.getId(), routine.getId(), request);
+
+			// then
+			Routine updatedRoutine = routineRepository.findById(routine.getId()).get();
+			assertSoftly(softly -> {
+				softly.assertThat(updatedRoutine.getTitle()).isEqualTo("수정된 제목");
+				softly.assertThat(updatedRoutine.getCategory()).isEqualTo(PlanCategory.EXERCISE);
+				softly.assertThat(updatedRoutine.getColorValue()).isEqualTo("#FF0000");
+				softly.assertThat(updatedRoutine.getIsPublic()).isFalse();
+				softly.assertThat(updatedRoutine.getReminderMinutes()).isEqualTo(30);
+				softly.assertThat(updatedRoutine.getMemoValue()).isEqualTo("수정된 메모");
+				softly.assertThat(updatedRoutine.getScheduleModifiedAt()).isEqualTo(originalScheduleModifiedAt);
+			});
+		}
+
+		@Test
+		@Disabled
+		void 시간_수정시_미래의_미완료_기록이_삭제되고_누락된_기록이_생성된다() {
+			// given
+			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
+			// 과거 완료 기록 (유지)
+			RoutineRecord pastComplete = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(routine).recordAt("2024-12-12 07:00:00").build()
+			);
+			// 과거 미완료 기록 (유지)
+			RoutineRecord pastIncomplete = testFixtureBuilder.buildRoutineRecord(
+				INCOMPLETED_RECORD(routine).recordAt("2024-12-13 07:00:00").build()
+			);
+			// 미래 미완료 (삭제)
+			RoutineRecord futureIncomplete = testFixtureBuilder.buildRoutineRecord(
+				INCOMPLETED_RECORD(routine).recordAt("2024-12-30 07:00:00").build()
+			);
+			// 미래 완료 (유지)
+			RoutineRecord futureComplete = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(routine).recordAt("2024-12-31 07:00:00").build()
+			);
+
+			RoutineUpdateRequest request = new RoutineUpdateRequest(
+				routine.getTitle(),
+				routine.getCategory(),
+				routine.getColorValue(),
+				LocalTime.of(9, 0),  // 7시 -> 9시로 변경
+				routine.getIsPublic(),
+				routine.getDaysOfWeekBitmask().getDaysOfWeek().stream().toList(),
+				routine.getReminderMinutes(),
+				null,
+				false,  // isTitleChanged
+				false,  // isCategoryChanged
+				false,  // isColorChanged
+				true,   // isTimeChanged
+				false,  // isPublicChanged
+				false,  // isDaysOfWeekChanged
+				false,  // isReminderMinutesChanged
+				false   // isMemoChanged
+			);
+
+			// when
+			routineUseCase.updateRoutine(USER.getId(), routine.getId(), request);
+
+			// then
+			List<RoutineRecord> remainingRecords = routineRecordRepository.findAll();
+			assertSoftly(softly -> {
+				softly.assertThat(remainingRecords).hasSize(3);
+
+				List<Long> remainingIds = remainingRecords.stream()
+					.map(RoutineRecord::getId)
+					.toList();
+
+				softly.assertThat(remainingIds)
+					.contains(pastComplete.getId(), pastIncomplete.getId(), futureComplete.getId());
+				softly.assertThat(remainingIds)
+					.doesNotContain(futureIncomplete.getId());
+			});
+		}
+
+		@Test
+		@Disabled
+		void 요일_수정시_미래의_미완료_기록이_삭제되고_누락된_기록이_생성된다() {
+			// given
+			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)  // 월화수목금
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
+			// 과거 완료 기록 (유지)
+			RoutineRecord pastComplete = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(routine).recordAt("2024-12-12 07:00:00").build()
+			);
+			// 과거 미완료 기록 (유지)
+			RoutineRecord pastIncomplete = testFixtureBuilder.buildRoutineRecord(
+				INCOMPLETED_RECORD(routine).recordAt("2024-12-13 07:00:00").build()
+			);
+			// 미래 미완료 (삭제)
+			RoutineRecord futureIncomplete = testFixtureBuilder.buildRoutineRecord(
+				INCOMPLETED_RECORD(routine).recordAt("2024-12-30 07:00:00").build()
+			);
+			// 미래 완료 (유지)
+			RoutineRecord futureComplete = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(routine).recordAt("2024-12-31 07:00:00").build()
+			);
+
+			RoutineUpdateRequest request = new RoutineUpdateRequest(
+				routine.getTitle(),
+				routine.getCategory(),
+				routine.getColorValue(),
+				routine.getTime(),
+				routine.getIsPublic(),
+				List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY),  // 월수금으로 변경
+				routine.getReminderMinutes(),
+				null,
+				false,  // isTitleChanged
+				false,  // isCategoryChanged
+				false,  // isColorChanged
+				false,  // isTimeChanged
+				false,  // isPublicChanged
+				true,   // isDaysOfWeekChanged
+				false,  // isReminderMinutesChanged
+				false   // isMemoChanged
+			);
+
+			// when
+			routineUseCase.updateRoutine(USER.getId(), routine.getId(), request);
+
+			// then
+			List<RoutineRecord> remainingRecords = routineRecordRepository.findAll();
+			assertSoftly(softly -> {
+				softly.assertThat(remainingRecords).hasSizeGreaterThan(4);  // 정확한 개수는 날짜에 따라 다름
+
+				List<Long> remainingIds = remainingRecords.stream()
+					.map(RoutineRecord::getId)
+					.toList();
+
+				softly.assertThat(remainingIds)
+					.contains(pastComplete.getId(), pastIncomplete.getId(), futureComplete.getId());
+				softly.assertThat(remainingIds)
+					.doesNotContain(futureIncomplete.getId());
+
+				// 새로 생성된 기록들 확인
+				remainingRecords.stream()
+					.filter(record -> !record.getId().equals(pastComplete.getId())
+						&& !record.getId().equals(pastIncomplete.getId())
+						&& !record.getId().equals(futureComplete.getId()))
+					.forEach(record -> {
+						DayOfWeek dayOfWeek = record.getRecordAt().toLocalDate().getDayOfWeek();
+						softly.assertThat(dayOfWeek)
+							.isIn(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY);
+						softly.assertThat(record.getIsCompleted()).isFalse();
+					});
+			});
+		}
+
+		@Test
+		void 종일_루틴을_특정_시간_루틴으로_변경할_수_있다() {
+			// given
+			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
+			RoutineUpdateRequest request = new RoutineUpdateRequest(
+				routine.getTitle(),
+				routine.getCategory(),
+				routine.getColorValue(),
+				LocalTime.of(9, 0),
+				routine.getIsPublic(),
+				routine.getDaysOfWeekBitmask().getDaysOfWeek().stream().toList(),
+				routine.getReminderMinutes(),
+				null,
+				false,  // isTitleChanged
+				false,  // isCategoryChanged
+				false,  // isColorChanged
+				true,   // isTimeChanged
+				false,  // isPublicChanged
+				false,  // isDaysOfWeekChanged
+				false,  // isReminderMinutesChanged
+				false   // isMemoChanged
+			);
+
+			// when
+			routineUseCase.updateRoutine(USER.getId(), routine.getId(), request);
+
+			// then
+			Routine updatedRoutine = routineRepository.findById(routine.getId()).get();
+			assertThat(updatedRoutine.getTime()).isEqualTo(LocalTime.of(9, 0));
+			assertThat(updatedRoutine.isAllDay()).isFalse();
+		}
+
+		@Test
+		void 특정_시간_루틴을_종일_루틴으로_변경할_수_있다() {
+			// given
+			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
+			RoutineUpdateRequest request = new RoutineUpdateRequest(
+				routine.getTitle(),
+				routine.getCategory(),
+				routine.getColorValue(),
+				null,  // 종일 루틴으로 변경
+				routine.getIsPublic(),
+				routine.getDaysOfWeekBitmask().getDaysOfWeek().stream().toList(),
+				routine.getReminderMinutes(),
+				null,
+				false,  // isTitleChanged
+				false,  // isCategoryChanged
+				false,  // isColorChanged
+				true,   // isTimeChanged
+				false,  // isPublicChanged
+				false,  // isDaysOfWeekChanged
+				false,  // isReminderMinutesChanged
+				false   // isMemoChanged
+			);
+
+			// when
+			routineUseCase.updateRoutine(USER.getId(), routine.getId(), request);
+
+			// then
+			Routine updatedRoutine = routineRepository.findById(routine.getId()).get();
+			assertThat(updatedRoutine.getTime()).isNull();
+			assertThat(updatedRoutine.isAllDay()).isTrue();
+		}
+
+		@Test
+		void 존재하지_않는_루틴을_수정하려고_하면_예외가_발생한다() {
+			// given
+			RoutineUpdateRequest request = new RoutineUpdateRequest(
+				"제목",
+				null,
+				null,
+				LocalTime.of(9, 0),
+				true,
+				List.of(DayOfWeek.MONDAY),
+				null,
+				null,
+				true,   // isTitleChanged
+				false,  // isCategoryChanged
+				false,  // isColorChanged
+				true,   // isTimeChanged
+				true,   // isPublicChanged
+				true,   // isDaysOfWeekChanged
+				false,  // isReminderMinutesChanged
+				false   // isMemoChanged
+			);
+
+			// when & then
+			assertThatThrownBy(() -> routineUseCase.updateRoutine(USER.getId(), 999L, request))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(NOT_FOUND_ROUTINE.getMessage());
+		}
+
+		@Test
+		void 삭제된_루틴을_수정하려고_하면_예외가_발생한다() {
+			// given
+			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.deletedAt("2024-12-01 01:00:00")
+					.build()
+			);
+
+			RoutineUpdateRequest request = new RoutineUpdateRequest(
+				"새 제목",
+				null,
+				null,
+				LocalTime.of(9, 0),
+				true,
+				List.of(DayOfWeek.MONDAY),
+				null,
+				null,
+				true,   // isTitleChanged
+				false,  // isCategoryChanged
+				false,  // isColorChanged
+				true,   // isTimeChanged
+				true,   // isPublicChanged
+				true,   // isDaysOfWeekChange
+				false,  // isReminderMinutesChanged
+				false   // isMemoChanged
+			);
+			// when & then
+			assertThatThrownBy(() -> routineUseCase.updateRoutine(USER.getId(), routine.getId(), request))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(NOT_FOUND_ROUTINE.getMessage());
+		}
+
+		@Test
+		void 수정_요청에서_변경_표시된_필드만_업데이트된다() {
+
+			// given
+			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
+			String originalTitle = routine.getTitle();
+			PlanCategory originalCategory = routine.getCategory();
+			String originalColor = routine.getColorValue();
+			LocalTime originalTime = routine.getTime();
+			Boolean originalIsPublic = routine.getIsPublic();
+			List<DayOfWeek> originalDaysOfWeek = routine.getDaysOfWeekBitmask().getDaysOfWeek().stream().toList();
+			Integer originalReminderMinutes = routine.getReminderMinutes();
+			String originalMemo = routine.getMemoValue();
+
+			RoutineUpdateRequest request = new RoutineUpdateRequest(
+				"새 제목",
+				PlanCategory.EXERCISE,
+				"#FF0000",
+				LocalTime.of(9, 0),
+				false,
+				List.of(DayOfWeek.MONDAY),
+				30,
+				"새 메모",
+				false,  // isTitleChanged
+				false,  // isCategoryChanged
+				true,   // isColorChanged만 true
+				false,  // isTimeChanged
+				false,  // isPublicChanged
+				false,  // isDaysOfWeekChanged
+				false,  // isReminderMinutesChanged
+				false   // isMemoChanged
+			);
+
+			// when
+			routineUseCase.updateRoutine(USER.getId(), routine.getId(), request);
+
+			// then
+			Routine updatedRoutine = routineRepository.findById(routine.getId()).get();
+			assertSoftly(softly -> {
+				softly.assertThat(updatedRoutine.getTitle()).isEqualTo(originalTitle);
+				softly.assertThat(updatedRoutine.getCategory()).isEqualTo(originalCategory);
+				softly.assertThat(updatedRoutine.getColorValue()).isEqualTo("#FF0000");  // 이것만 변경됨
+				softly.assertThat(updatedRoutine.getTime()).isEqualTo(originalTime);
+				softly.assertThat(updatedRoutine.getIsPublic()).isEqualTo(originalIsPublic);
+				softly.assertThat(updatedRoutine.getDaysOfWeekBitmask().getDaysOfWeek())
+					.containsExactlyElementsOf(originalDaysOfWeek);
+				softly.assertThat(updatedRoutine.getReminderMinutes()).isEqualTo(originalReminderMinutes);
+				softly.assertThat(updatedRoutine.getMemoValue()).isEqualTo(originalMemo);
+			});
 		}
 	}
 

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
@@ -313,7 +313,7 @@ class RoutineUseCaseTest extends ServiceTest {
 
 			RoutineUpdateRequest request = new RoutineUpdateRequest(
 				"수정된 제목",
-				PlanCategory.EXERCISE,
+				PlanCategory.POWER,
 				"#FF0000",
 				routine.getTime(),
 				false,
@@ -337,7 +337,7 @@ class RoutineUseCaseTest extends ServiceTest {
 			Routine updatedRoutine = routineRepository.findById(routine.getId()).get();
 			assertSoftly(softly -> {
 				softly.assertThat(updatedRoutine.getTitle()).isEqualTo("수정된 제목");
-				softly.assertThat(updatedRoutine.getCategory()).isEqualTo(PlanCategory.EXERCISE);
+				softly.assertThat(updatedRoutine.getCategory()).isEqualTo(PlanCategory.POWER);
 				softly.assertThat(updatedRoutine.getColorValue()).isEqualTo("#FF0000");
 				softly.assertThat(updatedRoutine.getIsPublic()).isFalse();
 				softly.assertThat(updatedRoutine.getReminderMinutes()).isEqualTo(30);
@@ -645,7 +645,7 @@ class RoutineUseCaseTest extends ServiceTest {
 
 			RoutineUpdateRequest request = new RoutineUpdateRequest(
 				"새 제목",
-				PlanCategory.EXERCISE,
+				PlanCategory.POWER,
 				"#FF0000",
 				LocalTime.of(9, 0),
 				false,

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
@@ -40,8 +40,15 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 		@Test
 		void 유효한_루틴_기록을_조회할_수_있다() {
 			// given
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
-			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(COMPLETED_SYNCED_RECORD(ROUTINE));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
+			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(ROUTINE).recordAt("2024-12-02 01:00:00").build() // 월요일
+			);
 
 			// when
 			List<RoutineRecord> records = routineRecordRepository.findRoutineRecordsForUserAndDate(
@@ -60,20 +67,29 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 		@Test
 		void 여러_루틴_기록을_한번에_조회할_수_있다() {
 			// given
-			Routine ROUTINE_WEEKLY1 = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
-			Routine ROUTINE_WEEKLY2 = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine ROUTINE_WEEKLY1 = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+			// given
+			Routine ROUTINE_WEEKLY2 = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 
 			RoutineRecord RECORD_WEEKLY1_1 = testFixtureBuilder.buildRoutineRecord(
-				COMPLETED_SYNCED_RECORD(ROUTINE_WEEKLY1)
+				COMPLETED_RECORD(ROUTINE_WEEKLY1).recordAt("2024-12-02 01:00:00").build() // 월요일
 			);
 			RoutineRecord RECORD_WEEKLY1_2 = testFixtureBuilder.buildRoutineRecord(
-				INCOMPLETED_SYNCED_RECORD(ROUTINE_WEEKLY1)
+				INCOMPLETED_RECORD(ROUTINE_WEEKLY1).recordAt("2024-12-02 01:00:00").build() // 화요일
 			);
 			RoutineRecord RECORD_WEEKLY2_1 = testFixtureBuilder.buildRoutineRecord(
-				COMPLETED_SYNCED_RECORD(ROUTINE_WEEKLY2)
+				INCOMPLETED_RECORD(ROUTINE_WEEKLY2).recordAt("2024-12-02 01:00:00").build() // 월요일
 			);
 			RoutineRecord RECORD_WEEKLY2_2 = testFixtureBuilder.buildRoutineRecord(
-				INCOMPLETED_SYNCED_RECORD(ROUTINE_WEEKLY2)
+				COMPLETED_RECORD(ROUTINE_WEEKLY2).recordAt("2024-12-02 01:00:00").build() // 화요일
 			);
 
 			// when

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
@@ -1,7 +1,7 @@
 package im.toduck.domain.routine.persistence.repository;
 
-import static im.toduck.fixtures.RoutineFixtures.*;
-import static im.toduck.fixtures.RoutineRecordFixtures.*;
+import static im.toduck.fixtures.routine.RoutineFixtures.*;
+import static im.toduck.fixtures.routine.RoutineRecordFixtures.*;
 import static im.toduck.fixtures.user.UserFixtures.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
@@ -42,7 +42,7 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 		void 유효한_루틴_기록을_조회할_수_있다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-11-29 01:00:00")
 					.build()
 			);
@@ -62,7 +62,6 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 				softly.assertThat(records).hasSize(1);
 				softly.assertThat(records).contains(RECORD);
 			});
-
 		}
 
 		@Test
@@ -119,8 +118,14 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 		@Test
 		void 유효한_루틴_기록을_조회할_수_있다() {
 			// given
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
-			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(COMPLETED_SYNCED_RECORD(ROUTINE));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(ROUTINE).recordAt("2024-12-02 07:00:00").build() // 월요일
+			);
 
 			// when
 			Optional<RoutineRecord> foundRecord = routineRecordRepository.findByRoutineAndRecordDate(
@@ -138,7 +143,11 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 		@Test
 		void 존재하지_않는_루틴_기록은_빈_Optional을_반환한다() {
 			// given
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			LocalDate NON_EXISTENT_DATE = LocalDate.now().plusDays(1);
 
 			// when
@@ -154,8 +163,14 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 		@Test
 		void 종일_루틴의_기록이_정상적으로_조회된디() {
 			// given
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE_ALL_DAY(USER));
-			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(COMPLETED_SYNCED_RECORD(ROUTINE));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ALLDAY_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+			RoutineRecord RECORD = testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(ROUTINE).recordAt("2024-12-02 00:00:00").allDay(true).build() // 월요일
+			);
 
 			// when
 			Optional<RoutineRecord> foundRecord = routineRecordRepository.findByRoutineAndRecordDate(
@@ -178,28 +193,47 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 		@Test
 		void 미래의_미완료_루틴_기록만_삭제된다() {
 			// given
-			Routine routine = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
+			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
+			// 기준 시간 설정 (테스트 내에서 "현재"로 간주)
+			LocalDateTime now = LocalDateTime.of(2024, 12, 15, 0, 0);
 
 			// 미래의 미완료 기록 (삭제 대상)
 			RoutineRecord futureIncomplete1 = testFixtureBuilder.buildRoutineRecord(
-				OFFSET_INCOMPLETED_SYNCED_RECORD(routine, 4L)
+				INCOMPLETED_RECORD(routine)
+					.recordAt("2024-12-30 07:00:00") // 미래 날짜
+					.allDay(routine.getTime() == null)
+					.build()
 			);
 			RoutineRecord futureIncomplete2 = testFixtureBuilder.buildRoutineRecord(
-				OFFSET_INCOMPLETED_SYNCED_RECORD(routine, 5L)
+				INCOMPLETED_RECORD(routine)
+					.recordAt("2025-01-06 07:00:00") // 미래 날짜
+					.allDay(routine.getTime() == null)
+					.build()
 			);
 
 			// 미래의 완료 기록 (유지되어야 함)
 			RoutineRecord futureComplete = testFixtureBuilder.buildRoutineRecord(
-				OFFSET_COMPLETED_SYNCED_RECORD(routine, 4L)
+				COMPLETED_RECORD(routine)
+					.recordAt("2024-12-23 07:00:00") // 미래 날짜
+					.allDay(routine.getTime() == null)
+					.build()
 			);
 
 			// 과거의 미완료 기록 (유지되어야 함)
 			RoutineRecord pastIncomplete = testFixtureBuilder.buildRoutineRecord(
-				OFFSET_COMPLETED_SYNCED_RECORD(routine, -3L)
+				COMPLETED_RECORD(routine)
+					.recordAt("2024-11-25 07:00:00") // 과거 날짜
+					.allDay(routine.getTime() == null)
+					.build()
 			);
 
 			// when
-			routineRecordRepository.deleteIncompletedFuturesByRoutine(routine, LocalDateTime.now());
+			routineRecordRepository.deleteIncompletedFuturesByRoutine(routine, now);
 
 			// then
 			List<RoutineRecord> remainingRecords = routineRecordRepository.findAll();
@@ -216,21 +250,38 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 		@Test
 		void 다른_루틴의_기록은_영향받지_않는다() {
 			// given
-			Routine routine1 = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
-			Routine routine2 = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine routine1 = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+			Routine routine2 = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
+			// 기준 시간 설정 (테스트 내에서 "현재"로 간주)
+			LocalDateTime now = LocalDateTime.of(2024, 12, 15, 0, 0);
 
 			// routine1의 미래 미완료 기록 (삭제 대상)
 			RoutineRecord routine1Future = testFixtureBuilder.buildRoutineRecord(
-				OFFSET_INCOMPLETED_SYNCED_RECORD(routine1, 1L)
+				INCOMPLETED_RECORD(routine1)
+					.recordAt("2024-12-16 07:00:00") // 미래 날짜
+					.allDay(routine1.getTime() == null)
+					.build()
 			);
 
 			// routine2의 미래 미완료 기록 (유지되어야 함)
 			RoutineRecord routine2Future = testFixtureBuilder.buildRoutineRecord(
-				OFFSET_INCOMPLETED_SYNCED_RECORD(routine2, 1L)
+				INCOMPLETED_RECORD(routine2)
+					.recordAt("2024-12-16 07:00:00") // 미래 날짜
+					.allDay(routine2.getTime() == null)
+					.build()
 			);
 
 			// when
-			routineRecordRepository.deleteIncompletedFuturesByRoutine(routine1, LocalDateTime.now());
+			routineRecordRepository.deleteIncompletedFuturesByRoutine(routine1, now);
 
 			// then
 			List<RoutineRecord> remainingRecords = routineRecordRepository.findAll();
@@ -245,11 +296,18 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 		@Test
 		void 루틴_기록이_없는_경우_정상_동작한다() {
 			// given
-			Routine routine = testFixtureBuilder.buildRoutine(MONDAY_ONLY_MORNING_ROUTINE(USER));
+			Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+
+			// 기준 시간 설정
+			LocalDateTime now = LocalDateTime.of(2024, 12, 15, 0, 0);
 
 			// when & then
 			assertThatCode(() ->
-				routineRecordRepository.deleteIncompletedFuturesByRoutine(routine, LocalDateTime.now())
+				routineRecordRepository.deleteIncompletedFuturesByRoutine(routine, now)
 			).doesNotThrowAnyException();
 		}
 	}

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -198,7 +199,7 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 			);
 
 			// when
-			routineRecordRepository.deleteIncompletedFuturesByRoutine(routine);
+			routineRecordRepository.deleteIncompletedFuturesByRoutine(routine, LocalDateTime.now());
 
 			// then
 			List<RoutineRecord> remainingRecords = routineRecordRepository.findAll();
@@ -229,7 +230,7 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 			);
 
 			// when
-			routineRecordRepository.deleteIncompletedFuturesByRoutine(routine1);
+			routineRecordRepository.deleteIncompletedFuturesByRoutine(routine1, LocalDateTime.now());
 
 			// then
 			List<RoutineRecord> remainingRecords = routineRecordRepository.findAll();
@@ -248,7 +249,7 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 
 			// when & then
 			assertThatCode(() ->
-				routineRecordRepository.deleteIncompletedFuturesByRoutine(routine)
+				routineRecordRepository.deleteIncompletedFuturesByRoutine(routine, LocalDateTime.now())
 			).doesNotThrowAnyException();
 		}
 	}

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
@@ -39,7 +39,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 주어진_날짜와_조건에_따라_기록되지_않은_루틴을_올바르게_조회한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-12-01 01:00:00")
 					.build()
 			);
@@ -56,7 +56,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 종일_루틴이_아닌_경우_루틴_반복요일및시간_변경일시가_조회_날짜보다_이후인_경우_조회되지_않음을_확인한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-12-01 01:00:00")
 					.scheduleModifiedAt("2024-12-06 01:00:00")
 					.build()
@@ -74,7 +74,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 주어진_날짜와_조건에_따라_이미_루틴기록이_있는_루틴을_조회하지_않는다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-11-29 01:00:00")
 					.scheduleModifiedAt("2024-12-01 01:00:00")
 					.build()
@@ -159,7 +159,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 루틴이_삭제되었더라면_조회되지_않는다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-11-29 01:00:00")
 					.scheduleModifiedAt("2024-12-01 01:00:00")
 					.deletedAt("2024-12-02 02:00:00")
@@ -178,13 +178,13 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 종일_루틴_여부와_관계없이_조회_날짜가_루틴_반복요일및시간_변경일시의_날짜와_같다면_조회된다() {
 			// given
 			Routine ALLDAY_ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(USER)
+				PUBLIC_MONDAY_ALLDAY_ROUTINE(USER)
 					.createdAt("2024-12-01 01:00:00")
 					.scheduleModifiedAt("2024-12-09 01:00:00")
 					.build()
 			);
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-12-01 01:00:00")
 					.scheduleModifiedAt("2024-12-09 01:00:00")
 					.build()
@@ -206,7 +206,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 날짜가_유효한_경우를_정상적으로_확인한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-12-01 01:00:00")
 					.build()
 			);
@@ -223,7 +223,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 날짜가_루틴_생성_시점_이전인_경우를_정상적으로_확인한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-12-03 01:00:00")
 					.build()
 			);
@@ -240,7 +240,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 반복요일및시간_변경일시가_조회_날짜보다_이후인_경우를_정상적으로_확인한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-12-01 01:00:00")
 					.scheduleModifiedAt("2024-12-06 01:00:00")
 					.build()
@@ -258,7 +258,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 루틴의_반복_요일이_날짜의_요일과_일치하지_않는_경우를_정상적으로_확인한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-12-01 01:00:00")
 					.build()
 			);
@@ -275,7 +275,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 		void 루틴이_삭제된_경우를_정상적으로_확인한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
 					.createdAt("2024-11-29 01:00:00")
 					.scheduleModifiedAt("2024-12-01 01:00:00")
 					.deletedAt("2024-12-02 02:00:00")

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -154,7 +154,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 		void 루틴이_자신의_소유가_아닌_경우_게시글_생성에_실패한다() {
 			// given
 			User ANOTHER_USER = testFixtureBuilder.buildUser(GENERAL_USER());
-			Routine ANOTHER_USER_ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(ANOTHER_USER));
+			Routine ANOTHER_USER_ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(ANOTHER_USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			SocialCreateRequest requestWithAnotherUserRoutine = new SocialCreateRequest(
 				null,
 				content,
@@ -173,7 +177,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 		@Test
 		void 비공개_루틴으로_게시글_작성시_실패한다() {
 			// given
-			Routine PRIVATE_ROUTINE = testFixtureBuilder.buildRoutine(PRIVATE_ROUTINE(USER));
+			Routine PRIVATE_ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PRIVATE_SUNDAY_NIGHT_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			SocialCreateRequest requestWithPrivateRoutine = new SocialCreateRequest(
 				null,
 				content,
@@ -238,7 +246,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 		@Test
 		void 게시글이_삭제되어도_루틴은_삭제되지_않는다() {
 			// given
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			Social SOCIAL_WITH_ROUTINE = testFixtureBuilder.buildSocial(
 				SINGLE_SOCIAL_WITH_ROUTINE(USER, ROUTINE, false)
 			);
@@ -452,7 +464,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void isChangeRoutine이_true이고_routineId가_null인_경우_해당_게시글의_공유_루틴을_제거한다() {
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			Social SOCIAL_WITH_ROUTINE = testFixtureBuilder.buildSocial(
 				SINGLE_SOCIAL_WITH_ROUTINE(USER, ROUTINE, false)
 			);
@@ -482,7 +498,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void isChangeRoutine이_false인_경우_해당_게시글의_공유_루틴을_변경하지_않는다() {
-			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			Social SOCIAL_WITH_ROUTINE = testFixtureBuilder.buildSocial(
 				SINGLE_SOCIAL_WITH_ROUTINE(USER, ROUTINE, false)
 			);
@@ -583,7 +603,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void 비공개_루틴으로_게시글_수정시_실패한다() {
-			Routine PRIVATE_ROUTINE = testFixtureBuilder.buildRoutine(PRIVATE_ROUTINE(USER));
+			Routine PRIVATE_ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PRIVATE_SUNDAY_NIGHT_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
 				true, null, false, PRIVATE_ROUTINE.getId(),
 				updateContent, isAnonymous, validCategoryIds, imageUrls
@@ -610,7 +634,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@BeforeEach
 		void setUp() {
-			ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
+			ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			SOCIAL_BOARD = testFixtureBuilder.buildSocial(SINGLE_SOCIAL_WITH_ROUTINE(USER, ROUTINE, false));
 			COMMENT = testFixtureBuilder.buildComment(SINGLE_COMMENT(USER, SOCIAL_BOARD));
 			LIKE = testFixtureBuilder.buildLike(LIKE(USER, SOCIAL_BOARD));

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -1,6 +1,6 @@
 package im.toduck.domain.social.domain.usecase;
 
-import static im.toduck.fixtures.RoutineFixtures.*;
+import static im.toduck.fixtures.routine.RoutineFixtures.*;
 import static im.toduck.fixtures.social.CommentFixtures.*;
 import static im.toduck.fixtures.social.LikeFixtures.*;
 import static im.toduck.fixtures.social.SocialCategoryFixtures.*;

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
@@ -1,7 +1,7 @@
 package im.toduck.domain.social.domain.usecase;
 
-import static im.toduck.fixtures.RoutineFixtures.*;
-import static im.toduck.fixtures.RoutineFixtures.PRIVATE_ROUTINE;
+import static im.toduck.fixtures.routine.RoutineFixtures.PRIVATE_ROUTINE;
+import static im.toduck.fixtures.routine.RoutineFixtures.*;
 import static im.toduck.fixtures.social.SocialFixtures.*;
 import static im.toduck.fixtures.user.UserFixtures.*;
 import static im.toduck.global.exception.ExceptionCode.*;
@@ -241,7 +241,11 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 			List<Routine> routines = new ArrayList<>();
 
 			for (int i = 0; i < routineCount; i++) {
-				Routine routine = testFixtureBuilder.buildRoutine(WEEKEND_NOON_ROUTINE(PROFILE_USER));
+				Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+					PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(PROFILE_USER)
+						.createdAt("2024-11-29 01:00:00")
+						.build()
+				);
 				routines.add(routine);
 			}
 
@@ -292,8 +296,11 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 			sharedCountField.setAccessible(true);
 
 			for (int i = 0; i < routineCount; i++) {
-				Routine routine = testFixtureBuilder.buildRoutine(WEEKEND_NOON_ROUTINE(PROFILE_USER));
-
+				Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+					PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(PROFILE_USER)
+						.createdAt("2024-11-29 01:00:00")
+						.build()
+				);
 				int sharedCount = i * 10;
 				sharedCountField.set(routine, sharedCount);
 
@@ -365,7 +372,11 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 				"30 minutes jogging"
 			);
 
-			SOURCE_ROUTINE_IS_PUBLIC = testFixtureBuilder.buildRoutine(WEEKEND_NOON_ROUTINE(PROFILE_USER));
+			SOURCE_ROUTINE_IS_PUBLIC = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PRIVATE_MONDAY_ONLY_MORNING_ROUTINE(PROFILE_USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
 			SOURCE_ROUTINE_IS_PRIVATE = testFixtureBuilder.buildRoutine(PRIVATE_ROUTINE(PROFILE_USER));
 		}
 

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
@@ -1,6 +1,5 @@
 package im.toduck.domain.social.domain.usecase;
 
-import static im.toduck.fixtures.routine.RoutineFixtures.PRIVATE_ROUTINE;
 import static im.toduck.fixtures.routine.RoutineFixtures.*;
 import static im.toduck.fixtures.social.SocialFixtures.*;
 import static im.toduck.fixtures.user.UserFixtures.*;
@@ -373,11 +372,15 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 			);
 
 			SOURCE_ROUTINE_IS_PUBLIC = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(PROFILE_USER)
+					.createdAt("2024-11-29 01:00:00")
+					.build()
+			);
+			SOURCE_ROUTINE_IS_PRIVATE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
 				PRIVATE_MONDAY_ONLY_MORNING_ROUTINE(PROFILE_USER)
 					.createdAt("2024-11-29 01:00:00")
 					.build()
 			);
-			SOURCE_ROUTINE_IS_PRIVATE = testFixtureBuilder.buildRoutine(PRIVATE_ROUTINE(PROFILE_USER));
 		}
 
 		@Test

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
@@ -241,7 +241,7 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 
 			for (int i = 0; i < routineCount; i++) {
 				Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-					PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(PROFILE_USER)
+					PUBLIC_MONDAY_MORNING_ROUTINE(PROFILE_USER)
 						.createdAt("2024-11-29 01:00:00")
 						.build()
 				);
@@ -296,7 +296,7 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 
 			for (int i = 0; i < routineCount; i++) {
 				Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-					PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(PROFILE_USER)
+					PUBLIC_MONDAY_MORNING_ROUTINE(PROFILE_USER)
 						.createdAt("2024-11-29 01:00:00")
 						.build()
 				);
@@ -372,12 +372,12 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 			);
 
 			SOURCE_ROUTINE_IS_PUBLIC = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(PROFILE_USER)
+				PUBLIC_MONDAY_MORNING_ROUTINE(PROFILE_USER)
 					.createdAt("2024-11-29 01:00:00")
 					.build()
 			);
 			SOURCE_ROUTINE_IS_PRIVATE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
-				PRIVATE_MONDAY_ONLY_MORNING_ROUTINE(PROFILE_USER)
+				PRIVATE_MONDAY_MORNING_ROUTINE(PROFILE_USER)
 					.createdAt("2024-11-29 01:00:00")
 					.build()
 			);

--- a/src/test/java/im/toduck/fixtures/routine/RoutineFixtures.java
+++ b/src/test/java/im/toduck/fixtures/routine/RoutineFixtures.java
@@ -35,6 +35,20 @@ public class RoutineFixtures {
 			.routine(routine);
 	}
 
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_MONDAY_ONLY_MORNING_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("내용")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.MONDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#FF0000"))
+			.isPublic(false)
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
 	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(User user) {
 		Routine routine = Routine.builder()
 			.user(user)

--- a/src/test/java/im/toduck/fixtures/routine/RoutineFixtures.java
+++ b/src/test/java/im/toduck/fixtures/routine/RoutineFixtures.java
@@ -1,4 +1,4 @@
-package im.toduck.fixtures;
+package im.toduck.fixtures.routine;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -21,6 +21,65 @@ public class RoutineFixtures {
 	private static final LocalTime EVENING_TIME = LocalTime.of(19, 0);
 	private static final LocalTime NIGHT_TIME = LocalTime.of(22, 0);
 
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("내용")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.MONDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#FF0000"))
+			.isPublic(true)
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("내용")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.MONDAY)))
+			.time(null)
+			.color(PlanCategoryColor.from("#FF0000"))
+			.isPublic(true)
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_DAILY_EVENING_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("매일 저녁 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(Arrays.asList(DayOfWeek.values())))
+			.time(EVENING_TIME)
+			.color(PlanCategoryColor.from("#FFA500"))
+			.isPublic(true)
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_WEEKDAY_MORNING_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("평일 아침 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
+				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+					DayOfWeek.FRIDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#0000FF"))
+			.isPublic(false)
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	@Deprecated
 	public static Routine MONDAY_ONLY_MORNING_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)
@@ -32,6 +91,7 @@ public class RoutineFixtures {
 			.build();
 	}
 
+	@Deprecated
 	public static Routine MONDAY_ONLY_MORNING_ROUTINE_ALL_DAY(User user) {
 		return Routine.builder()
 			.user(user)
@@ -43,6 +103,7 @@ public class RoutineFixtures {
 			.build();
 	}
 
+	@Deprecated
 	public static Routine WEEKDAY_MORNING_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)
@@ -56,6 +117,7 @@ public class RoutineFixtures {
 			.build();
 	}
 
+	@Deprecated
 	public static Routine WEEKEND_NOON_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)
@@ -68,6 +130,7 @@ public class RoutineFixtures {
 			.build();
 	}
 
+	@Deprecated
 	public static Routine DAILY_EVENING_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)
@@ -79,6 +142,7 @@ public class RoutineFixtures {
 			.build();
 	}
 
+	@Deprecated
 	public static Routine TUESDAY_THURSDAY_SATURDAY_NIGHT_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)
@@ -91,6 +155,7 @@ public class RoutineFixtures {
 			.build();
 	}
 
+	@Deprecated
 	public static Routine WEDNESDAY_FRIDAY_MORNING_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)
@@ -102,6 +167,7 @@ public class RoutineFixtures {
 			.build();
 	}
 
+	@Deprecated
 	public static Routine EVERYDAY_EXCEPT_SUNDAY_NOON_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)
@@ -115,6 +181,7 @@ public class RoutineFixtures {
 			.build();
 	}
 
+	@Deprecated
 	public static Routine FIRST_DAY_OF_WEEK_MORNING_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)
@@ -126,6 +193,7 @@ public class RoutineFixtures {
 			.build();
 	}
 
+	@Deprecated
 	public static Routine LAST_DAY_OF_WEEK_NIGHT_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)
@@ -138,6 +206,7 @@ public class RoutineFixtures {
 
 	}
 
+	@Deprecated
 	public static Routine DELETED_MONDAY_ONLY_MORNING_ROUTINE(User user, LocalDateTime dateTime) {
 		Routine routine = MONDAY_ONLY_MORNING_ROUTINE(user);
 		ReflectionTestUtils.setField(routine, "deletedAt", dateTime);
@@ -145,6 +214,7 @@ public class RoutineFixtures {
 		return routine;
 	}
 
+	@Deprecated
 	public static Routine PRIVATE_ROUTINE(User user) {
 		return Routine.builder()
 			.user(user)

--- a/src/test/java/im/toduck/fixtures/routine/RoutineFixtures.java
+++ b/src/test/java/im/toduck/fixtures/routine/RoutineFixtures.java
@@ -1,16 +1,12 @@
 package im.toduck.fixtures.routine;
 
 import java.time.DayOfWeek;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 
-import org.springframework.test.util.ReflectionTestUtils;
-
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.vo.PlanCategoryColor;
-import im.toduck.domain.routine.persistence.vo.RoutineMemo;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.helper.DaysOfWeekBitmask;
 
@@ -21,7 +17,7 @@ public class RoutineFixtures {
 	private static final LocalTime EVENING_TIME = LocalTime.of(19, 0);
 	private static final LocalTime NIGHT_TIME = LocalTime.of(22, 0);
 
-	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_MONDAY_ONLY_MORNING_ROUTINE(User user) {
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_MONDAY_MORNING_ROUTINE(User user) {
 		Routine routine = Routine.builder()
 			.user(user)
 			.title("내용")
@@ -35,7 +31,7 @@ public class RoutineFixtures {
 			.routine(routine);
 	}
 
-	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_MONDAY_ONLY_MORNING_ROUTINE(User user) {
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_MONDAY_MORNING_ROUTINE(User user) {
 		Routine routine = Routine.builder()
 			.user(user)
 			.title("내용")
@@ -49,7 +45,7 @@ public class RoutineFixtures {
 			.routine(routine);
 	}
 
-	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_MONDAY_ONLY_ALLDAY_ROUTINE(User user) {
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_MONDAY_ALLDAY_ROUTINE(User user) {
 		Routine routine = Routine.builder()
 			.user(user)
 			.title("내용")
@@ -66,7 +62,7 @@ public class RoutineFixtures {
 	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_DAILY_EVENING_ROUTINE(User user) {
 		Routine routine = Routine.builder()
 			.user(user)
-			.title("매일 저녁 루틴")
+			.title("매일 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(Arrays.asList(DayOfWeek.values())))
 			.time(EVENING_TIME)
 			.color(PlanCategoryColor.from("#FFA500"))
@@ -80,7 +76,37 @@ public class RoutineFixtures {
 	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_WEEKDAY_MORNING_ROUTINE(User user) {
 		Routine routine = Routine.builder()
 			.user(user)
-			.title("평일 아침 루틴")
+			.title("평일 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
+				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+					DayOfWeek.FRIDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#0000FF"))
+			.isPublic(true) // 수정: false -> true
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_DAILY_EVENING_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("매일 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(Arrays.asList(DayOfWeek.values())))
+			.time(EVENING_TIME)
+			.color(PlanCategoryColor.from("#FFA500"))
+			.isPublic(false)
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_WEEKDAY_MORNING_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("평일 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
 				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
 					DayOfWeek.FRIDAY)))
@@ -93,99 +119,112 @@ public class RoutineFixtures {
 			.routine(routine);
 	}
 
-	@Deprecated
-	public static Routine MONDAY_ONLY_MORNING_ROUTINE(User user) {
-		return Routine.builder()
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_WEEKEND_NOON_ROUTINE(User user) {
+		Routine routine = Routine.builder()
 			.user(user)
-			.title("월요일 아침 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.MONDAY)))
-			.time(MORNING_TIME)
-			.color(PlanCategoryColor.from("#FF0000"))
-			.isPublic(true)
-			.build();
-	}
-
-	@Deprecated
-	public static Routine MONDAY_ONLY_MORNING_ROUTINE_ALL_DAY(User user) {
-		return Routine.builder()
-			.user(user)
-			.title("월요일 아침 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.MONDAY)))
-			.time(null)
-			.color(PlanCategoryColor.from("#FF0000"))
-			.isPublic(true)
-			.build();
-	}
-
-	@Deprecated
-	public static Routine WEEKDAY_MORNING_ROUTINE(User user) {
-		return Routine.builder()
-			.user(user)
-			.title("평일 아침 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
-				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
-					DayOfWeek.FRIDAY)))
-			.time(MORNING_TIME)
-			.color(PlanCategoryColor.from("#0000FF"))
-			.isPublic(false)
-			.build();
-	}
-
-	@Deprecated
-	public static Routine WEEKEND_NOON_ROUTINE(User user) {
-		return Routine.builder()
-			.user(user)
-			.title("주말 점심 루틴")
+			.title("주말 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)))
 			.time(NOON_TIME)
 			.color(PlanCategoryColor.from("#00FF00"))
-			.memo(RoutineMemo.from("주말 점심 루틴 메모"))
 			.isPublic(true)
 			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
 	}
 
-	@Deprecated
-	public static Routine DAILY_EVENING_ROUTINE(User user) {
-		return Routine.builder()
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_WEEKEND_NOON_ROUTINE(User user) {
+		Routine routine = Routine.builder()
 			.user(user)
-			.title("매일 저녁 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(Arrays.asList(DayOfWeek.values())))
-			.time(EVENING_TIME)
-			.color(PlanCategoryColor.from("#FFA500"))
+			.title("주말 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)))
+			.time(NOON_TIME)
+			.color(PlanCategoryColor.from("#00FF00"))
+			.isPublic(false)
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_TUE_THU_SAT_NIGHT_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("화목토 루틴")
+			.daysOfWeekBitmask(
+				DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY)))
+			.time(NIGHT_TIME)
+			.color(PlanCategoryColor.from("#800080"))
 			.isPublic(true)
 			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
 	}
 
-	@Deprecated
-	public static Routine TUESDAY_THURSDAY_SATURDAY_NIGHT_ROUTINE(User user) {
-		return Routine.builder()
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_TUE_THU_SAT_NIGHT_ROUTINE(User user) {
+		Routine routine = Routine.builder()
 			.user(user)
-			.title("화목토 밤 루틴")
+			.title("화목토 루틴")
 			.daysOfWeekBitmask(
 				DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY)))
 			.time(NIGHT_TIME)
 			.color(PlanCategoryColor.from("#800080"))
 			.isPublic(false)
 			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
 	}
 
-	@Deprecated
-	public static Routine WEDNESDAY_FRIDAY_MORNING_ROUTINE(User user) {
-		return Routine.builder()
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_WED_FRI_MORNING_ROUTINE(User user) {
+		Routine routine = Routine.builder()
 			.user(user)
-			.title("수금 아침 루틴")
+			.title("수금 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)))
 			.time(MORNING_TIME)
 			.color(PlanCategoryColor.from("#FFA500"))
 			.isPublic(true)
 			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
 	}
 
-	@Deprecated
-	public static Routine EVERYDAY_EXCEPT_SUNDAY_NOON_ROUTINE(User user) {
-		return Routine.builder()
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_WED_FRI_MORNING_ROUTINE(User user) {
+		Routine routine = Routine.builder()
 			.user(user)
-			.title("일요일 제외 매일 점심 루틴")
+			.title("수금 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#FFA500"))
+			.isPublic(false)
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_EXCEPT_SUNDAY_NOON_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("일요일 제외 매일 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
+				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY,
+					DayOfWeek.SATURDAY)))
+			.time(NOON_TIME)
+			.color(PlanCategoryColor.from("#008080"))
+			.isPublic(true)
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_EXCEPT_SUNDAY_NOON_ROUTINE(User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("일요일 제외 매일 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
 				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY,
 					DayOfWeek.SATURDAY)))
@@ -193,52 +232,37 @@ public class RoutineFixtures {
 			.color(PlanCategoryColor.from("#008080"))
 			.isPublic(false)
 			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
 	}
 
-	@Deprecated
-	public static Routine FIRST_DAY_OF_WEEK_MORNING_ROUTINE(User user) {
-		return Routine.builder()
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_SUNDAY_NIGHT_ROUTINE(User user) {
+		Routine routine = Routine.builder()
 			.user(user)
-			.title("월요일 아침 주간 시작 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.MONDAY)))
-			.time(MORNING_TIME)
-			.color(PlanCategoryColor.from("#4B0082"))
+			.title("일요일 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SUNDAY)))
+			.time(NIGHT_TIME)
+			.color(PlanCategoryColor.from("#006400"))
 			.isPublic(true)
 			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
 	}
 
-	@Deprecated
-	public static Routine LAST_DAY_OF_WEEK_NIGHT_ROUTINE(User user) {
-		return Routine.builder()
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PRIVATE_SUNDAY_NIGHT_ROUTINE(User user) {
+		Routine routine = Routine.builder()
 			.user(user)
-			.title("일요일 밤 주간 마무리 루틴")
+			.title("일요일 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SUNDAY)))
 			.time(NIGHT_TIME)
 			.color(PlanCategoryColor.from("#006400"))
 			.isPublic(false)
 			.build();
 
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
 	}
-
-	@Deprecated
-	public static Routine DELETED_MONDAY_ONLY_MORNING_ROUTINE(User user, LocalDateTime dateTime) {
-		Routine routine = MONDAY_ONLY_MORNING_ROUTINE(user);
-		ReflectionTestUtils.setField(routine, "deletedAt", dateTime);
-
-		return routine;
-	}
-
-	@Deprecated
-	public static Routine PRIVATE_ROUTINE(User user) {
-		return Routine.builder()
-			.user(user)
-			.title("비공개 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SUNDAY)))
-			.time(NIGHT_TIME)
-			.color(PlanCategoryColor.from("#006400"))
-			.isPublic(false)
-			.build();
-
-	}
-
 }
+

--- a/src/test/java/im/toduck/fixtures/routine/RoutineRecordFixtures.java
+++ b/src/test/java/im/toduck/fixtures/routine/RoutineRecordFixtures.java
@@ -1,17 +1,13 @@
 package im.toduck.fixtures.routine;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Random;
 
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 
 public class RoutineRecordFixtures {
 	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-	private static final Random random = new Random();
 
 	public static RoutineRecordBuilder COMPLETED_RECORD(Routine routine) {
 		return new RoutineRecordBuilder(routine, true);
@@ -54,90 +50,5 @@ public class RoutineRecordFixtures {
 				.isCompleted(isCompleted)
 				.build();
 		}
-	}
-
-	@Deprecated
-	public static RoutineRecord COMPLETED_SYNCED_RECORD(Routine routine) {
-		return createRoutineRecord(routine, true, false, 0L);
-	}
-
-	@Deprecated
-	public static RoutineRecord INCOMPLETED_SYNCED_RECORD(Routine routine) {
-		return createRoutineRecord(routine, false, false, 0L);
-	}
-
-	@Deprecated
-	public static RoutineRecord COMPLETED_MODIFIED_RECORD(Routine routine) {
-		return createRoutineRecord(routine, true, true, 0L);
-	}
-
-	@Deprecated
-	public static RoutineRecord INCOMPLETED_MODIFIED_RECORD(Routine routine) {
-		return createRoutineRecord(routine, false, true, 0L);
-	}
-
-	@Deprecated
-	public static RoutineRecord OFFSET_COMPLETED_SYNCED_RECORD(Routine routine, Long weekOffset) {
-		return createRoutineRecord(routine, true, false, weekOffset);
-	}
-
-	@Deprecated
-	public static RoutineRecord OFFSET_INCOMPLETED_SYNCED_RECORD(Routine routine, Long weekOffset) {
-		return createRoutineRecord(routine, false, false, weekOffset);
-	}
-
-	private static RoutineRecord createRoutineRecord(
-		Routine routine,
-		boolean isCompleted,
-		boolean isModified,
-		Long weekOffset
-	) {
-		LocalDateTime recordedAt =
-			isModified ? calculateModifiedRecordAt(routine, weekOffset) : calculateSyncedRecordAt(routine, weekOffset);
-
-		return RoutineRecord.builder()
-			.routine(routine)
-			.recordAt(recordedAt)
-			.isAllDay(routine.getTime() == null)
-			.isCompleted(isCompleted)
-			.build();
-	}
-
-	private static LocalDateTime calculateSyncedRecordAt(Routine routine, Long weekOffset) {
-		return calculateRecordAt(routine, routine.getTime(), true, weekOffset);
-	}
-
-	private static LocalDateTime calculateModifiedRecordAt(Routine routine, Long weekOffset) {
-		return calculateRecordAt(routine, generateDifferentTime(routine.getTime()), false, weekOffset);
-	}
-
-	private static LocalDateTime calculateRecordAt(
-		Routine routine, LocalTime time,
-		boolean shouldIncludeDay,
-		long weekOffset
-	) {
-		LocalDate startDate = routine.getCreatedAt().toLocalDate();
-		LocalTime routineTime = time != null ? time : LocalTime.MIDNIGHT;
-
-		startDate = startDate.plusDays(weekOffset * 7);
-
-		while (true) {
-			if (routine.getDaysOfWeekBitmask().includesDayOf(startDate) == shouldIncludeDay) {
-				return LocalDateTime.of(startDate, routineTime);
-			}
-
-			startDate = startDate.plusDays(1);
-		}
-	}
-
-	private static LocalTime generateDifferentTime(LocalTime originalTime) {
-		LocalTime newTime;
-		do {
-			int hour = random.nextInt(24);
-			int minute = random.nextInt(60);
-			newTime = LocalTime.of(hour, minute);
-		} while (newTime.equals(originalTime));
-
-		return newTime;
 	}
 }

--- a/src/test/java/im/toduck/fixtures/routine/RoutineRecordFixtures.java
+++ b/src/test/java/im/toduck/fixtures/routine/RoutineRecordFixtures.java
@@ -1,37 +1,87 @@
-package im.toduck.fixtures;
+package im.toduck.fixtures.routine;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Random;
 
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 
 public class RoutineRecordFixtures {
-
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 	private static final Random random = new Random();
 
+	public static RoutineRecordBuilder COMPLETED_RECORD(Routine routine) {
+		return new RoutineRecordBuilder(routine, true);
+	}
+
+	public static RoutineRecordBuilder INCOMPLETED_RECORD(Routine routine) {
+		return new RoutineRecordBuilder(routine, false);
+	}
+
+	public static class RoutineRecordBuilder {
+		private final Routine routine;
+		private final boolean isCompleted;
+		private LocalDateTime recordAt;
+		private boolean isAllDay;
+
+		private RoutineRecordBuilder(Routine routine, boolean isCompleted) {
+			this.routine = routine;
+			this.isCompleted = isCompleted;
+		}
+
+		public RoutineRecordBuilder recordAt(String recordAt) {
+			this.recordAt = LocalDateTime.parse(recordAt, FORMATTER);
+			return this;
+		}
+
+		public RoutineRecordBuilder allDay(boolean isAllDay) {
+			this.isAllDay = isAllDay;
+			return this;
+		}
+
+		public RoutineRecord build() {
+			if (recordAt == null) {
+				throw new IllegalStateException("recordAt을 설정하세요");
+			}
+
+			return RoutineRecord.builder()
+				.routine(routine)
+				.recordAt(recordAt)
+				.isAllDay(isAllDay)
+				.isCompleted(isCompleted)
+				.build();
+		}
+	}
+
+	@Deprecated
 	public static RoutineRecord COMPLETED_SYNCED_RECORD(Routine routine) {
 		return createRoutineRecord(routine, true, false, 0L);
 	}
 
+	@Deprecated
 	public static RoutineRecord INCOMPLETED_SYNCED_RECORD(Routine routine) {
 		return createRoutineRecord(routine, false, false, 0L);
 	}
 
+	@Deprecated
 	public static RoutineRecord COMPLETED_MODIFIED_RECORD(Routine routine) {
 		return createRoutineRecord(routine, true, true, 0L);
 	}
 
+	@Deprecated
 	public static RoutineRecord INCOMPLETED_MODIFIED_RECORD(Routine routine) {
 		return createRoutineRecord(routine, false, true, 0L);
 	}
 
+	@Deprecated
 	public static RoutineRecord OFFSET_COMPLETED_SYNCED_RECORD(Routine routine, Long weekOffset) {
 		return createRoutineRecord(routine, true, false, weekOffset);
 	}
 
+	@Deprecated
 	public static RoutineRecord OFFSET_INCOMPLETED_SYNCED_RECORD(Routine routine, Long weekOffset) {
 		return createRoutineRecord(routine, false, false, weekOffset);
 	}

--- a/src/test/java/im/toduck/fixtures/routine/RoutineWithAuditInfo.java
+++ b/src/test/java/im/toduck/fixtures/routine/RoutineWithAuditInfo.java
@@ -1,0 +1,146 @@
+package im.toduck.fixtures.routine;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import im.toduck.domain.routine.persistence.entity.Routine;
+
+public class RoutineWithAuditInfo {
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+	private final Routine routine;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime scheduleModifiedAt;
+	private final LocalDateTime deletedAt;
+
+	private RoutineWithAuditInfo(final Routine routine, LocalDateTime createdAt,
+		LocalDateTime scheduleModifiedAt, LocalDateTime deletedAt) {
+		this.routine = routine;
+		this.createdAt = createdAt;
+		this.scheduleModifiedAt = scheduleModifiedAt;
+		this.deletedAt = deletedAt;
+	}
+
+	public static RoutineWithAuditInfoBuilder builder() {
+		return new RoutineWithAuditInfoBuilder();
+	}
+
+	public Routine getRoutine() {
+		return routine;
+	}
+
+	public LocalDateTime getCreatedAt() {
+		return createdAt;
+	}
+
+	public LocalDateTime getScheduleModifiedAt() {
+		return scheduleModifiedAt;
+	}
+
+	public LocalDateTime getDeletedAt() {
+		return deletedAt;
+	}
+
+	public boolean requiresAudit() {
+		return createdAt != null || scheduleModifiedAt != null || deletedAt != null;
+	}
+
+	public static class RoutineWithAuditInfoBuilder {
+		private Routine routine;
+		private LocalDateTime createdAt;
+		private LocalDateTime scheduleModifiedAt;
+		private LocalDateTime deletedAt;
+
+		private RoutineWithAuditInfoBuilder() {
+		}
+
+		public RoutineWithAuditInfoBuilder routine(Routine routine) {
+			this.routine = routine;
+			return this;
+		}
+
+		/**
+		 * 루틴의 생성 시간을 설정합니다.
+		 * schedule_modified_at이 별도로 지정되지 않은 경우, 이 시간으로 자동 설정됩니다.
+		 *
+		 * @param dateTime 'yyyy-MM-dd HH:mm:ss' 형식의 날짜와 시간 문자열
+		 *                 예시: "2024-01-01 13:30:00"
+		 * @throws DateTimeParseException 날짜와 시간 문자열을 파싱할 수 없는 경우
+		 */
+		public RoutineWithAuditInfoBuilder createdAt(String dateTime) {
+			this.createdAt = LocalDateTime.parse(dateTime, FORMATTER);
+			return this;
+		}
+
+		/**
+		 * 루틴의 스케줄 수정 시간을 설정합니다.
+		 * 이 값을 설정하지 않으면 createdAt과 동일한 시간으로 설정됩니다.
+		 *
+		 * @param dateTime 'yyyy-MM-dd HH:mm:ss' 형식의 날짜와 시간 문자열
+		 *                 예시: "2024-01-01 13:30:00"
+		 * @throws DateTimeParseException 날짜와 시간 문자열을 파싱할 수 없는 경우
+		 */
+		public RoutineWithAuditInfoBuilder scheduleModifiedAt(String dateTime) {
+			this.scheduleModifiedAt = LocalDateTime.parse(dateTime, FORMATTER);
+			return this;
+		}
+
+		/**
+		 * 루틴의 삭제 시간을 설정합니다.
+		 *
+		 * @param dateTime 'yyyy-MM-dd HH:mm:ss' 형식의 날짜와 시간 문자열
+		 *                 예시: "2024-01-01 13:30:00"
+		 * @throws DateTimeParseException 날짜와 시간 문자열을 파싱할 수 없는 경우
+		 */
+		public RoutineWithAuditInfoBuilder deletedAt(String dateTime) {
+			this.deletedAt = LocalDateTime.parse(dateTime, FORMATTER);
+			return this;
+		}
+
+		/**
+		 * RoutineWithAuditInfo 객체를 생성합니다.
+		 *
+		 * 다음과 같은 경우들이 유효합니다:
+		 * 1. audit 필드를 전혀 지정하지 않은 경우
+		 * 2. createdAt만 지정한 경우: scheduleModifiedAt은 createdAt과 동일하게 설정되고, deletedAt은 null
+		 * 3. createdAt과 scheduleModifiedAt을 지정한 경우: deletedAt은 null
+		 * 4. createdAt과 deletedAt을 지정한 경우: scheduleModifiedAt은 createdAt과 동일하게 설정
+		 * 5. 모든 필드(createdAt, scheduleModifiedAt, deletedAt)를 지정한 경우
+		 *
+		 * 이외의 모든 조합(예: scheduleModifiedAt만 지정, deletedAt만 지정 등)은 IllegalStateException을 발생시킵니다.
+		 *
+		 * @return 생성된 RoutineWithAuditInfo 객체
+		 * @throws IllegalStateException 유효하지 않은 필드 조합으로 생성을 시도한 경우
+		 */
+		public RoutineWithAuditInfo build() {
+			if (routine == null) {
+				throw new IllegalStateException("Routine 은 필수 값입니다.");
+			}
+
+			if (createdAt == null && scheduleModifiedAt == null && deletedAt == null) {
+				return new RoutineWithAuditInfo(routine, null, null, null);
+			}
+
+			if (createdAt != null && scheduleModifiedAt == null && deletedAt == null) {
+				return new RoutineWithAuditInfo(routine, createdAt, createdAt, null);
+			}
+
+			if (createdAt != null && scheduleModifiedAt != null && deletedAt == null) {
+				return new RoutineWithAuditInfo(routine, createdAt, scheduleModifiedAt, null);
+			}
+
+			if (createdAt != null && scheduleModifiedAt == null && deletedAt != null) {
+				return new RoutineWithAuditInfo(routine, createdAt, createdAt, deletedAt);
+			}
+
+			if (createdAt != null && scheduleModifiedAt != null && deletedAt != null) {
+				return new RoutineWithAuditInfo(routine, createdAt, scheduleModifiedAt, deletedAt);
+			}
+
+			throw new IllegalStateException(
+				"유효하지 않은 audit 필드 조합입니다. build() 메서드의 JavaDoc을 참고하세요."
+			);
+		}
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용
루틴 수정 기능 구현 및 루틴 조회, 삭제 로직 재구성

**1️⃣ 루틴 수정 API 개발**
- 루틴의 제목, 카테고리, 색상, 시간, 공개 여부, 반복 요일, 알림 시간, 메모 수정 기능 구현
- 각 필드별 변경 여부 플래그를 통한 선택적 업데이트 지원
- 종일 루틴 ↔ 특정 시간 루틴 간 변경 지원, 반복 요일 변경 지원
- 반복 요일 패턴 변경 지원
- PUT /api/routines/{routineId} 엔드포인트 추가

**2️⃣ 루틴 스케줄 변경 히스토리 관리**
- `schedule_modified_at` 필드 추가로 루틴 일정 변경 시점 기록
- 루틴 시간 또는 반복 요일 변경 시 미래의 미완료 기록 자동 정리
- 루틴 수정/삭제 시 과거 기록은 유지하고 미래 기록만 관리하는 메커니즘
- `saveMissingIncompleteRecordsInBulk` 메서드 추가로 스케줄 변경 간 누락된 기록 보존
- **루틴 스케줄 변경 관리**
	- 루틴 이행 이력을 정확하게 보존하면서 미래 기록은 새로운 설정에 맞게 생성됩니다. 예를 들어, 사용자가 월/수/금 루틴을 화/목 루틴으로 변경하더라도 변경 이전의 월/수/금 날짜들에 대한 기록은 그대로 유지됩니다.
	- 루틴의 시간이나 반복 요일이 변경될 경우:
		1. 변경 시점(`LocalDateTime.now()`)을 기준으로 미래의 미완료 루틴 기록을 삭제
		2. 이전 스케줄 변경 시점부터 현재 시점까지의 누락된 기록을 생성하여 과거 기록 보존
		3. Routine 엔티티의 `scheduleModifiedAt` 필드를 현재 시점으로 업데이트

**3️⃣ 루틴 조회 로직 개선**
- 루틴 스케줄 변경 히스토리에 기반한 조회 로직 개선
- 종일 루틴과 특정 시간 루틴에 대한 별도 처리 로직 구현
- 루틴 삭제 상태 관리 개선 (soft delete)
- 쿼리 성능 최적화

**4️⃣ 기타 변경사항**
- 일부 DTO 필드 추가, 제약 조건 단순화
- 테스트 코드 리팩토링: 기존 fixture 기반 테스트를 시간 기반 테스트로 변경하여 날짜/시간 의존성 문제 해결 (고정된 날짜/시간을 사용하는 방식으로 변경)

### 전체 기능 흐름도
루틴 수정 흐름:
```mermaid
flowchart LR
    A[루틴 수정 요청] --> B{시간/요일 변경?}
    B -->|예| C[미래 미완료 기록 삭제]
    C --> D[과거 누락 기록 생성]
    D --> E[루틴 정보 업데이트]
    B -->|아니오| E
    E --> F[수정 완료]
```
루틴 삭제 흐름:
```mermaid
flowchart LR
    A[루틴 삭제 요청] --> B{기록 유지?}
    B -->|예| C[미래 미완료 기록 삭제]
    C --> D[과거 누락 기록 생성]
    D --> E[루틴 soft delete]
    B -->|아니오| F[모든 기록 삭제]
    F --> E
    E --> G[삭제 완료]
```

누락 기록 저장 흐름:
```mermaid
flowchart LR
    A[누락 기록 저장] --> B[기존 기록 조회] --> C[반복 요일 날짜 생성] --> D[기존 기록 없는 날짜 필터링] --> E[시작/종료일 경계 처리] --> F[신규 기록 객체 생성] --> G{신규 기록 존재?}
    G -->|예| H[일괄 저장] --> I[종료]
    G -->|아니오| I
```
루틴 완료 상태 변경 흐름:
```mermaid
flowchart LR
    A[완료 상태 변경 요청] --> B{기록 존재?}
    B -->|예| C[기존 기록 상태 변경] --> G[완료]
    B -->|아니오| D{날짜 유효?}
    D -->|유효| E[새 기록 생성] --> G
    D -->|유효하지 않음| F[에러 반환]
```
루틴 기록 조회 흐름:
```mermaid
flowchart LR
    A[루틴 기록 조회] --> B[사용자 기록 조회] --> C[미기록 루틴 조회] --> D[변경 히스토리 기반 필터링] --> E[조회 결과 생성] --> F[응답 반환]
```

## ✅ 리뷰 요구사항 (참고)
**변경사항 많은거 죄송합니다 ㅎㅎ..**
1. 테스트 코드 리팩토링 관련 (추후)
   - 변경된 테스트 구조에서 일부 `@Disabled` 테스트가 있으며 보강 필요
   - 특히 시간 변경, 반복 요일 변경 시 기록 처리 로직에 대한 테스트 보강 필요
2. 클라이언트 측에 실제 사용 중 이상이나 개선점 피드백을 요청해둔 상태입니다.
3. 성능 최적화 필요(내부적으로 루틴 수정 및 삭제 시 Record 벌크 연산 중)