### PR TITLE
일정 삭제 API 개발

### DIFF
--- a/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleMapper.java
+++ b/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleMapper.java
@@ -93,6 +93,7 @@ public class ScheduleMapper {
 			.scheduleRecordId(scheduleRecord.getId())
 			.isComplete(scheduleRecord.getIsCompleted())
 			.recordDate(scheduleRecord.getRecordDate())
+			.deletedAt(scheduleRecord.getDeletedAt())
 			.build();
 	}
 
@@ -101,5 +102,21 @@ public class ScheduleMapper {
 			return null;
 		}
 		return daysOfWeekBitmask.getDaysOfWeek().stream().toList();
+	}
+
+	public static Schedule copyToSchedule(Schedule schedule, LocalDate queryDate) {
+		ScheduleDate from = ScheduleDate.from(queryDate, queryDate);
+
+		return new Schedule(
+			schedule.getTitle(),
+			schedule.getCategory(),
+			schedule.getColor(),
+			from,
+			schedule.getScheduleTime(),
+			schedule.getDaysOfWeekBitmask(),
+			schedule.getLocation(),
+			schedule.getMemo(),
+			schedule.getUser()
+		);
 	}
 }

--- a/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleRecordMapper.java
+++ b/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleRecordMapper.java
@@ -3,6 +3,7 @@ package im.toduck.domain.schedule.common.mapper;
 import im.toduck.domain.schedule.persistence.entity.Schedule;
 import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleDeleteRequest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -15,5 +16,15 @@ public class ScheduleRecordMapper {
 			.isCompleted(scheduleCompleteRequest.isComplete())
 			.schedule(schedule)
 			.build();
+	}
+
+	public static ScheduleRecord toSoftDeletedScheduleRecord(Schedule schedule, ScheduleDeleteRequest request) {
+		ScheduleRecord scheduleRecord = ScheduleRecord.builder()
+			.isCompleted(false)
+			.recordDate(request.queryDate())
+			.schedule(schedule)
+			.build();
+		scheduleRecord.softDelete();
+		return scheduleRecord;
 	}
 }

--- a/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleRecordMapper.java
+++ b/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleRecordMapper.java
@@ -1,0 +1,19 @@
+package im.toduck.domain.schedule.common.mapper;
+
+import im.toduck.domain.schedule.persistence.entity.Schedule;
+import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ScheduleRecordMapper {
+
+	public static ScheduleRecord toScheduleRecord(Schedule schedule, ScheduleCompleteRequest scheduleCompleteRequest) {
+		return ScheduleRecord.builder()
+			.recordDate(scheduleCompleteRequest.queryDate())
+			.isCompleted(scheduleCompleteRequest.isComplete())
+			.schedule(schedule)
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleRecordService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleRecordService.java
@@ -22,7 +22,6 @@ public class ScheduleRecordService {
 		ScheduleCompleteRequest scheduleCompleteRequest) {
 		return scheduleRecordRepository
 			.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
-				userId,
 				scheduleCompleteRequest.queryDate(),
 				scheduleCompleteRequest.scheduleId());
 	}

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleRecordService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleRecordService.java
@@ -1,0 +1,38 @@
+package im.toduck.domain.schedule.domain.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import im.toduck.domain.schedule.common.mapper.ScheduleRecordMapper;
+import im.toduck.domain.schedule.persistence.entity.Schedule;
+import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
+import im.toduck.domain.schedule.persistence.repository.ScheduleRecordRepository;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ScheduleRecordService {
+	private final ScheduleRecordRepository scheduleRecordRepository;
+
+	public Optional<ScheduleRecord> getScheduleRecordWithSchedule(Long userId,
+		ScheduleCompleteRequest scheduleCompleteRequest) {
+		return scheduleRecordRepository
+			.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+				userId,
+				scheduleCompleteRequest.queryDate(),
+				scheduleCompleteRequest.scheduleId());
+	}
+
+	public void completeScheduleRecord(ScheduleRecord scheduleRecord, ScheduleCompleteRequest scheduleCompleteRequest) {
+		scheduleRecord.changeComplete(scheduleCompleteRequest.isComplete());
+	}
+
+	public void createScheduleRecord(Schedule schedule, ScheduleCompleteRequest scheduleCompleteRequest) {
+		ScheduleRecord scheduleRecord = ScheduleRecordMapper.toScheduleRecord(schedule, scheduleCompleteRequest);
+		scheduleRecordRepository.save(scheduleRecord);
+	}
+}

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleService.java
@@ -96,7 +96,7 @@ public class ScheduleService {
 					ScheduleMapper.copyToSchedule(schedule, scheduleDeleteRequest.queryDate()));
 				scheduleRecord.changeSchedule(save);
 			});
-		scheduleRecordRepository.deleteByNonCompletedScheduleAndBetweenStartDateAndEndDate(
+		scheduleRecordRepository.deleteByNonCompletedScheduleAndAfterStartDate(
 			schedule.getId(),
 			scheduleDeleteRequest.queryDate(),
 			schedule.getScheduleDate().getEndDate());

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleService.java
@@ -3,6 +3,7 @@ package im.toduck.domain.schedule.domain.service;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,5 +52,9 @@ public class ScheduleService {
 		return scheduleRecordRepository.findScheduleRecordFetchJoinSchedule(scheduleRecordId)
 			.map(ScheduleMapper::toScheduleInfoResponse)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SCHEDULE_RECORD));
+	}
+
+	public Optional<Schedule> getScheduleById(Long scheduleId) {
+		return scheduleRepository.findById(scheduleId);
 	}
 }

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleService.java
@@ -9,11 +9,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.domain.schedule.common.mapper.ScheduleMapper;
+import im.toduck.domain.schedule.common.mapper.ScheduleRecordMapper;
 import im.toduck.domain.schedule.persistence.entity.Schedule;
 import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
 import im.toduck.domain.schedule.persistence.repository.ScheduleRecordRepository;
 import im.toduck.domain.schedule.persistence.repository.ScheduleRepository;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleDeleteRequest;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleCreateResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleInfoResponse;
@@ -57,4 +59,52 @@ public class ScheduleService {
 	public Optional<Schedule> getScheduleById(Long scheduleId) {
 		return scheduleRepository.findById(scheduleId);
 	}
+
+	public void deleteSingleDaySchedule(Schedule schedule, ScheduleDeleteRequest request) {
+		if (!request.isOneDayDeleted()) {
+			throw CommonException.from(ExceptionCode.NON_REPESTITIVE_ONE_SCHEDULE_NOT_PERIOD_DELETE);
+		}
+		scheduleRecordRepository.deleteByScheduleIdAndRecordDate(
+			schedule.getId(),
+			schedule.getScheduleDate().getStartDate());
+		scheduleRepository.delete(schedule);
+	}
+
+	public void deleteOneDayDeletionForRepeatingSchedule(Schedule schedule, ScheduleDeleteRequest request) {
+		scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+				request.queryDate(),
+				schedule.getId())
+			.ifPresentOrElse(scheduleRecord -> {
+				scheduleRecordRepository.softDeleteByScheduleIdAndRecordDate(
+					schedule.getId(),
+					request.queryDate());
+			}, () -> {
+				ScheduleRecord softDeletedScheduleRecord = ScheduleRecordMapper
+					.toSoftDeletedScheduleRecord(schedule, request);
+				scheduleRecordRepository.save(softDeletedScheduleRecord);
+			});
+	}
+
+	@Transactional
+	public void deleteAfterDeletionForRepeatingSchedule(Schedule schedule,
+		ScheduleDeleteRequest scheduleDeleteRequest) {
+		scheduleRecordRepository.findByCompletedScheduleAndAfterStartDate(
+				schedule.getId(),
+				scheduleDeleteRequest.queryDate())
+			.forEach(scheduleRecord -> {
+				Schedule save = scheduleRepository.save(
+					ScheduleMapper.copyToSchedule(schedule, scheduleDeleteRequest.queryDate()));
+				scheduleRecord.changeSchedule(save);
+			});
+		scheduleRecordRepository.deleteByNonCompletedScheduleAndBetweenStartDateAndEndDate(
+			schedule.getId(),
+			scheduleDeleteRequest.queryDate(),
+			schedule.getScheduleDate().getEndDate());
+		if (schedule.getScheduleDate().getStartDate().equals(scheduleDeleteRequest.queryDate())) {
+			scheduleRepository.delete(schedule);
+			return;
+		}
+		schedule.changeEndDate(scheduleDeleteRequest.queryDate().minusDays(1));
+	}
+
 }

--- a/src/main/java/im/toduck/domain/schedule/domain/usecase/ScheduleUseCase.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/usecase/ScheduleUseCase.java
@@ -75,15 +75,15 @@ public class ScheduleUseCase {
 		if (isSingleDaySchedule(schedule)) {
 			scheduleService.deleteSingleDaySchedule(schedule, scheduleDeleteRequest);
 			log.info("반복 X 하루 일정 삭제 성공 : {}", scheduleDeleteRequest.scheduleId());
-		} else {
-			if (scheduleDeleteRequest.isOneDayDeleted()) {
-				scheduleService.deleteOneDayDeletionForRepeatingSchedule(schedule, scheduleDeleteRequest);
-				log.info("반복 일정 중 하루 삭제 성공 : {}", scheduleDeleteRequest.scheduleId());
-			} else {
-				scheduleService.deleteAfterDeletionForRepeatingSchedule(schedule, scheduleDeleteRequest);
-				log.info("반복 일정 중 기간 삭제 성공 : {}", scheduleDeleteRequest.scheduleId());
-			}
+			return;
 		}
+		if (scheduleDeleteRequest.isOneDayDeleted()) {
+			scheduleService.deleteOneDayDeletionForRepeatingSchedule(schedule, scheduleDeleteRequest);
+			log.info("반복 일정 중 하루 삭제 성공 : {}", scheduleDeleteRequest.scheduleId());
+			return;
+		}
+		scheduleService.deleteAfterDeletionForRepeatingSchedule(schedule, scheduleDeleteRequest);
+		log.info("반복 일정 중 기간 삭제 성공 : {}", scheduleDeleteRequest.scheduleId());
 	}
 
 	private boolean isSingleDaySchedule(Schedule schedule) {

--- a/src/main/java/im/toduck/domain/schedule/persistence/entity/Schedule.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/entity/Schedule.java
@@ -1,5 +1,7 @@
 package im.toduck.domain.schedule.persistence.entity;
 
+import java.time.LocalDate;
+
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -88,5 +90,9 @@ public class Schedule extends BaseEntity {
 		this.location = location;
 		this.memo = memo;
 		this.user = user;
+	}
+
+	public void changeEndDate(LocalDate localDate) {
+		this.scheduleDate.changeEndDate(localDate);
 	}
 }

--- a/src/main/java/im/toduck/domain/schedule/persistence/entity/ScheduleRecord.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/entity/ScheduleRecord.java
@@ -1,9 +1,7 @@
 package im.toduck.domain.schedule.persistence.entity;
 
 import java.time.LocalDate;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
+import java.time.LocalDateTime;
 
 import im.toduck.global.base.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -23,8 +21,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "schedule_record")
 @Getter
 @NoArgsConstructor
-@SQLDelete(sql = "UPDATE schedule_record SET deleted_at = NOW() where id=?")
-@SQLRestriction(value = "deleted_at is NULL")
 public class ScheduleRecord extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,5 +45,13 @@ public class ScheduleRecord extends BaseEntity {
 
 	public void changeComplete(Boolean complete) {
 		this.isCompleted = complete;
+	}
+
+	public void changeSchedule(Schedule schedule) {
+		this.schedule = schedule;
+	}
+
+	public void softDelete() {
+		super.deletedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/im/toduck/domain/schedule/persistence/entity/ScheduleRecord.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/entity/ScheduleRecord.java
@@ -46,4 +46,8 @@ public class ScheduleRecord extends BaseEntity {
 		this.recordDate = recordDate;
 		this.schedule = schedule;
 	}
+
+	public void changeComplete(Boolean complete) {
+		this.isCompleted = complete;
+	}
 }

--- a/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustom.java
@@ -7,11 +7,23 @@ import java.util.Optional;
 import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
 
 public interface ScheduleRecordRepositoryCustom {
+	Optional<ScheduleRecord> findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+		LocalDate localDate,
+		Long aLong);
+
 	List<ScheduleRecord> findByScheduleAndBetweenStartDateAndEndDate(Long scheduleId, LocalDate startDate,
 		LocalDate endDate);
 
 	Optional<ScheduleRecord> findScheduleRecordFetchJoinSchedule(Long scheduleRecordId);
 
-	Optional<ScheduleRecord> findScheduleRecordByUserIdAndRecordDateAndScheduleId(Long userId, LocalDate localDate,
-		Long aLong);
+	void deleteByScheduleIdAndRecordDate(Long id, LocalDate startDate);
+
+	List<ScheduleRecord> findByCompletedScheduleAndAfterStartDate(Long scheduleId,
+		LocalDate startDate);
+
+	void deleteByNonCompletedScheduleAndBetweenStartDateAndEndDate(Long scheduleId,
+		LocalDate startDate,
+		LocalDate endDate);
+
+	void softDeleteByScheduleIdAndRecordDate(Long id, LocalDate localDate);
 }

--- a/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustom.java
@@ -21,7 +21,7 @@ public interface ScheduleRecordRepositoryCustom {
 	List<ScheduleRecord> findByCompletedScheduleAndAfterStartDate(Long scheduleId,
 		LocalDate startDate);
 
-	void deleteByNonCompletedScheduleAndBetweenStartDateAndEndDate(Long scheduleId,
+	void deleteByNonCompletedScheduleAndAfterStartDate(Long scheduleId,
 		LocalDate startDate,
 		LocalDate endDate);
 

--- a/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustom.java
@@ -11,4 +11,7 @@ public interface ScheduleRecordRepositoryCustom {
 		LocalDate endDate);
 
 	Optional<ScheduleRecord> findScheduleRecordFetchJoinSchedule(Long scheduleRecordId);
+
+	Optional<ScheduleRecord> findScheduleRecordByUserIdAndRecordDateAndScheduleId(Long userId, LocalDate localDate,
+		Long aLong);
 }

--- a/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustomImpl.java
@@ -38,7 +38,7 @@ public class ScheduleRecordRepositoryCustomImpl implements ScheduleRecordReposit
 	}
 
 	@Override
-	public void deleteByNonCompletedScheduleAndBetweenStartDateAndEndDate(Long scheduleId,
+	public void deleteByNonCompletedScheduleAndAfterStartDate(Long scheduleId,
 		LocalDate startDate,
 		LocalDate endDate) {
 		queryFactory

--- a/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustomImpl.java
@@ -21,6 +21,23 @@ public class ScheduleRecordRepositoryCustomImpl implements ScheduleRecordReposit
 	private final QSchedule schedule = QSchedule.schedule;
 
 	@Override
+	public Optional<ScheduleRecord> findScheduleRecordByUserIdAndRecordDateAndScheduleId(Long userId,
+		LocalDate localDate,
+		Long aLong) {
+		return Optional.ofNullable(
+			queryFactory
+				.select(scheduleRecord)
+				.from(scheduleRecord)
+				.leftJoin(scheduleRecord.schedule, schedule).fetchJoin()
+				.where(
+					scheduleRecord.schedule.id.eq(aLong)
+						.and(scheduleRecord.recordDate.eq(localDate))
+						.and(scheduleRecord.schedule.user.id.eq(userId))
+				)
+				.fetchOne());
+	}
+
+	@Override
 	public List<ScheduleRecord> findByScheduleAndBetweenStartDateAndEndDate(Long scheduleId, LocalDate startDate,
 		LocalDate endDate) {
 		return queryFactory

--- a/src/main/java/im/toduck/domain/schedule/persistence/vo/ScheduleDate.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/vo/ScheduleDate.java
@@ -34,4 +34,9 @@ public class ScheduleDate {
 			throw new VoException("시작일은 종료일보다 이전이어야 합니다.");
 		}
 	}
+
+	public void changeEndDate(LocalDate localDate) {
+		validate(this.startDate, localDate);
+		this.endDate = localDate;
+	}
 }

--- a/src/main/java/im/toduck/domain/schedule/presentation/api/ScheduleApi.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/api/ScheduleApi.java
@@ -1,13 +1,16 @@
 package im.toduck.domain.schedule.presentation.api;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleDeleteRequest;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleCreateResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleInfoResponse;
@@ -91,4 +94,51 @@ public interface ScheduleApi {
 		@AuthenticationPrincipal CustomUserDetails user,
 		@RequestParam Long scheduleRecordId
 	);
+
+	@Operation(
+		summary = "일정 완료 API",
+		description = """
+			일정 완료 상태를 변경합니다.
+			- 완료 처리를 원하는 일정의 Id와 날짜를 지정합니다.
+			- 일정 기록이 없다면 일정 기록이 생성됩니다.
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "일정 완료 상태 변경 성공"
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_USER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SCHEDULE),
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> completeSchedule(
+		@AuthenticationPrincipal CustomUserDetails user,
+		@RequestBody ScheduleCompleteRequest scheduleCompleteRequest
+	);
+
+	@Operation(
+		summary = "일정 삭제 API",
+		description = """
+			일정 및 일정 기록을 삭제합니다.
+			- 삭제를 원하는 일정의 Id와 삭제 기간을 지정합니다.
+			- 하루 일정을 원할 경우 isOneDayDeleted true 입니다.
+			- 특정 날짜 이후 삭제를 원할 경우 isOneDayDeleted false입니다 .
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "일정 삭제 성공"
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_USER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SCHEDULE),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NON_REPESTITIVE_ONE_SCHEDULE_NOT_PERIOD_DELETE),
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> deleteSchedule(
+		@AuthenticationPrincipal CustomUserDetails user,
+		@RequestBody @Valid ScheduleDeleteRequest scheduleDeleteRequest
+	);
+
 }

--- a/src/main/java/im/toduck/domain/schedule/presentation/controller/ScheduleController.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package im.toduck.domain.schedule.presentation.controller;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import im.toduck.domain.schedule.domain.usecase.ScheduleUseCase;
 import im.toduck.domain.schedule.presentation.api.ScheduleApi;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleCreateResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
@@ -57,5 +59,15 @@ public class ScheduleController implements ScheduleApi {
 	) {
 		return ResponseEntity.ok()
 			.body(ApiResponse.createSuccess(scheduleUseCase.getSchedule(user.getUserId(), scheduleRecordId)));
+	}
+
+	@PostMapping("/is-complete")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> completeSchedule(
+		@AuthenticationPrincipal CustomUserDetails user,
+		@RequestBody ScheduleCompleteRequest scheduleCompleteRequest
+	) {
+		scheduleUseCase.completeSchedule(user.getUserId(), scheduleCompleteRequest);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
 	}
 }

--- a/src/main/java/im/toduck/domain/schedule/presentation/controller/ScheduleController.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/controller/ScheduleController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +18,7 @@ import im.toduck.domain.schedule.domain.usecase.ScheduleUseCase;
 import im.toduck.domain.schedule.presentation.api.ScheduleApi;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleDeleteRequest;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleCreateResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
 import im.toduck.global.presentation.ApiResponse;
@@ -68,6 +70,16 @@ public class ScheduleController implements ScheduleApi {
 		@RequestBody ScheduleCompleteRequest scheduleCompleteRequest
 	) {
 		scheduleUseCase.completeSchedule(user.getUserId(), scheduleCompleteRequest);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@DeleteMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteSchedule(
+		@AuthenticationPrincipal CustomUserDetails user,
+		@RequestBody @Valid ScheduleDeleteRequest scheduleDeleteRequest
+	) {
+		scheduleUseCase.deleteSchedule(user.getUserId(), scheduleDeleteRequest);
 		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
 	}
 }

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleCompleteRequest.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleCompleteRequest.java
@@ -1,0 +1,17 @@
+package im.toduck.domain.schedule.presentation.dto.request;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ScheduleCompleteRequest(
+	@Schema(description = "일정 Id", example = "1")
+	Long scheduleId,
+	@Schema(description = "일정 완료 여부", example = "false")
+	Boolean isComplete,
+	@Schema(description = "일정 조회 날짜", example = "2024-08-31")
+	LocalDate queryDate
+) {
+}

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleDeleteRequest.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleDeleteRequest.java
@@ -1,0 +1,21 @@
+package im.toduck.domain.schedule.presentation.dto.request;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record ScheduleDeleteRequest(
+	@Schema(description = "일정 Id", example = "1")
+	@NotNull
+	Long scheduleId,
+	@Schema(description = "일정 하루 삭제 OR 이후 삭제 여부[true ", example = "true")
+	@NotNull
+	Boolean isOneDayDeleted,
+	@Schema(description = "일정 삭제 날짜", example = "2024-08-31")
+	@NotNull
+	LocalDate queryDate
+) {
+}

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleDeleteRequest.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleDeleteRequest.java
@@ -11,7 +11,7 @@ public record ScheduleDeleteRequest(
 	@Schema(description = "일정 Id", example = "1")
 	@NotNull
 	Long scheduleId,
-	@Schema(description = "일정 하루 삭제 OR 이후 삭제 여부[true ", example = "true")
+	@Schema(description = "일정 하루 삭제 OR 이후 삭제 여부 ", example = "true")
 	@NotNull
 	Boolean isOneDayDeleted,
 	@Schema(description = "일정 삭제 날짜", example = "2024-08-31")

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleHeadResponse.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleHeadResponse.java
@@ -75,6 +75,7 @@ public record ScheduleHeadResponse(
 		@Schema(description = "장소", example = "일정 장소")
 		String location
 	) {
+		@Schema(description = "일정 기록 DTO")
 		public record ScheduleRecordDto(
 			@Schema(description = "일정 고유 id", example = "1")
 			Long scheduleRecordId,

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleHeadResponse.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleHeadResponse.java
@@ -2,12 +2,14 @@ package im.toduck.domain.schedule.presentation.dto.response;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 
 import im.toduck.domain.person.persistence.entity.PlanCategory;
@@ -81,11 +83,16 @@ public record ScheduleHeadResponse(
 			@Schema(description = "일정 기록 날짜", example = "2024-08-31")
 			@JsonSerialize(using = LocalDateSerializer.class)
 			@JsonFormat(pattern = "yyyy-MM-dd")
-			LocalDate recordDate
+			LocalDate recordDate,
+			@Schema(description = "일정 기록 삭제 날짜", example = "2024-08-31T14:30:00")
+			@JsonSerialize(using = LocalDateTimeSerializer.class)
+			@JsonFormat(pattern = "yyyy-MM-ddTHH:mm:ss")
+			LocalDateTime deletedAt
+
 		) {
 			public static ScheduleRecordDto from(ScheduleRecord scheduleRecord) {
 				return new ScheduleRecordDto(scheduleRecord.getId(), scheduleRecord.getIsCompleted(),
-					scheduleRecord.getRecordDate());
+					scheduleRecord.getRecordDate(), scheduleRecord.getDeletedAt());
 			}
 		}
 	}

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleInfoResponse.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleInfoResponse.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "일정 기록에 대한 모든 정보를 담은 응답 DTO")
 public record ScheduleInfoResponse(
 	@Schema(description = "일정 Id", example = "1")
 	Long scheduleId,

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleInfoResponse.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleInfoResponse.java
@@ -2,12 +2,14 @@ package im.toduck.domain.schedule.presentation.dto.response;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 
 import im.toduck.domain.person.persistence.entity.PlanCategory;
@@ -64,7 +66,11 @@ public record ScheduleInfoResponse(
 	@Schema(description = "일정 기록 날짜", example = "2024-08-31")
 	@JsonSerialize(using = LocalDateSerializer.class)
 	@JsonFormat(pattern = "yyyy-MM-dd")
-	LocalDate recordDate
+	LocalDate recordDate,
 
+	@Schema(description = "일정 기록 삭제 날짜", example = "2024-08-31T14:30:00")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonFormat(pattern = "yyyy-MM-ddTHH:mm:ss")
+	LocalDateTime deletedAt
 ) {
 }

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -58,9 +58,6 @@ public enum ExceptionCode {
 		"차단 해제 시 차단 정보를 찾을 수 없을 때 발생하는 오류입니다."),
 	ALREADY_BLOCKED(HttpStatus.CONFLICT, 40205, "이미 차단된 사용자입니다.",
 		"해당 사용자를 이미 차단한 경우 발생하는 오류입니다."),
-	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 40206, "일정 기록을 찾을 수 없습니다.",
-		"일정 기록을 찾을 수 없을 때 발생하는 오류입니다."),
-	NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, 40207, "일정을 찾을 수 없습니다."),
 
 	/* 404xx */
 	NOT_FOUND_SOCIAL_BOARD(HttpStatus.NOT_FOUND, 40401, "게시글을 찾을 수 없습니다."),
@@ -83,6 +80,13 @@ public enum ExceptionCode {
 	INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, 40417, "검색 키워드는 null일 수 없습니다."),
 	NOT_FOUND_PARENT_COMMENT(HttpStatus.NOT_FOUND, 40418, "부모 댓글을 찾을 수 없습니다."),
 	INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, 40419, "답글은 부모 댓글이 될 수 없습니다."),
+
+	/* 411xx schedule */
+	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",
+		"일정 기록을 찾을 수 없을 때 발생하는 오류입니다."),
+	NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, 41102, "일정을 찾을 수 없습니다."),
+	NON_REPESTITIVE_ONE_SCHEDULE_NOT_PERIOD_DELETE(HttpStatus.BAD_REQUEST, 41103, "반복되지 않는 1일 일정은 기간 삭제가 불가능합니다.",
+		"반복되지 않는 1일 일정은 기간 삭제가 불가능한 요청을 클라이언트에서 보냈을 때 발생합니다."),
 
 	/* 432xx */
 	NOT_FOUND_ROUTINE(HttpStatus.NOT_FOUND, 43201, "권한이 없거나 존재하지 않는 루틴입니다."),

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -85,8 +85,8 @@ public enum ExceptionCode {
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",
 		"일정 기록을 찾을 수 없을 때 발생하는 오류입니다."),
 	NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, 41102, "일정을 찾을 수 없습니다."),
-	NON_REPESTITIVE_ONE_SCHEDULE_NOT_PERIOD_DELETE(HttpStatus.BAD_REQUEST, 41103, "반복되지 않는 1일 일정은 기간 삭제가 불가능합니다.",
-		"반복되지 않는 1일 일정은 기간 삭제가 불가능한 요청을 클라이언트에서 보냈을 때 발생합니다."),
+	NON_REPESTITIVE_ONE_SCHEDULE_NOT_PERIOD_DELETE(HttpStatus.BAD_REQUEST, 41103, "반복되지 않는 하루 일정은 기간 삭제가 불가능합니다.",
+		"반복되지 않는 하루 일정은 기간 삭제가 불가능한 요청을 클라이언트에서 보냈을 때 발생합니다."),
 
 	/* 432xx */
 	NOT_FOUND_ROUTINE(HttpStatus.NOT_FOUND, 43201, "권한이 없거나 존재하지 않는 루틴입니다."),

--- a/src/test/java/im/toduck/domain/schedule/persistence/repository/ScheduleRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/schedule/persistence/repository/ScheduleRecordRepositoryTest.java
@@ -353,7 +353,7 @@ class ScheduleRecordRepositoryTest extends RepositoryTest {
 			ScheduleRecord savedScheduleRecord = testFixtureBuilder.buildScheduleRecord(
 				IS_NOT_COMPLETE_SCHEDULE_RECORD(QUERY_END_DATE, savedSchedule));
 			// when
-			scheduleRecordRepository.deleteByNonCompletedScheduleAndBetweenStartDateAndEndDate(savedSchedule.getId(),
+			scheduleRecordRepository.deleteByNonCompletedScheduleAndAfterStartDate(savedSchedule.getId(),
 				QUERY_START_DATE, QUERY_END_DATE);
 			entityManager.flush();
 			entityManager.clear();
@@ -373,7 +373,7 @@ class ScheduleRecordRepositoryTest extends RepositoryTest {
 				IS_COMPLETE_SCHEDULE_RECORD(QUERY_END_DATE, savedSchedule));
 
 			// when
-			scheduleRecordRepository.deleteByNonCompletedScheduleAndBetweenStartDateAndEndDate(savedSchedule.getId(),
+			scheduleRecordRepository.deleteByNonCompletedScheduleAndAfterStartDate(savedSchedule.getId(),
 				QUERY_START_DATE, QUERY_END_DATE);
 			entityManager.flush();
 			entityManager.clear();


### PR DESCRIPTION
## ✨ 작업 내용


**1️⃣ 일정 완료 API 개발**

> 일정 완료 여부를 변경하는 요청일 시 일정 기록(Schedule_record)를 생성하도록 구현했습니다.
> 복잡한 로직은 없으니 테스트 케이스만 보시고 이상한 점 말씀해주세요

  <br/>

**2️⃣ 일정 삭제 API 개발**

> 일정 삭제 API 는 다소 복잡합니다. 
> 일정 기록 삭제에 전체 삭제는 존재하지 않고 특정 날짜 이후 삭제와 하루 삭제만 존재합니다.
> ScheduleRecord의 deletedAt을 사용했습니다. soft delete를 적용하지 않고 해당 값의 null 여부로 삭제되었는지 판단합니다.
> 특정 날짜 이후 삭제는 완료 기록들은 남겨두고 미 완료 기록들만 삭제합니다.


기간 x 반복 x

- 바로 삭제 ( 완료 여부 상관 없이 삭제 , 하루 삭제만 존재)

기간 x  반복 O

- 하루 삭제
    
    ScheduleRecord 에 deleteAt필드를 사용할 예정
    
    - 해당 날짜에 대한 일정 기록이 있을시
        - deleteAt 를 null
    - 해당 날짜에 대한 일정 기록이 없을시
        - deleteAt 초기화
- 특정 날짜 이후 삭제
    - 기간 x 반복 O → 기간 O 반복 O 로 수정할 것임
        - endDate날짜를 특정 날짜로 수정
    - 특정 날짜 이후 일정 기록들도 삭제
        - ***단,완료된 일정들은 하루짜리 반복 x 일정으로 수정***

기간 o 반복 O,X

- 하루 삭제
    - 위와 동일
- 특정 날짜 이후 삭제
    - 위와 동일
  <br/>



## ✅ 리뷰 요구사항(선택)
- 코드와 로직이 다소 복잡한데 테스트 코드를 잘 작성했는지 피드백 부탁드립니다
