### PR TITLE
일정 수정 API 개발

### DIFF
--- a/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleMapper.java
+++ b/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleMapper.java
@@ -10,8 +10,8 @@ import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
 import im.toduck.domain.schedule.persistence.vo.ScheduleDate;
 import im.toduck.domain.schedule.persistence.vo.ScheduleTime;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
-import im.toduck.domain.schedule.presentation.dto.response.ScheduleCreateResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
+import im.toduck.domain.schedule.presentation.dto.response.ScheduleIdResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleInfoResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.helper.DaysOfWeekBitmask;
@@ -41,8 +41,8 @@ public class ScheduleMapper {
 			user);
 	}
 
-	public static ScheduleCreateResponse toScheduleCreateResponse(final Schedule schedule) {
-		return ScheduleCreateResponse.builder()
+	public static ScheduleIdResponse toScheduleIdResponse(final Schedule schedule) {
+		return ScheduleIdResponse.builder()
 			.scheduleId(schedule.getId())
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleRecordMapper.java
+++ b/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleRecordMapper.java
@@ -1,9 +1,10 @@
 package im.toduck.domain.schedule.common.mapper;
 
+import java.time.LocalDate;
+
 import im.toduck.domain.schedule.persistence.entity.Schedule;
 import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
-import im.toduck.domain.schedule.presentation.dto.request.ScheduleDeleteRequest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -18,10 +19,10 @@ public class ScheduleRecordMapper {
 			.build();
 	}
 
-	public static ScheduleRecord toSoftDeletedScheduleRecord(Schedule schedule, ScheduleDeleteRequest request) {
+	public static ScheduleRecord toSoftDeletedScheduleRecord(Schedule schedule, LocalDate queryDate) {
 		ScheduleRecord scheduleRecord = ScheduleRecord.builder()
 			.isCompleted(false)
-			.recordDate(request.queryDate())
+			.recordDate(queryDate)
 			.schedule(schedule)
 			.build();
 		scheduleRecord.softDelete();

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleModifyService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleModifyService.java
@@ -1,9 +1,6 @@
 package im.toduck.domain.schedule.domain.service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,52 +11,18 @@ import im.toduck.domain.schedule.persistence.entity.Schedule;
 import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
 import im.toduck.domain.schedule.persistence.repository.ScheduleRecordRepository;
 import im.toduck.domain.schedule.persistence.repository.ScheduleRepository;
-import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleDeleteRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleModifyRequest;
-import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleIdResponse;
-import im.toduck.domain.schedule.presentation.dto.response.ScheduleInfoResponse;
-import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class ScheduleService {
+public class ScheduleModifyService {
 	private final ScheduleRepository scheduleRepository;
 	private final ScheduleRecordRepository scheduleRecordRepository;
-
-	@Transactional
-	public ScheduleIdResponse createSchedule(User user, ScheduleCreateRequest request) {
-		Schedule schedule = ScheduleMapper.toSchedule(user, request);
-		Schedule save = scheduleRepository.save(schedule);
-		return ScheduleMapper.toScheduleIdResponse(save);
-	}
-
-	@Transactional(readOnly = true)
-	public ScheduleHeadResponse getRangeSchedule(User user, LocalDate startDate, LocalDate endDate) {
-		List<ScheduleHeadResponse.ScheduleHeadDto> scheduleHeadDtos = new ArrayList<>();
-		scheduleRepository.findSchedules(user.getId(), startDate, endDate)
-			.forEach(schedule -> {
-				List<ScheduleRecord> scheduleRecordList = scheduleRecordRepository
-					.findByScheduleAndBetweenStartDateAndEndDate(schedule.getId(), startDate, endDate);
-				scheduleHeadDtos.add(ScheduleMapper.toScheduleHeadDto(schedule, scheduleRecordList));
-			});
-		return ScheduleMapper.toScheduleHeadResponse(startDate, endDate, scheduleHeadDtos);
-	}
-
-	@Transactional(readOnly = true)
-	public ScheduleInfoResponse getSchedule(Long scheduleRecordId) {
-		return scheduleRecordRepository.findScheduleRecordFetchJoinSchedule(scheduleRecordId)
-			.map(ScheduleMapper::toScheduleInfoResponse)
-			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SCHEDULE_RECORD));
-	}
-
-	public Optional<Schedule> getScheduleById(Long scheduleId) {
-		return scheduleRepository.findById(scheduleId);
-	}
 
 	public void deleteSingleDaySchedule(Schedule schedule, ScheduleDeleteRequest request) {
 		if (!request.isOneDayDeleted()) {
@@ -72,35 +35,16 @@ public class ScheduleService {
 	}
 
 	public void deleteOneDayDeletionForRepeatingSchedule(Schedule schedule, ScheduleDeleteRequest request) {
-		scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
-				request.queryDate(),
-				schedule.getId())
-			.ifPresentOrElse(scheduleRecord -> {
-				scheduleRecordRepository.softDeleteByScheduleIdAndRecordDate(
-					schedule.getId(),
-					request.queryDate());
-			}, () -> {
-				ScheduleRecord softDeletedScheduleRecord = ScheduleRecordMapper
-					.toSoftDeletedScheduleRecord(schedule, request.queryDate());
-				scheduleRecordRepository.save(softDeletedScheduleRecord);
-			});
+		softDeleteScheduleRecord(request.queryDate(), schedule);
 	}
 
 	@Transactional
 	public void deleteAfterDeletionForRepeatingSchedule(Schedule schedule,
 		ScheduleDeleteRequest scheduleDeleteRequest) {
-		scheduleRecordRepository.findByCompletedScheduleAndAfterStartDate(
-				schedule.getId(),
-				scheduleDeleteRequest.queryDate())
-			.forEach(scheduleRecord -> {
-				Schedule save = scheduleRepository.save(
-					ScheduleMapper.copyToSchedule(schedule, scheduleDeleteRequest.queryDate()));
-				scheduleRecord.changeSchedule(save);
-			});
-		scheduleRecordRepository.deleteByNonCompletedScheduleAndAfterStartDate(
-			schedule.getId(),
-			scheduleDeleteRequest.queryDate(),
-			schedule.getScheduleDate().getEndDate());
+
+		// 특정 날짜의 일정 기록이 있는지 확인하고 있으면 soft delete, 없으면 soft delete된 일정 기록 생성
+		deleteScheduleRecord(schedule, scheduleDeleteRequest.queryDate());
+
 		if (schedule.getScheduleDate().getStartDate().equals(scheduleDeleteRequest.queryDate())) {
 			scheduleRepository.delete(schedule);
 			return;
@@ -108,27 +52,48 @@ public class ScheduleService {
 		schedule.changeEndDate(scheduleDeleteRequest.queryDate().minusDays(1));
 	}
 
+	// 특정 날짜 이후 기록 중 완료 기록이 있다면 각각 하루짜리 반복 없는 일정 기록으로 변경
+	private void deleteScheduleRecord(Schedule schedule, LocalDate scheduleDeleteRequest) {
+		scheduleRecordRepository.findByCompletedScheduleAndAfterStartDate(
+				schedule.getId(),
+				scheduleDeleteRequest)
+			.forEach(scheduleRecord -> {
+				Schedule save = scheduleRepository.save(
+					ScheduleMapper.copyToSchedule(schedule, scheduleDeleteRequest));
+				scheduleRecord.changeSchedule(save);
+			});
+		scheduleRecordRepository.deleteByNonCompletedScheduleAndAfterStartDate(
+			schedule.getId(),
+			scheduleDeleteRequest,
+			schedule.getScheduleDate().getEndDate());
+	}
+
+	@Transactional
 	public ScheduleIdResponse updateSingleDate(Schedule schedule, ScheduleModifyRequest request) {
 		if (isSingleDaySchedule(schedule)) {
 			schedule.updateInfo(request.scheduleData());
 			return ScheduleMapper.toScheduleIdResponse(schedule);
 		}
-		// 특정 날짜의 일정 기록이 있는지 확인하고 있으면 soft delete, 없으면 soft delete된 일정 기록 생성
+		softDeleteScheduleRecord(request.queryDate(), schedule);
+		Schedule newSchedule = ScheduleMapper.toSchedule(schedule.getUser(), request.scheduleData());
+		return ScheduleMapper
+			.toScheduleIdResponse(scheduleRepository.save(newSchedule));
+	}
+
+	// 특정 날짜의 일정 기록이 있는지 확인하고 있으면 soft delete, 없으면 soft delete된 일정 기록 생성
+	private void softDeleteScheduleRecord(LocalDate request, Schedule schedule) {
 		scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
-				request.queryDate(),
+				request,
 				schedule.getId())
 			.ifPresentOrElse(scheduleRecord -> {
 				scheduleRecordRepository.softDeleteByScheduleIdAndRecordDate(
 					schedule.getId(),
-					request.queryDate());
+					request);
 			}, () -> {
 				ScheduleRecord softDeletedScheduleRecord = ScheduleRecordMapper
-					.toSoftDeletedScheduleRecord(schedule, request.queryDate());
+					.toSoftDeletedScheduleRecord(schedule, request);
 				scheduleRecordRepository.save(softDeletedScheduleRecord);
 			});
-		Schedule newSchedule = ScheduleMapper.toSchedule(schedule.getUser(), request.scheduleData());
-		return ScheduleMapper
-			.toScheduleIdResponse(scheduleRepository.save(newSchedule));
 	}
 
 	private boolean isSingleDaySchedule(Schedule schedule) {
@@ -136,21 +101,10 @@ public class ScheduleService {
 			&& schedule.getDaysOfWeekBitmask() == null;
 	}
 
+	@Transactional
 	public ScheduleIdResponse updateAfterDate(Schedule schedule, ScheduleModifyRequest request) {
 		// 특정 날짜 이후 기록 중 완료 기록이 있다면 각각 하루짜리 반복 없는 일정 기록으로 변경
-		scheduleRecordRepository.findByCompletedScheduleAndAfterStartDate(
-				schedule.getId(),
-				request.queryDate())
-			.forEach(scheduleRecord -> {
-				Schedule save = scheduleRepository.save(
-					ScheduleMapper.copyToSchedule(schedule, request.queryDate()));
-				scheduleRecord.changeSchedule(save);
-			});
-		// 특정 날짜 이후 기록 중 미완료 기록이 있다면 삭제
-		scheduleRecordRepository.deleteByNonCompletedScheduleAndAfterStartDate(
-			schedule.getId(),
-			request.queryDate(),
-			schedule.getScheduleDate().getEndDate());
+		deleteScheduleRecord(schedule, request.queryDate());
 		// 특정 날짜가 시작일이라면 해당 일정 삭제
 		if (schedule.getScheduleDate().getStartDate().equals(request.queryDate())) {
 			scheduleRepository.delete(schedule);

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleReadService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleReadService.java
@@ -1,0 +1,60 @@
+package im.toduck.domain.schedule.domain.service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.schedule.common.mapper.ScheduleMapper;
+import im.toduck.domain.schedule.persistence.entity.Schedule;
+import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
+import im.toduck.domain.schedule.persistence.repository.ScheduleRecordRepository;
+import im.toduck.domain.schedule.persistence.repository.ScheduleRepository;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
+import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
+import im.toduck.domain.schedule.presentation.dto.response.ScheduleIdResponse;
+import im.toduck.domain.schedule.presentation.dto.response.ScheduleInfoResponse;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleReadService {
+	private final ScheduleRepository scheduleRepository;
+	private final ScheduleRecordRepository scheduleRecordRepository;
+
+	@Transactional
+	public ScheduleIdResponse createSchedule(User user, ScheduleCreateRequest request) {
+		Schedule schedule = ScheduleMapper.toSchedule(user, request);
+		Schedule save = scheduleRepository.save(schedule);
+		return ScheduleMapper.toScheduleIdResponse(save);
+	}
+
+	@Transactional(readOnly = true)
+	public ScheduleHeadResponse getRangeSchedule(User user, LocalDate startDate, LocalDate endDate) {
+		List<ScheduleHeadResponse.ScheduleHeadDto> scheduleHeadDtos = new ArrayList<>();
+		scheduleRepository.findSchedules(user.getId(), startDate, endDate)
+			.forEach(schedule -> {
+				List<ScheduleRecord> scheduleRecordList = scheduleRecordRepository
+					.findByScheduleAndBetweenStartDateAndEndDate(schedule.getId(), startDate, endDate);
+				scheduleHeadDtos.add(ScheduleMapper.toScheduleHeadDto(schedule, scheduleRecordList));
+			});
+		return ScheduleMapper.toScheduleHeadResponse(startDate, endDate, scheduleHeadDtos);
+	}
+
+	@Transactional(readOnly = true)
+	public ScheduleInfoResponse getSchedule(Long scheduleRecordId) {
+		return scheduleRecordRepository.findScheduleRecordFetchJoinSchedule(scheduleRecordId)
+			.map(ScheduleMapper::toScheduleInfoResponse)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SCHEDULE_RECORD));
+	}
+
+	public Optional<Schedule> getScheduleById(Long scheduleId) {
+		return scheduleRepository.findById(scheduleId);
+	}
+}

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleRecordService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleRecordService.java
@@ -21,7 +21,7 @@ public class ScheduleRecordService {
 	public Optional<ScheduleRecord> getScheduleRecordWithSchedule(Long userId,
 		ScheduleCompleteRequest scheduleCompleteRequest) {
 		return scheduleRecordRepository
-			.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+			.findScheduleRecordByRecordDateAndScheduleId(
 				scheduleCompleteRequest.queryDate(),
 				scheduleCompleteRequest.scheduleId());
 	}

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleService.java
@@ -72,7 +72,7 @@ public class ScheduleService {
 	}
 
 	public void deleteOneDayDeletionForRepeatingSchedule(Schedule schedule, ScheduleDeleteRequest request) {
-		scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+		scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
 				request.queryDate(),
 				schedule.getId())
 			.ifPresentOrElse(scheduleRecord -> {
@@ -114,7 +114,7 @@ public class ScheduleService {
 			return ScheduleMapper.toScheduleIdResponse(schedule);
 		}
 		// 특정 날짜의 일정 기록이 있는지 확인하고 있으면 soft delete, 없으면 soft delete된 일정 기록 생성
-		scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+		scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
 				request.queryDate(),
 				schedule.getId())
 			.ifPresentOrElse(scheduleRecord -> {

--- a/src/main/java/im/toduck/domain/schedule/persistence/entity/Schedule.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/entity/Schedule.java
@@ -10,6 +10,7 @@ import im.toduck.domain.routine.persistence.vo.PlanCategoryColor;
 import im.toduck.domain.schedule.common.converter.ScheduleDaysOfWeekBitmaskConverter;
 import im.toduck.domain.schedule.persistence.vo.ScheduleDate;
 import im.toduck.domain.schedule.persistence.vo.ScheduleTime;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.base.entity.BaseEntity;
 import im.toduck.global.helper.DaysOfWeekBitmask;
@@ -94,5 +95,20 @@ public class Schedule extends BaseEntity {
 
 	public void changeEndDate(LocalDate localDate) {
 		this.scheduleDate.changeEndDate(localDate);
+	}
+
+	public void updateInfo(ScheduleCreateRequest updateDto) {
+		DaysOfWeekBitmask daysOfWeekBitmask = null;
+		if (updateDto.daysOfWeek() != null) {
+			daysOfWeekBitmask = DaysOfWeekBitmask.createByDayOfWeek(updateDto.daysOfWeek());
+		}
+		this.title = updateDto.title();
+		this.category = updateDto.category();
+		this.color = PlanCategoryColor.from(updateDto.color());
+		this.scheduleDate = ScheduleDate.from(updateDto.startDate(), updateDto.endDate());
+		this.scheduleTime = ScheduleTime.from(updateDto.isAllDay(), updateDto.time(), updateDto.alarm());
+		this.daysOfWeekBitmask = daysOfWeekBitmask;
+		this.location = updateDto.location();
+		this.memo = updateDto.memo();
 	}
 }

--- a/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustom.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import im.toduck.domain.schedule.persistence.entity.ScheduleRecord;
 
 public interface ScheduleRecordRepositoryCustom {
-	Optional<ScheduleRecord> findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+	Optional<ScheduleRecord> findScheduleRecordByRecordDateAndScheduleId(
 		LocalDate localDate,
 		Long aLong);
 

--- a/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/repository/querydsl/ScheduleRecordRepositoryCustomImpl.java
@@ -77,7 +77,7 @@ public class ScheduleRecordRepositoryCustomImpl implements ScheduleRecordReposit
 	}
 
 	@Override
-	public Optional<ScheduleRecord> findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+	public Optional<ScheduleRecord> findScheduleRecordByRecordDateAndScheduleId(
 		LocalDate localDate,
 		Long aLong) {
 		return Optional.ofNullable(

--- a/src/main/java/im/toduck/domain/schedule/presentation/api/ScheduleApi.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/api/ScheduleApi.java
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleDeleteRequest;
-import im.toduck.domain.schedule.presentation.dto.response.ScheduleCreateResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
+import im.toduck.domain.schedule.presentation.dto.response.ScheduleIdResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleInfoResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
@@ -36,14 +36,14 @@ public interface ScheduleApi {
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
-			responseClass = ScheduleCreateResponse.class,
+			responseClass = ScheduleIdResponse.class,
 			description = "일정 생성 성공, 생성된 일정의 Id를 반환합니다."
 		),
 		errors = {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_USER),
 		}
 	)
-	ResponseEntity<ApiResponse<ScheduleCreateResponse>> createSchedule(
+	ResponseEntity<ApiResponse<ScheduleIdResponse>> createSchedule(
 		@RequestBody @Valid ScheduleCreateRequest request,
 		@AuthenticationPrincipal CustomUserDetails user
 	);

--- a/src/main/java/im/toduck/domain/schedule/presentation/api/ScheduleApi.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/api/ScheduleApi.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleDeleteRequest;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleModifyRequest;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleIdResponse;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleInfoResponse;
@@ -139,6 +140,31 @@ public interface ScheduleApi {
 	ResponseEntity<ApiResponse<Map<String, Object>>> deleteSchedule(
 		@AuthenticationPrincipal CustomUserDetails user,
 		@RequestBody @Valid ScheduleDeleteRequest scheduleDeleteRequest
+	);
+
+	@Operation(
+		summary = "일정 수정 API",
+		description = """
+			일정을 수정합니다.
+			- 수정을 원하는 일정의 Id와 수정을 원하는 날짜, 하루or이후 일정 수정 여부 그리고 수정할 정보를 지정합니다.
+			- 수정된 일정의 Id를 반환합니다.
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = ScheduleIdResponse.class,
+			description = "일정 수정 성공, 수정된 일정의 Id를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_USER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_SCHEDULE),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NON_REPESTITIVE_ONE_SCHEDULE_NOT_PERIOD_DELETE),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.PERIOD_SCHEDULE_CANNOT_AFTER_DATE_UPDATE),
+		}
+	)
+	ResponseEntity<ApiResponse<ScheduleIdResponse>> updateSchedule(
+		@AuthenticationPrincipal CustomUserDetails user,
+		@RequestBody @Valid ScheduleModifyRequest request
 	);
 
 }

--- a/src/main/java/im/toduck/domain/schedule/presentation/controller/ScheduleController.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/controller/ScheduleController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,8 +20,9 @@ import im.toduck.domain.schedule.presentation.api.ScheduleApi;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCompleteRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleCreateRequest;
 import im.toduck.domain.schedule.presentation.dto.request.ScheduleDeleteRequest;
-import im.toduck.domain.schedule.presentation.dto.response.ScheduleCreateResponse;
+import im.toduck.domain.schedule.presentation.dto.request.ScheduleModifyRequest;
 import im.toduck.domain.schedule.presentation.dto.response.ScheduleHeadResponse;
+import im.toduck.domain.schedule.presentation.dto.response.ScheduleIdResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -34,7 +36,7 @@ public class ScheduleController implements ScheduleApi {
 
 	@PostMapping
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<ScheduleCreateResponse>> createSchedule(
+	public ResponseEntity<ApiResponse<ScheduleIdResponse>> createSchedule(
 		@RequestBody @Valid ScheduleCreateRequest request,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
@@ -81,5 +83,15 @@ public class ScheduleController implements ScheduleApi {
 	) {
 		scheduleUseCase.deleteSchedule(user.getUserId(), scheduleDeleteRequest);
 		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@PutMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<ScheduleIdResponse>> updateSchedule(
+		@AuthenticationPrincipal CustomUserDetails user,
+		@RequestBody @Valid ScheduleModifyRequest request
+	) {
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(scheduleUseCase.updateSchedule(user.getUserId(), request)));
 	}
 }

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleModifyRequest.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleModifyRequest.java
@@ -1,0 +1,24 @@
+package im.toduck.domain.schedule.presentation.dto.request;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "일정 수정 요청 DTO")
+public record ScheduleModifyRequest(
+	@Schema(description = "해당 일정의 모 일정 ID", example = "1")
+	Long scheduleId,
+
+	@Schema(description = "하루 일정 혹은 이후 일정 수정 여부", example = "true")
+	Boolean isOneDayDeleted,
+
+	@Schema(description = "일정 수정 날짜", example = "2025-02-07")
+	LocalDate queryDate,
+
+	@Schema(description = "일정 수정 데이터 ")
+	ScheduleCreateRequest scheduleData // TODO : 추후 분리해야한다면 분리
+
+) {
+}

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleIdResponse.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleIdResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 
 @Schema(description = "일정 생성 응답 DTO")
 @Builder
-public record ScheduleCreateResponse(
+public record ScheduleIdResponse(
 	@Schema(description = "생성된 일정 Id", example = "1")
 	Long scheduleId
 ) {

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -87,6 +87,11 @@ public enum ExceptionCode {
 	NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, 41102, "일정을 찾을 수 없습니다."),
 	NON_REPESTITIVE_ONE_SCHEDULE_NOT_PERIOD_DELETE(HttpStatus.BAD_REQUEST, 41103, "반복되지 않는 하루 일정은 기간 삭제가 불가능합니다.",
 		"반복되지 않는 하루 일정은 기간 삭제가 불가능한 요청을 클라이언트에서 보냈을 때 발생합니다."),
+	ONE_DAY__NONREPEATABLE_SCHEDULE_CANNOT_AFTER_DATE_UPDATE(HttpStatus.FORBIDDEN, 41104,
+		"반복되지 않는 하루 일정은 하루 삭제만 가능합니다.",
+		"반복되지 않는 하루 일정을 하루 삭제만 가능한 요청을 클라이언트에서 일괄 수정 보냈을 때 발생합니다."),
+	PERIOD_SCHEDULE_CANNOT_AFTER_DATE_UPDATE(HttpStatus.BAD_REQUEST, 41105, "기간 일정은 하루 삭제만 가능합니다.",
+		"기간 일정을 하루 삭제만 가능한 요청을 클라이언트에서 일괄 수정 보냈을 때 발생합니다."),
 
 	/* 432xx */
 	NOT_FOUND_ROUTINE(HttpStatus.NOT_FOUND, 43201, "권한이 없거나 존재하지 않는 루틴입니다."),

--- a/src/test/java/im/toduck/domain/schedule/domain/usecase/ScheduleUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/schedule/domain/usecase/ScheduleUseCaseTest.java
@@ -382,7 +382,7 @@ class ScheduleUseCaseTest extends ServiceTest {
 			// when
 			scheduleUsecase.completeSchedule(savedUser.getId(), request);
 			// then
-			Optional<ScheduleRecord> scheduleRecord = scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+			Optional<ScheduleRecord> scheduleRecord = scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
 				MOCK_DATE,
 				savedSchedule.getId());
 			assertSoftly(softly -> {
@@ -406,7 +406,7 @@ class ScheduleUseCaseTest extends ServiceTest {
 			scheduleUsecase.completeSchedule(savedUser.getId(), request);
 
 			// then
-			Optional<ScheduleRecord> scheduleRecord = scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+			Optional<ScheduleRecord> scheduleRecord = scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
 				MOCK_DATE,
 				savedSchedule.getId());
 
@@ -558,7 +558,7 @@ class ScheduleUseCaseTest extends ServiceTest {
 			scheduleUsecase.deleteSchedule(testFixtureBuilder.buildUser(GENERAL_USER()).getId(), request);
 
 			// then
-			Optional<ScheduleRecord> scheduleRecord = scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+			Optional<ScheduleRecord> scheduleRecord = scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
 				LocalDate.of(2025, 1, 10),
 				savedSchedule.getId());
 			assertSoftly(softly -> {
@@ -946,7 +946,7 @@ class ScheduleUseCaseTest extends ServiceTest {
 					scheduleRecord1.getId());
 				Optional<ScheduleRecord> notCompletedScheduleRecord = scheduleRecordRepository
 					.findById(scheduleRecord2.getId());
-				Optional<ScheduleRecord> softDeletedScheduleRecord = scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+				Optional<ScheduleRecord> softDeletedScheduleRecord = scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
 					LocalDate.of(2025, 1, 5),
 					savedSchedule.getId());
 
@@ -1024,7 +1024,7 @@ class ScheduleUseCaseTest extends ServiceTest {
 					scheduleRecord1.getId());
 				Optional<ScheduleRecord> notCompletedScheduleRecord = scheduleRecordRepository
 					.findById(scheduleRecord2.getId());
-				Optional<ScheduleRecord> softDeletedScheduleRecord = scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+				Optional<ScheduleRecord> softDeletedScheduleRecord = scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
 					LocalDate.of(2025, 1, 5),
 					savedSchedule.getId());
 				assertSoftly(softly -> {

--- a/src/test/java/im/toduck/domain/schedule/persistence/repository/ScheduleRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/schedule/persistence/repository/ScheduleRecordRepositoryTest.java
@@ -151,7 +151,7 @@ class ScheduleRecordRepositoryTest extends RepositoryTest {
 			ScheduleRecord savedScheduleRecord = testFixtureBuilder.buildScheduleRecord(
 				IS_COMPLETE_SCHEDULE_RECORD(QUERY_END_DATE, savedSchedule));
 			// when
-			ScheduleRecord scheduleRecord = scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+			ScheduleRecord scheduleRecord = scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
 				QUERY_END_DATE,
 				savedSchedule.getId()).get();
 
@@ -168,7 +168,7 @@ class ScheduleRecordRepositoryTest extends RepositoryTest {
 			Schedule savedSchedule = testFixtureBuilder.buildSchedule(DEFAULT_NON_REPEATABLE_SCHEDULE(savedUser,
 				LESS_THAN_QUERY_DATE, GREATER_THAN_QUERY_DATE));
 			// when
-			Optional<ScheduleRecord> scheduleRecord = scheduleRecordRepository.findScheduleRecordByUserIdAndRecordDateAndScheduleId(
+			Optional<ScheduleRecord> scheduleRecord = scheduleRecordRepository.findScheduleRecordByRecordDateAndScheduleId(
 				QUERY_END_DATE,
 				savedSchedule.getId());
 


### PR DESCRIPTION
## ✨ 작업 내용



### **1️⃣ 일정 수정 API 개발**

> 일정 수정 API 는 다소 복잡합니다
> 일정 수정 로직은 전체 수정은 없습니다
> 하루 일정 수정과 특정날짜(queryDate) 이후 일정 일괄 수정만 존재합니다

#### 하루 수정

- 하루 , 반복 x 일정 경우에는 schedule 레코드를 수정합니다.
- 다른 경우의 수의 일정들은 해당 날짜 일정 기록을 soft delete하여 삭제 마킹을 합니다

#### 특정 날짜(queryDate) 이후 수정

- 기존 일정의 endDate 를 queryDate 하루 전으로 수정합니다 ( 삭제  api 로직과 동일)
- queryDate로 시작하는 수정 일정을 새로 생성 합니다.
- 기존 일정의 queryDate 이후의 일정 기록중 완료 기록은 각각 하루짜리 반복x 인 일정으로 남겨둡니다.
- 기존 일정의 queryDate 이후의 일정 기록중  미완료 기록은 삭제됩니다.

#### 예외 상황

- 특정 날짜를 선택하고 기간 일정으로 수정을 하고 이후 날짜 일괄 수정을 해서 발생하는 경우의 수
 -  해당 경우의 수는 논리적으로 존재할 수 없으므로 예외처리 하였습니다.
<br>
- 하루 짜리 반복 x 일정을 특정 날짜 이후 수정 할 수 있나? 
 - 해당 로직은 논리적으로 존재할 수 없으므로 예외처리 하였습니다.
 



