### PR TITLE
일반 로그인 식별자 수정

### DIFF
--- a/src/main/java/im/toduck/domain/auth/domain/service/GeneralAuthService.java
+++ b/src/main/java/im/toduck/domain/auth/domain/service/GeneralAuthService.java
@@ -22,17 +22,17 @@ public class GeneralAuthService {
 	private final PasswordEncoder passwordEncoder;
 
 	@Transactional(readOnly = true)
-	public User getUserIfValid(String phoneNumber, String password) {
-		Optional<User> user = userService.getUserByPhoneNumber(phoneNumber);
+	public User getUserIfValid(final String loginId, final String password) {
+		Optional<User> user = userService.getUserByLoginId(loginId);
 
 		if (user.isEmpty()) {
-			log.warn("존재하지 않는 유저 로그인 시도 - 유저 id: {}", phoneNumber);
-			throw CommonException.from(INVALID_PHONE_NUMBER_OR_PASSWORD);
+			log.warn("존재하지 않는 유저 로그인 시도 - 로그인 ID: {}", loginId);
+			throw CommonException.from(INVALID_LOGIN_ID_OR_PASSWORD);
 		}
 
 		if (!isValidPassword(password, user.get())) {
-			log.warn("잘못된 password 로그인 시도 - 유저 id: {}", user.get().getId());
-			throw CommonException.from(INVALID_PHONE_NUMBER_OR_PASSWORD);
+			log.warn("잘못된 비밀번호 로그인 시도 - 로그인 ID: {}", loginId);
+			throw CommonException.from(INVALID_LOGIN_ID_OR_PASSWORD);
 		}
 
 		return user.get();

--- a/src/main/java/im/toduck/domain/auth/domain/usecase/AuthUseCase.java
+++ b/src/main/java/im/toduck/domain/auth/domain/usecase/AuthUseCase.java
@@ -20,8 +20,8 @@ public class AuthUseCase {
 	private final JwtService jwtService;
 
 	@Transactional(readOnly = true)
-	public Pair<Long, JwtPair> signIn(LoginRequest request) {
-		User user = generalAuthService.getUserIfValid(request.phoneNumber(), request.password());
+	public Pair<Long, JwtPair> signIn(final LoginRequest request) {
+		User user = generalAuthService.getUserIfValid(request.loginId(), request.password());
 
 		return Pair.of(user.getId(), jwtService.createToken(user));
 	}

--- a/src/main/java/im/toduck/domain/auth/presentation/api/AuthControllerApi.java
+++ b/src/main/java/im/toduck/domain/auth/presentation/api/AuthControllerApi.java
@@ -33,7 +33,7 @@ public interface AuthControllerApi {
 		success = @ApiSuccessResponseExplanation(responseClass = LoginResponse.class, description = "AccessToken은 응답"
 			+ "으로 제공되며, RefreshToken은 Cookie로 제공됩니다.\n"),
 		errors = {
-			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.INVALID_PHONE_NUMBER_OR_PASSWORD)
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.INVALID_LOGIN_ID_OR_PASSWORD)
 		}
 	)
 	ResponseEntity<ApiResponse<LoginResponse>> signIn(LoginRequest request);

--- a/src/main/java/im/toduck/domain/auth/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/im/toduck/domain/auth/presentation/dto/request/LoginRequest.java
@@ -1,17 +1,21 @@
 package im.toduck.domain.auth.presentation.dto.request;
 
+import static im.toduck.global.regex.UserRegex.*;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "로그인 요청 DTO")
 public record LoginRequest(
-	// TODO: 추후 정책에 따른 전화번호 양식 검증 필요, 전화번호 예시 업데이트 필요
-	@Schema(description = "로그인 할 사용자 전화번호", example = "01012345678")
-	@NotBlank(message = "전화번호를 입력해주세요.")
-	String phoneNumber,
 
-	// TODO: 추후 정책에 따른 비밀번호 양식 검증 필요
+	@Schema(description = "사용자 아이디", example = "toduck")
+	@Pattern(regexp = LOGIN_ID_REGEXP, message = "올바른 ID를 입력해주세요.")
+	@NotBlank(message = "아이디를 입력해주세요.")
+	String loginId,
+
 	@Schema(description = "사용자 비밀번호", example = "password123")
+	@Pattern(regexp = PASSWORD_REGEXP, message = "올바른 비밀번호를 입력해주세요.")
 	@NotBlank(message = "비밀번호를 입력해주세요.")
 	String password
 ) {

--- a/src/main/java/im/toduck/domain/auth/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/im/toduck/domain/auth/presentation/dto/request/LoginRequest.java
@@ -14,7 +14,7 @@ public record LoginRequest(
 	@NotBlank(message = "아이디를 입력해주세요.")
 	String loginId,
 
-	@Schema(description = "사용자 비밀번호", example = "password123")
+	@Schema(description = "사용자 비밀번호", example = "Password2025@")
 	@Pattern(regexp = PASSWORD_REGEXP, message = "올바른 비밀번호를 입력해주세요.")
 	@NotBlank(message = "비밀번호를 입력해주세요.")
 	String password

--- a/src/main/java/im/toduck/domain/auth/presentation/dto/request/SignUpRequest.java
+++ b/src/main/java/im/toduck/domain/auth/presentation/dto/request/SignUpRequest.java
@@ -24,7 +24,7 @@ public class SignUpRequest {
 		@NotBlank(message = "아이디를 입력해주세요.")
 		String loginId,
 
-		@Schema(description = "사용자 비밀번호", example = "password123")
+		@Schema(description = "사용자 비밀번호", example = "Password2025@")
 		@Pattern(regexp = PASSWORD_REGEXP, message = "올바른 비밀번호를 입력해주세요.")
 		@NotBlank(message = "비밀번호를 입력해주세요.")
 		String password

--- a/src/main/java/im/toduck/domain/user/domain/service/UserService.java
+++ b/src/main/java/im/toduck/domain/user/domain/service/UserService.java
@@ -29,8 +29,8 @@ public class UserService {
 	}
 
 	@Transactional(readOnly = true)
-	public Optional<User> getUserByPhoneNumber(String phoneNumber) {
-		return userRepository.findByPhoneNumber(phoneNumber);
+	public Optional<User> getUserByLoginId(final String loginId) {
+		return userRepository.findByLoginId(loginId);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 public enum ExceptionCode {
 
 	/* 401xx AUTH */
-	INVALID_PHONE_NUMBER_OR_PASSWORD(HttpStatus.UNAUTHORIZED, 40101, "전화번호 또는 비밀번호가 일치하지 않습니다.",
+	INVALID_LOGIN_ID_OR_PASSWORD(HttpStatus.UNAUTHORIZED, 40101, "아이디 또는 비밀번호가 일치하지 않습니다.",
 		"사용자가 제공한 전화번호나 비밀번호가 데이터베이스의 정보와 일치하지 않을 때 발생합니다."),
 	FORBIDDEN_ACCESS_TOKEN(HttpStatus.FORBIDDEN, 40102, "토큰에 접근 권한이 없습니다."),
 	EMPTY_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 40103, "토큰이 포함되어 있지 않습니다."),


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 일반 로그인 식별자 수정**

- 로그인 식별자로 `전화번호` 를 사용하던 것에서 `로그인 ID` 를 사용하는 것으로 수정

```JSON
{
  "loginId": "toduck",
  "password": "password123"
}
```
  <br/>

**2️⃣ api 문서에 있는 비밀번호 예시 정규식에 맞게 수정**

- 변경 전
```JAVA
@Schema(description = "사용자 비밀번호", example = "password123")
```

- 변경 후
```JAVA
@Schema(description = "사용자 비밀번호", example = "Password2025@")
```



## ✅ 리뷰 요구사항
- 궁금한 점이 있다면 댓글 남겨주세요!
