### PR TITLE
닉네임 변경 API 개발

### DIFF
--- a/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
@@ -1,0 +1,19 @@
+package im.toduck.domain.mypage.domain.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.domain.user.persistence.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+	private final UserRepository userRepository;
+
+	@Transactional
+	public long updateUniqueNickname(User user, String nickname) {
+		return userRepository.updateUniqueNickname(user, nickname);
+	}
+}

--- a/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
@@ -1,0 +1,31 @@
+package im.toduck.domain.mypage.domain.usecase;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.mypage.domain.service.MyPageService;
+import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.annotation.UseCase;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class MyPageUseCase {
+	private final UserService userService;
+	private final MyPageService myPageService;
+
+	private static final long UPDATE_SUCCESS = 1L;
+
+	@Transactional
+	public void updateNickname(Long userId, NickNameUpdateRequest request) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		if (myPageService.updateUniqueNickname(user, request.nickname()) != UPDATE_SUCCESS) {
+			throw CommonException.from(ExceptionCode.EXISTS_USER_NICKNAME);
+		}
+	}
+}

--- a/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
@@ -1,0 +1,39 @@
+package im.toduck.domain.mypage.presentation.api;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
+import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
+import im.toduck.global.annotation.swagger.ApiResponseExplanations;
+import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.exception.ExceptionCode;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "My Page")
+public interface MyPageApi {
+	@Operation(
+		summary = "닉네임 변경",
+		description = "사용자 닉네임을 변경합니다. 닉네임은 알파벳, 한글, 숫자로만 이루어진 2~8자의 문자열이어야 합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "닉네임 변경 성공, 빈 content 객체를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.EXISTS_USER_NICKNAME)
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> updateNickname(
+		@RequestBody @Valid NickNameUpdateRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+
+}

--- a/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
@@ -1,0 +1,37 @@
+package im.toduck.domain.mypage.presentation.controller;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import im.toduck.domain.mypage.domain.usecase.MyPageUseCase;
+import im.toduck.domain.mypage.presentation.api.MyPageApi;
+import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/my-page")
+public class MyPageController implements MyPageApi {
+	private final MyPageUseCase myPageUseCase;
+
+	@Override
+	@PatchMapping("/nickname")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> updateNickname(
+		@RequestBody @Valid NickNameUpdateRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		myPageUseCase.updateNickname(userDetails.getUserId(), request);
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
+	}
+}

--- a/src/main/java/im/toduck/domain/mypage/presentation/dto/request/NickNameUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/dto/request/NickNameUpdateRequest.java
@@ -1,0 +1,15 @@
+package im.toduck.domain.mypage.presentation.dto.request;
+
+import static im.toduck.global.regex.UserRegex.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record NickNameUpdateRequest(
+	@NotBlank(message = "닉네임은 공백일 수 없습니다.")
+	@Schema(description = "닉네임", example = "꽥꽥")
+	@Pattern(regexp = NICKNAME_REGEXP, message = "올바른 닉네임을 입력해주세요.")
+	String nickname
+) {
+}

--- a/src/main/java/im/toduck/domain/user/persistence/repository/UserRepository.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/UserRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import im.toduck.domain.user.persistence.entity.OAuthProvider;
 import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.domain.user.persistence.repository.querydsl.UserRepositoryCustom;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 	Optional<User> findByPhoneNumber(String username);
 
 	Optional<User> findByLoginId(String loginId);

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
@@ -1,0 +1,7 @@
+package im.toduck.domain.user.persistence.repository.querydsl;
+
+import im.toduck.domain.user.persistence.entity.User;
+
+public interface UserRepositoryCustom {
+	long updateUniqueNickname(User user, String nickname);
+}

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package im.toduck.domain.user.persistence.repository.querydsl;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import im.toduck.domain.user.persistence.entity.QUser;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryCustomImpl implements UserRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+	private final QUser qUser = QUser.user;
+
+	@Override
+	public long updateUniqueNickname(User user, String nickname) {
+		return queryFactory.update(qUser)
+			.set(qUser.nickname, nickname)
+			.where(
+				qUser.id.eq(user.getId())
+					.and(qUser.deletedAt.isNull())
+					.and(JPAExpressions.selectOne()
+						.from(qUser)
+						.where(qUser.nickname.eq(nickname))
+						.notExists()
+					)
+			)
+			.execute();
+	}
+}

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -58,6 +58,7 @@ public enum ExceptionCode {
 		"차단 해제 시 차단 정보를 찾을 수 없을 때 발생하는 오류입니다."),
 	ALREADY_BLOCKED(HttpStatus.CONFLICT, 40205, "이미 차단된 사용자입니다.",
 		"해당 사용자를 이미 차단한 경우 발생하는 오류입니다."),
+	EXISTS_USER_NICKNAME(HttpStatus.CONFLICT, 40206, "이미 사용 중인 닉네임입니다."),
 
 	/* 404xx */
 	NOT_FOUND_SOCIAL_BOARD(HttpStatus.NOT_FOUND, 40401, "게시글을 찾을 수 없습니다."),

--- a/src/main/java/im/toduck/global/regex/UserRegex.java
+++ b/src/main/java/im/toduck/global/regex/UserRegex.java
@@ -7,4 +7,5 @@ public interface UserRegex {
 	//TODO : 다른 팀원 의견 들어봐야함 현재는 영문 숫자 특수기호 조합 8자리 이상
 	String PASSWORD_REGEXP = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>]).{8,}$";
 	String VERIFIED_CODE_REGEXP = "[0-9]{5}";
+	String NICKNAME_REGEXP = "^[a-zA-Z0-9가-힣]{2,8}$";
 }

--- a/src/test/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCaseTest.java
@@ -1,0 +1,59 @@
+package im.toduck.domain.mypage.domain.usecase;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import im.toduck.ServiceTest;
+import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.domain.user.persistence.repository.UserRepository;
+import im.toduck.fixtures.user.UserFixtures;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+
+public class MyPageUseCaseTest extends ServiceTest {
+
+	@Autowired
+	private MyPageUseCase myPageUseCase;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Nested
+	@DisplayName("닉네임 변경 시")
+	class UpdateNickname {
+		@Test
+		public void 닉네임을_변경할_수_있다() {
+			// given
+			User user = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+			String nickname = "변경할닉네임";
+
+			// when
+			NickNameUpdateRequest request = new NickNameUpdateRequest(nickname);
+			myPageUseCase.updateNickname(user.getId(), request);
+
+			// then
+			assertThat(userRepository.findById(user.getId()).get().getNickname()).isEqualTo(nickname);
+		}
+
+		@Test
+		public void 이미_존재하는_닉네임으로_변경할_수_없다() {
+			// given
+			User existingUser = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+			User updatingUser = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+
+			String nickname = existingUser.getNickname();
+
+			// when & then
+			NickNameUpdateRequest request = new NickNameUpdateRequest(nickname);
+
+			assertThatThrownBy(() -> myPageUseCase.updateNickname(updatingUser.getId(), request))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(ExceptionCode.EXISTS_USER_NICKNAME.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 닉네임 변경**

- 알파벳 대소문자, 한글, 숫자만 조합하여 가능하도록 조정
- 중복 검사와 업데이트를 한 쿼리로 처리
  - 동시성 문제가 일어날 가능성이 높진 않을 것 같아 비관적 락이나 낙관적 락을 적용하진 않았지만, 그래도 일어날 가능성이 있기 때문에 한 쿼리로 합쳐 실행하여 중복 가능성을 줄여보았습니다.
  <br/>

## ✅ 리뷰 요구사항(선택)

> 비관적 락이나 낙관적 락을 적용하여 닉네임 중복 가능성에 대해서 아예 없애도록 해야 할지, 해야 한다면 어떤 방식이 더 좋을지 조언해주시면 감사하겠습니다.
>  Querydsl과 테스트 코드를 직접 작성해본 게 처음이어서, 해당 부분에 이상한 점이 없는지 봐주시면 감사하겠습니다.
