### PR TITLE
Feature/tod 174 diary create test

### DIFF
--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryImageFileMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryImageFileMapper.java
@@ -1,0 +1,16 @@
+package im.toduck.domain.diary.common.mapper;
+
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.persistence.entity.DiaryImage;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiaryImageFileMapper {
+	public static DiaryImage toDiaryImageFile(Diary diary, String url) {
+		return DiaryImage.builder()
+			.diary(diary)
+			.url(url)
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -4,6 +4,7 @@ import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
 import im.toduck.domain.user.persistence.entity.User;
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class DiaryMapper {
 	public static Diary toDiary(
 		final User user,
-		final DiaryCreateRequest request
+		@Valid final DiaryCreateRequest request
 	) {
 		return Diary.builder()
 			.user(user)

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -1,0 +1,35 @@
+package im.toduck.domain.diary.common.mapper;
+
+import java.time.LocalDate;
+
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.user.persistence.entity.Emotion;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiaryMapper {
+	public static Diary toDiary(
+		final User user,
+		final LocalDate date,
+		final Emotion emotion,
+		final String title,
+		final String memo
+	) {
+		return Diary.builder()
+			.user(user)
+			.date(date)
+			.emotion(emotion)
+			.title(title)
+			.memo(memo)
+			.build();
+	}
+
+	public static DiaryCreateResponse toDiaryCreateResponse(Diary diary) {
+		return DiaryCreateResponse.builder()
+			.diaryId(diary.getId())
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -1,10 +1,8 @@
 package im.toduck.domain.diary.common.mapper;
 
-import java.time.LocalDate;
-
 import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
-import im.toduck.domain.user.persistence.entity.Emotion;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -13,17 +11,14 @@ import lombok.NoArgsConstructor;
 public class DiaryMapper {
 	public static Diary toDiary(
 		final User user,
-		final LocalDate date,
-		final Emotion emotion,
-		final String title,
-		final String memo
+		final DiaryCreateRequest request
 	) {
 		return Diary.builder()
 			.user(user)
-			.date(date)
-			.emotion(emotion)
-			.title(title)
-			.memo(memo)
+			.date(request.date())
+			.emotion(request.emotion())
+			.title(request.title())
+			.memo(request.memo())
 			.build();
 	}
 

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -1,8 +1,18 @@
 package im.toduck.domain.diary.domain.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import im.toduck.domain.diary.common.mapper.DiaryImageFileMapper;
+import im.toduck.domain.diary.common.mapper.DiaryMapper;
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.persistence.entity.DiaryImage;
+import im.toduck.domain.diary.persistence.repository.DiaryImageRepository;
 import im.toduck.domain.diary.persistence.repository.DiaryRepository;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.user.persistence.entity.User;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -11,5 +21,28 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class DiaryService {
 	private final DiaryRepository diaryRepository;
+	private final DiaryImageRepository diaryImageRepository;
 
+	@Transactional
+	public Diary createDiary(
+		final User user,
+		final DiaryCreateRequest request
+	) {
+		Diary diary = DiaryMapper.toDiary(
+			user,
+			request.date(),
+			request.emotion(),
+			request.title(),
+			request.memo()
+		);
+		return diaryRepository.save(diary);
+	}
+
+	@Transactional
+	public void addDiaryImageFiles(final List<String> imageUrls, final Diary diary) {
+		List<DiaryImage> diaryImageFiles = imageUrls.stream()
+			.map(url -> DiaryImageFileMapper.toDiaryImageFile(diary, url))
+			.toList();
+		diaryImageRepository.saveAll(diaryImageFiles);
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -28,13 +28,7 @@ public class DiaryService {
 		final User user,
 		final DiaryCreateRequest request
 	) {
-		Diary diary = DiaryMapper.toDiary(
-			user,
-			request.date(),
-			request.emotion(),
-			request.title(),
-			request.memo()
-		);
+		Diary diary = DiaryMapper.toDiary(user, request);
 		return diaryRepository.save(diary);
 	}
 

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -1,6 +1,8 @@
 package im.toduck.domain.diary.domain.service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
@@ -13,6 +15,7 @@ import im.toduck.domain.diary.persistence.repository.DiaryRepository;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.user.persistence.entity.User;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,7 +29,7 @@ public class DiaryService {
 	@Transactional
 	public Diary createDiary(
 		final User user,
-		final DiaryCreateRequest request
+		@Valid final DiaryCreateRequest request
 	) {
 		Diary diary = DiaryMapper.toDiary(user, request);
 		return diaryRepository.save(diary);
@@ -34,7 +37,9 @@ public class DiaryService {
 
 	@Transactional
 	public void addDiaryImageFiles(final List<String> imageUrls, final Diary diary) {
-		List<DiaryImage> diaryImageFiles = imageUrls.stream()
+		List<String> safeImageUrls = Optional.ofNullable(imageUrls).orElse(Collections.emptyList());
+
+		List<DiaryImage> diaryImageFiles = safeImageUrls.stream()
 			.map(url -> DiaryImageFileMapper.toDiaryImageFile(diary, url))
 			.toList();
 		diaryImageRepository.saveAll(diaryImageFiles);

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -1,0 +1,35 @@
+package im.toduck.domain.diary.domain.usecase;
+
+import im.toduck.domain.diary.common.mapper.DiaryMapper;
+import im.toduck.domain.diary.domain.service.DiaryService;
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.annotation.UseCase;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class DiaryUseCase {
+	private final UserService userService;
+	private final DiaryService diaryService;
+
+	@Transactional
+	public DiaryCreateResponse createDiary(final Long userId, final DiaryCreateRequest request) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		Diary diary = diaryService.createDiary(user, request);
+		diaryService.addDiaryImageFiles(request.diaryImageUrls(), diary);
+
+		log.info("일기 생성 - UserId: {}, DiaryId: {}", userId, diary.getId());
+		return DiaryMapper.toDiaryCreateResponse(diary);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -11,6 +11,7 @@ import im.toduck.global.annotation.UseCase;
 import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -22,7 +23,7 @@ public class DiaryUseCase {
 	private final DiaryService diaryService;
 
 	@Transactional
-	public DiaryCreateResponse createDiary(final Long userId, final DiaryCreateRequest request) {
+	public DiaryCreateResponse createDiary(final Long userId, @Valid final DiaryCreateRequest request) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -37,7 +38,7 @@ public class Diary extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -42,7 +42,7 @@ public class Diary extends BaseEntity {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	@Column(nullable = false)
+	@Column(name = "diary_date", nullable = false)
 	private LocalDate date;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
@@ -12,11 +12,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "diary_images")
+@Table(name = "diary_image_file")
 @Getter
 @NoArgsConstructor
 @SQLDelete(sql = "UPDATE record SET deleted_at = NOW() where id=?")
@@ -30,11 +31,12 @@ public class DiaryImage extends BaseEntity {
 	@JoinColumn(name = "diary_id", nullable = false)
 	private Diary diary;
 
-	@Column(name = "image_url", length = 256, nullable = false)
-	private String imgUrl;
+	@Column(name = "url", length = 512, nullable = false)
+	private String url;
 
-	public DiaryImage(Diary diary, String imgUrl) {
+	@Builder
+	public DiaryImage(Diary diary, String url) {
 		this.diary = diary;
-		this.imgUrl = imgUrl;
+		this.url = url;
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryImageRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryImageRepository.java
@@ -1,0 +1,12 @@
+package im.toduck.domain.diary.persistence.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.persistence.entity.DiaryImage;
+
+public interface DiaryImageRepository extends JpaRepository<DiaryImage, Long> {
+	List<DiaryImage> findAllByDiary(Diary diary);
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -1,0 +1,38 @@
+package im.toduck.domain.diary.presentation.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
+import im.toduck.global.annotation.swagger.ApiResponseExplanations;
+import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.exception.ExceptionCode;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "Diary")
+public interface DiaryApi {
+	@Operation(
+		summary = "일기 생성",
+		description = "일기를 작성합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = DiaryCreateResponse.class,
+			description = "일기 생성 성공, 생성된 일기의 Id를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_EMOTION)
+		}
+	)
+	ResponseEntity<ApiResponse<DiaryCreateResponse>> createDiary(
+		@RequestBody @Valid DiaryCreateRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -6,10 +6,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
-import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
-import im.toduck.global.exception.ExceptionCode;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,10 +24,7 @@ public interface DiaryApi {
 		success = @ApiSuccessResponseExplanation(
 			responseClass = DiaryCreateResponse.class,
 			description = "일기 생성 성공, 생성된 일기의 Id를 반환합니다."
-		),
-		errors = {
-			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_EMOTION)
-		}
+		)
 	)
 	ResponseEntity<ApiResponse<DiaryCreateResponse>> createDiary(
 		@RequestBody @Valid DiaryCreateRequest request,

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -1,0 +1,38 @@
+package im.toduck.domain.diary.presentation.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import im.toduck.domain.diary.domain.usecase.DiaryUseCase;
+import im.toduck.domain.diary.presentation.api.DiaryApi;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/diary")
+public class DiaryController implements DiaryApi {
+
+	private final DiaryUseCase diaryUseCase;
+
+	@Override
+	@PostMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<DiaryCreateResponse>> createDiary(
+		@RequestBody @Valid final DiaryCreateRequest request,
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.createSuccess(diaryUseCase.createDiary(userDetails.getUserId(), request))
+		);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
@@ -1,0 +1,34 @@
+package im.toduck.domain.diary.presentation.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import im.toduck.domain.user.persistence.entity.Emotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "다이어리 생성 요청 DTO")
+public record DiaryCreateRequest(
+	@NotNull(message = "날짜는 비어있을 수 없습니다.")
+	@Schema(description = "일기 날짜", example = "2025-03-12")
+	LocalDate date,
+
+	@NotNull(message = "감정은 비어있을 수 없습니다.")
+	@Schema(description = "감정", example = "HAPPY")
+	Emotion emotion,
+
+	@Size(max = 16, message = "제목은 16자를 초과할 수 없습니다.")
+	@Schema(description = "일기 제목", example = "슬퍼")
+	String title,
+
+	@Size(max = 200, message = "일기는 200자를 초과할 수 없습니다.")
+	@Schema(description = "문장 기록", example = "출근 전에 지갑을 두고 나오는 바람에 다시 돌아갔다")
+	String memo,
+
+	@Size(max = 2, message = "이미지는 최대 2개까지만 등록할 수 있습니다.")
+	@Schema(description = "이미지 URL 목록", example = "[\"https://cdn.toduck.app/image1.jpg\"]")
+	List<String> diaryImageUrls
+) {
+
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryCreateResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryCreateResponse.java
@@ -1,0 +1,13 @@
+package im.toduck.domain.diary.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "일기 생성 응답 DTO")
+@Builder
+public record DiaryCreateResponse(
+	@Schema(description = "생성된 일기 Id", example = "1")
+	Long diaryId
+) {
+
+}

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -82,7 +82,7 @@ public enum ExceptionCode {
 	INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, 40419, "답글은 부모 댓글이 될 수 없습니다."),
 
 	/* 405xx diary */
-	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 45001, "유효하지 않은 감정입니다."),
+	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 40501, "유효하지 않은 감정입니다."),
 
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -95,6 +95,9 @@ public enum ExceptionCode {
 	PRIVATE_ROUTINE(HttpStatus.FORBIDDEN, 43203, "비공개된 루틴입니다.",
 		"요청하신 루틴은 비공개 상태입니다. 접근 권한이 없는 경우 접근할 수 없습니다."),
 
+	/* 450xx diary */
+	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 45001, "유효하지 않은 감정입니다."),
+
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),
 	METHOD_FORBIDDEN(HttpStatus.METHOD_NOT_ALLOWED, 49902, "지원하지 않는 HTTP 메서드를 사용합니다."),

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -82,7 +82,6 @@ public enum ExceptionCode {
 	INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, 40419, "답글은 부모 댓글이 될 수 없습니다."),
 
 	/* 405xx diary */
-	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 40501, "유효하지 않은 감정입니다."),
 
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -81,6 +81,9 @@ public enum ExceptionCode {
 	NOT_FOUND_PARENT_COMMENT(HttpStatus.NOT_FOUND, 40418, "부모 댓글을 찾을 수 없습니다."),
 	INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, 40419, "답글은 부모 댓글이 될 수 없습니다."),
 
+	/* 405xx diary */
+	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 45001, "유효하지 않은 감정입니다."),
+
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",
 		"일정 기록을 찾을 수 없을 때 발생하는 오류입니다."),
@@ -94,9 +97,6 @@ public enum ExceptionCode {
 		"요청된 날짜에 대한 루틴 변경이 불가능합니다. 루틴의 반복 요일과 현재 날짜를 확인하고 올바른 날짜로 다시 요청해 주세요."),
 	PRIVATE_ROUTINE(HttpStatus.FORBIDDEN, 43203, "비공개된 루틴입니다.",
 		"요청하신 루틴은 비공개 상태입니다. 접근 권한이 없는 경우 접근할 수 없습니다."),
-
-	/* 450xx diary */
-	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 45001, "유효하지 않은 감정입니다."),
 
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),

--- a/src/test/java/im/toduck/builder/BuilderSupporter.java
+++ b/src/test/java/im/toduck/builder/BuilderSupporter.java
@@ -3,6 +3,8 @@ package im.toduck.builder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import im.toduck.domain.diary.persistence.repository.DiaryImageRepository;
+import im.toduck.domain.diary.persistence.repository.DiaryRepository;
 import im.toduck.domain.routine.persistence.repository.RoutineRecordRepository;
 import im.toduck.domain.routine.persistence.repository.RoutineRepository;
 import im.toduck.domain.schedule.persistence.repository.ScheduleRecordRepository;
@@ -63,6 +65,12 @@ public class BuilderSupporter {
 	@Autowired
 	private ScheduleRecordRepository scheduleRecordRepository;
 
+	@Autowired
+	private DiaryRepository diaryRepository;
+
+	@Autowired
+	private DiaryImageRepository diaryImageRepository;
+
 	public UserRepository userRepository() {
 		return userRepository;
 	}
@@ -119,4 +127,11 @@ public class BuilderSupporter {
 		return scheduleRecordRepository;
 	}
 
+	public DiaryRepository diaryRepository() {
+		return diaryRepository;
+	}
+
+	public DiaryImageRepository diaryImageRepository() {
+		return diaryImageRepository;
+	}
 }

--- a/src/test/java/im/toduck/builder/TestFixtureBuilder.java
+++ b/src/test/java/im/toduck/builder/TestFixtureBuilder.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.persistence.entity.DiaryImage;
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.schedule.persistence.entity.Schedule;
@@ -91,4 +93,11 @@ public class TestFixtureBuilder {
 		return bs.scheduleRecordRepository().save(scheduleRecord);
 	}
 
+	public Diary buildDiary(final Diary diary) {
+		return bs.diaryRepository().save(diary);
+	}
+
+	public List<DiaryImage> buildDiaryImage(final List<DiaryImage> diaryImage) {
+		return bs.diaryImageRepository().saveAll(diaryImage);
+	}
 }

--- a/src/test/java/im/toduck/domain/diary/domain/usecase/DiaryUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/diary/domain/usecase/DiaryUseCaseTest.java
@@ -1,0 +1,88 @@
+package im.toduck.domain.diary.domain.usecase;
+
+import static im.toduck.fixtures.user.UserFixtures.*;
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import im.toduck.ServiceTest;
+import im.toduck.domain.diary.persistence.repository.DiaryImageRepository;
+import im.toduck.domain.diary.persistence.repository.DiaryRepository;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.user.persistence.entity.Emotion;
+import im.toduck.domain.user.persistence.entity.User;
+import jakarta.validation.ConstraintViolationException;
+
+public class DiaryUseCaseTest extends ServiceTest {
+	private User USER;
+
+	@Autowired
+	private DiaryUseCase diaryUseCase;
+
+	@Autowired
+	private DiaryRepository diaryRepository;
+
+	@Autowired
+	private DiaryImageRepository diaryImageRepository;
+
+	@BeforeEach
+	public void setUp() {
+		USER = testFixtureBuilder.buildUser(GENERAL_USER());
+	}
+
+	@Nested
+	@DisplayName("다이어리 생성시")
+	class CreateDiary {
+		String dateStr = "2025-03-21";
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+		LocalDate date = LocalDate.parse(dateStr, formatter);
+		Emotion emotion = Emotion.valueOf("HAPPY");
+
+		@Test
+		void 성공() {
+			// given
+			DiaryCreateRequest DATE_EMOTION_NOT_NULL_REQUEST = new DiaryCreateRequest(
+				date,
+				emotion,
+				null,
+				null,
+				null
+			);
+
+			// when
+			DiaryCreateResponse response = diaryUseCase.createDiary(USER.getId(), DATE_EMOTION_NOT_NULL_REQUEST);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(response.diaryId()).isNotNull();
+			});
+		}
+
+		@Test
+		void 실패_date_emotion이_null이면_에러를_반환한다() {
+			// given
+			DiaryCreateRequest DATE_EMOTION_NULL_REQUEST = new DiaryCreateRequest(
+				null,
+				null,
+				null,
+				null,
+				null
+			);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> diaryUseCase.createDiary(USER.getId(), DATE_EMOTION_NULL_REQUEST))
+					.isInstanceOf(ConstraintViolationException.class);
+			});
+		}
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용

diary create 테스트 코드를 작성했습니다. 필수 값인 date와 emotion에 null을 넣고 create했을 때 ConstraintViolationException이 떠야하는데 DataIntegrityViolationException이 떠서 오류가 나는 상황입니다. gpt로 해결 못해 도움을 요청해봅니다.
참고로 정상적으로 값이 들어갔을 때 create 테스트는 성공했습니다.
![image](https://github.com/user-attachments/assets/dcfd4d4e-2bf1-40fe-9ad5-fc17d370f0bd)


**1️⃣ 작업내용1**

- 설명1
  <br/>

**2️⃣ 작업내용2**

- 설명1
  <br/>

**3️⃣ 작업내용3**

- 설명1
  <br/>

## ✅ 리뷰 요구사항(선택)


