### PR TITLE
diary crud API

### DIFF
--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryImageFileMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryImageFileMapper.java
@@ -1,0 +1,16 @@
+package im.toduck.domain.diary.common.mapper;
+
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.persistence.entity.DiaryImage;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiaryImageFileMapper {
+	public static DiaryImage toDiaryImageFile(Diary diary, String url) {
+		return DiaryImage.builder()
+			.diary(diary)
+			.url(url)
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryImageFileMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryImageFileMapper.java
@@ -2,6 +2,7 @@ package im.toduck.domain.diary.common.mapper;
 
 import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.persistence.entity.DiaryImage;
+import im.toduck.domain.diary.presentation.dto.response.DiaryImageDto;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -12,5 +13,12 @@ public class DiaryImageFileMapper {
 			.diary(diary)
 			.url(url)
 			.build();
+	}
+
+	public static DiaryImageDto fromDiaryImage(DiaryImage diaryImage) {
+		return new DiaryImageDto(
+			diaryImage.getId(),
+			diaryImage.getUrl()
+		);
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -1,0 +1,35 @@
+package im.toduck.domain.diary.common.mapper;
+
+import java.time.LocalDate;
+
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.user.persistence.entity.Emotion;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiaryMapper {
+	public static Diary toDiary(
+		final User user,
+		final LocalDate date,
+		final Emotion emotion,
+		final String title,
+		final String memo
+	) {
+		return Diary.builder()
+			.user(user)
+			.date(date)
+			.emotion(emotion)
+			.title(title)
+			.memo(memo)
+			.build();
+	}
+
+	public static DiaryCreateResponse toDiaryCreateResponse(Diary diary) {
+		return DiaryCreateResponse.builder()
+			.diaryId(diary.getId())
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -1,11 +1,8 @@
 package im.toduck.domain.diary.common.mapper;
 
-import java.util.stream.Collectors;
-
 import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
-import im.toduck.domain.diary.presentation.dto.response.DiaryImageDto;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.AccessLevel;
@@ -39,8 +36,8 @@ public class DiaryMapper {
 			diary.getTitle(),
 			diary.getMemo(),
 			diary.getDiaryImages().stream()
-				.map(DiaryImageDto::fromEntity)
-				.collect(Collectors.toList())
+				.map(DiaryImageFileMapper::fromDiaryImage)
+				.toList()
 		);
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -1,10 +1,8 @@
 package im.toduck.domain.diary.common.mapper;
 
-import java.time.LocalDate;
-
 import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
-import im.toduck.domain.user.persistence.entity.Emotion;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -13,17 +11,14 @@ import lombok.NoArgsConstructor;
 public class DiaryMapper {
 	public static Diary toDiary(
 		final User user,
-		final LocalDate date,
-		final Emotion emotion,
-		final String title,
-		final String memo
+		final DiaryCreateRequest request
 	) {
 		return Diary.builder()
 			.user(user)
-			.date(date)
-			.emotion(emotion)
-			.title(title)
-			.memo(memo)
+			.date(request.date())
+			.emotion(request.emotion())
+			.title(request.title())
+			.memo(request.memo())
 			.build();
 	}
 

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -1,8 +1,12 @@
 package im.toduck.domain.diary.common.mapper;
 
+import java.util.stream.Collectors;
+
 import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.diary.presentation.dto.response.DiaryImageDto;
+import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -26,5 +30,17 @@ public class DiaryMapper {
 		return DiaryCreateResponse.builder()
 			.diaryId(diary.getId())
 			.build();
+	}
+
+	public static DiaryResponse fromDiary(Diary diary) {
+		return new DiaryResponse(
+			diary.getDate(),
+			diary.getEmotion(),
+			diary.getTitle(),
+			diary.getMemo(),
+			diary.getDiaryImages().stream()
+				.map(DiaryImageDto::fromEntity)
+				.collect(Collectors.toList())
+		);
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -1,8 +1,18 @@
 package im.toduck.domain.diary.domain.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import im.toduck.domain.diary.common.mapper.DiaryImageFileMapper;
+import im.toduck.domain.diary.common.mapper.DiaryMapper;
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.persistence.entity.DiaryImage;
+import im.toduck.domain.diary.persistence.repository.DiaryImageRepository;
 import im.toduck.domain.diary.persistence.repository.DiaryRepository;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.user.persistence.entity.User;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -11,5 +21,28 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class DiaryService {
 	private final DiaryRepository diaryRepository;
+	private final DiaryImageRepository diaryImageRepository;
 
+	@Transactional
+	public Diary createDiary(
+		final User user,
+		final DiaryCreateRequest request
+	) {
+		Diary diary = DiaryMapper.toDiary(
+			user,
+			request.date(),
+			request.emotion(),
+			request.title(),
+			request.memo()
+		);
+		return diaryRepository.save(diary);
+	}
+
+	@Transactional
+	public void addDiaryImageFiles(final List<String> imageUrls, final Diary diary) {
+		List<DiaryImage> diaryImageFiles = imageUrls.stream()
+			.map(url -> DiaryImageFileMapper.toDiaryImageFile(diary, url))
+			.toList();
+		diaryImageRepository.saveAll(diaryImageFiles);
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -28,13 +28,7 @@ public class DiaryService {
 		final User user,
 		final DiaryCreateRequest request
 	) {
-		Diary diary = DiaryMapper.toDiary(
-			user,
-			request.date(),
-			request.emotion(),
-			request.title(),
-			request.memo()
-		);
+		Diary diary = DiaryMapper.toDiary(user, request);
 		return diaryRepository.save(diary);
 	}
 

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -1,6 +1,8 @@
 package im.toduck.domain.diary.domain.service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
@@ -34,7 +36,9 @@ public class DiaryService {
 
 	@Transactional
 	public void addDiaryImageFiles(final List<String> imageUrls, final Diary diary) {
-		List<DiaryImage> diaryImageFiles = imageUrls.stream()
+		List<String> safeImageUrls = Optional.ofNullable(imageUrls).orElse(Collections.emptyList());
+
+		List<DiaryImage> diaryImageFiles = safeImageUrls.stream()
 			.map(url -> DiaryImageFileMapper.toDiaryImageFile(diary, url))
 			.toList();
 		diaryImageRepository.saveAll(diaryImageFiles);

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -108,7 +108,7 @@ public class DiaryService {
 		LocalDate startDate = LocalDate.of(year, month, 1);
 		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
-		List<Diary> diaries = diaryRepository.findByUserIdAndDateBetween(userId, startDate, endDate);
+		List<Diary> diaries = diaryRepository.findByUserIdAndDateBetweenOrderByDateDesc(userId, startDate, endDate);
 
 		return diaries.stream()
 			.map(DiaryResponse::fromEntity)

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -4,10 +4,10 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.EnumUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.domain.diary.common.mapper.DiaryImageFileMapper;
 import im.toduck.domain.diary.common.mapper.DiaryMapper;
@@ -22,7 +22,6 @@ import im.toduck.domain.user.persistence.entity.Emotion;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -52,7 +51,7 @@ public class DiaryService {
 		diaryImageRepository.saveAll(diaryImageFiles);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public Optional<Diary> getDiaryById(final Long diaryId) {
 		return diaryRepository.findById(diaryId);
 	}
@@ -99,7 +98,7 @@ public class DiaryService {
 		}
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public List<DiaryResponse> getDiariesByMonth(
 		final Long userId,
 		final int year,
@@ -112,6 +111,6 @@ public class DiaryService {
 
 		return diaries.stream()
 			.map(DiaryResponse::fromEntity)
-			.collect(Collectors.toList());
+			.toList();
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -108,6 +108,16 @@ public class DiaryService {
 
 		List<Diary> diaries = diaryRepository.findByUserIdAndDateBetween(userId, startDate, endDate);
 
-		return diaries.stream().map(DiaryResponse::fromEntity).collect(Collectors.toList());
+		return diaries.stream()
+			.map(DiaryResponse::fromEntity)
+			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public List<DiaryResponse> getAllDiaries(Long userId) {
+		List<Diary> diaries = diaryRepository.findAllByUserId(userId);
+		return diaries.stream()
+			.map(DiaryResponse::fromEntity)
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -43,4 +43,15 @@ public class DiaryService {
 			.toList();
 		diaryImageRepository.saveAll(diaryImageFiles);
 	}
+
+	@Transactional
+	public Optional<Diary> getDiaryById(final Long diaryId) {
+		return diaryRepository.findById(diaryId);
+	}
+
+	@Transactional
+	public void deleteDiary(final Diary diary) {
+		List<DiaryImage> imageFiles = diaryImageRepository.findAllByDiary(diary);
+		imageFiles.forEach(DiaryImage::softDelete);
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.EnumUtils;
 import org.springframework.stereotype.Service;
 
 import im.toduck.domain.diary.common.mapper.DiaryImageFileMapper;
@@ -13,7 +14,11 @@ import im.toduck.domain.diary.persistence.entity.DiaryImage;
 import im.toduck.domain.diary.persistence.repository.DiaryImageRepository;
 import im.toduck.domain.diary.persistence.repository.DiaryRepository;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
+import im.toduck.domain.user.persistence.entity.Emotion;
 import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,5 +58,39 @@ public class DiaryService {
 	public void deleteDiary(final Diary diary) {
 		List<DiaryImage> imageFiles = diaryImageRepository.findAllByDiary(diary);
 		imageFiles.forEach(DiaryImage::softDelete);
+	}
+
+	@Transactional
+	public void updateDiary(
+		User user,
+		Diary diary,
+		DiaryUpdateRequest request
+	) {
+		if (request.isChangeEmotion()) {
+			if (request.emotion() == null) {
+				log.warn("일기 업데이트시 감정을 null 값으로 일기 수정 시도 - UserId: {}, DiaryId: {}", user.getId(), diary.getId());
+				throw CommonException.from(ExceptionCode.EMPTY_DIARY_EMOTION);
+			}
+
+			if (!EnumUtils.isValidEnum(Emotion.class, request.emotion().name())) {
+				log.warn("일기 업데이트 시 잘못된 감정 값 입력 - UserId: {}, DiaryId: {}, Emotion: {}",
+					user.getId(), diary.getId(), request.emotion());
+				throw CommonException.from(ExceptionCode.INVALID_DIARY_EMOTION);
+			}
+			diary.updateEmotion(request.emotion());
+		}
+
+		if (request.title() != null) {
+			diary.updateTitle(request.title());
+		}
+
+		if (request.memo() != null) {
+			diary.updateMemo(request.memo());
+		}
+
+		if (request.diaryImageUrls() != null) {
+			diaryImageRepository.deleteAllByDiary(diary);
+			addDiaryImageFiles(request.diaryImageUrls(), diary);
+		}
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -114,12 +114,4 @@ public class DiaryService {
 			.map(DiaryResponse::fromEntity)
 			.collect(Collectors.toList());
 	}
-
-	@Transactional
-	public List<DiaryResponse> getAllDiaries(Long userId) {
-		List<Diary> diaries = diaryRepository.findAllByUserId(userId);
-		return diaries.stream()
-			.map(DiaryResponse::fromEntity)
-			.collect(Collectors.toList());
-	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -1,8 +1,10 @@
 package im.toduck.domain.diary.domain.service;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.EnumUtils;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,7 @@ import im.toduck.domain.diary.persistence.repository.DiaryImageRepository;
 import im.toduck.domain.diary.persistence.repository.DiaryRepository;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.domain.user.persistence.entity.Emotion;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.exception.CommonException;
@@ -92,5 +95,19 @@ public class DiaryService {
 			diaryImageRepository.deleteAllByDiary(diary);
 			addDiaryImageFiles(request.diaryImageUrls(), diary);
 		}
+	}
+
+	@Transactional
+	public List<DiaryResponse> getDiariesByMonth(
+		final Long userId,
+		final int year,
+		final int month
+	) {
+		LocalDate startDate = LocalDate.of(year, month, 1);
+		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+		List<Diary> diaries = diaryRepository.findByUserIdAndDateBetween(userId, startDate, endDate);
+
+		return diaries.stream().map(DiaryResponse::fromEntity).collect(Collectors.toList());
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang3.EnumUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,10 +17,7 @@ import im.toduck.domain.diary.persistence.repository.DiaryRepository;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
-import im.toduck.domain.user.persistence.entity.Emotion;
 import im.toduck.domain.user.persistence.entity.User;
-import im.toduck.global.exception.CommonException;
-import im.toduck.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -71,16 +67,6 @@ public class DiaryService {
 		DiaryUpdateRequest request
 	) {
 		if (request.isChangeEmotion()) {
-			if (request.emotion() == null) {
-				log.warn("일기 업데이트시 감정을 null 값으로 일기 수정 시도 - UserId: {}, DiaryId: {}", user.getId(), diary.getId());
-				throw CommonException.from(ExceptionCode.EMPTY_DIARY_EMOTION);
-			}
-
-			if (!EnumUtils.isValidEnum(Emotion.class, request.emotion().name())) {
-				log.warn("일기 업데이트 시 잘못된 감정 값 입력 - UserId: {}, DiaryId: {}, Emotion: {}",
-					user.getId(), diary.getId(), request.emotion());
-				throw CommonException.from(ExceptionCode.INVALID_DIARY_EMOTION);
-			}
 			diary.updateEmotion(request.emotion());
 		}
 

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -96,7 +96,7 @@ public class DiaryService {
 		List<Diary> diaries = diaryRepository.findByUserIdAndDateBetweenOrderByDateDesc(userId, startDate, endDate);
 
 		return diaries.stream()
-			.map(DiaryResponse::fromEntity)
+			.map(DiaryMapper::fromDiary)
 			.toList();
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -61,6 +61,8 @@ public class DiaryService {
 	public void deleteDiary(final Diary diary) {
 		List<DiaryImage> imageFiles = diaryImageRepository.findAllByDiary(diary);
 		imageFiles.forEach(DiaryImage::softDelete);
+
+		diaryRepository.delete(diary);
 	}
 
 	@Transactional

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -83,11 +83,4 @@ public class DiaryUseCase {
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		return diaryService.getDiariesByMonth(userId, year, month);
 	}
-
-	@Transactional
-	public List<DiaryResponse> getAllDiaries(final Long userId) {
-		User user = userService.getUserById(userId)
-			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-		return diaryService.getAllDiaries(userId);
-	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -83,4 +83,10 @@ public class DiaryUseCase {
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		return diaryService.getDiariesByMonth(userId, year, month);
 	}
+
+	public List<DiaryResponse> getAllDiaries(final Long userId) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+		return diaryService.getAllDiaries(userId);
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -1,0 +1,35 @@
+package im.toduck.domain.diary.domain.usecase;
+
+import im.toduck.domain.diary.common.mapper.DiaryMapper;
+import im.toduck.domain.diary.domain.service.DiaryService;
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.annotation.UseCase;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class DiaryUseCase {
+	private final UserService userService;
+	private final DiaryService diaryService;
+
+	@Transactional
+	public DiaryCreateResponse createDiary(final Long userId, final DiaryCreateRequest request) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		Diary diary = diaryService.createDiary(user, request);
+		diaryService.addDiaryImageFiles(request.diaryImageUrls(), diary);
+
+		log.info("일기 생성 - UserId: {}, DiaryId: {}", userId, diary.getId());
+		return DiaryMapper.toDiaryCreateResponse(diary);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -1,11 +1,14 @@
 package im.toduck.domain.diary.domain.usecase;
 
+import java.util.List;
+
 import im.toduck.domain.diary.common.mapper.DiaryMapper;
 import im.toduck.domain.diary.domain.service.DiaryService;
 import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.annotation.UseCase;
@@ -72,5 +75,12 @@ public class DiaryUseCase {
 
 	private boolean isDiaryOwner(final Diary diary, final User user) {
 		return diary.isOwner(user);
+	}
+
+	@Transactional
+	public List<DiaryResponse> getDiariesByMonth(final Long userId, final int year, final int month) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+		return diaryService.getDiariesByMonth(userId, year, month);
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -32,4 +32,24 @@ public class DiaryUseCase {
 		log.info("일기 생성 - UserId: {}, DiaryId: {}", userId, diary.getId());
 		return DiaryMapper.toDiaryCreateResponse(diary);
 	}
+
+	private boolean isDiaryOwner(final Diary diary, final User user) {
+		return diary.isOwner(user);
+	}
+
+	@Transactional
+	public void deleteDiaryBoard(Long userId, Long diaryId) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+		Diary diary = diaryService.getDiaryById(diaryId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_DIARY));
+
+		if (!isDiaryOwner(diary, user)) {
+			log.warn("권한이 없는 유저가 소셜 게시판 삭제 시도 - UserId: {}, DiaryId: {}, ", user.getId(), diary.getId());
+			throw CommonException.from(ExceptionCode.UNAUTHORIZED_ACCESS_DIARY);
+		}
+
+		diaryService.deleteDiary(diary);
+		log.info("일기 삭제 - UserId: {}, DiaryId: {}", userId, diaryId);
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -38,7 +38,7 @@ public class DiaryUseCase {
 	}
 
 	@Transactional
-	public void deleteDiaryBoard(Long userId, Long diaryId) {
+	public void deleteDiary(Long userId, Long diaryId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		Diary diary = diaryService.getDiaryById(diaryId)

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -4,6 +4,7 @@ import im.toduck.domain.diary.common.mapper.DiaryMapper;
 import im.toduck.domain.diary.domain.service.DiaryService;
 import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
@@ -33,10 +34,6 @@ public class DiaryUseCase {
 		return DiaryMapper.toDiaryCreateResponse(diary);
 	}
 
-	private boolean isDiaryOwner(final Diary diary, final User user) {
-		return diary.isOwner(user);
-	}
-
 	@Transactional
 	public void deleteDiaryBoard(Long userId, Long diaryId) {
 		User user = userService.getUserById(userId)
@@ -51,5 +48,29 @@ public class DiaryUseCase {
 
 		diaryService.deleteDiary(diary);
 		log.info("일기 삭제 - UserId: {}, DiaryId: {}", userId, diaryId);
+	}
+
+	@Transactional
+	public void updateDiary(
+		final Long userId,
+		final Long diaryId,
+		final DiaryUpdateRequest request
+	) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+		Diary diary = diaryService.getDiaryById(diaryId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_DIARY));
+
+		if (!isDiaryOwner(diary, user)) {
+			log.warn("권한이 없는 유저가 일기 수정 시도 - UserId: {}, DiaryId: {}", user.getId(), diary.getId());
+			throw CommonException.from(ExceptionCode.UNAUTHORIZED_ACCESS_DIARY);
+		}
+
+		diaryService.updateDiary(user, diary, request);
+		log.info("일기 수정 - UserId: {}, DiaryId: {}", userId, diaryId);
+	}
+
+	private boolean isDiaryOwner(final Diary diary, final User user) {
+		return diary.isOwner(user);
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -84,6 +84,7 @@ public class DiaryUseCase {
 		return diaryService.getDiariesByMonth(userId, year, month);
 	}
 
+	@Transactional
 	public List<DiaryResponse> getAllDiaries(final Long userId) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -37,7 +38,7 @@ public class Diary extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -70,4 +70,8 @@ public class Diary extends BaseEntity {
 		this.title = title;
 		this.memo = memo;
 	}
+
+	public boolean isOwner(User requestingUser) {
+		return this.user.getId().equals(requestingUser.getId());
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -23,7 +23,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,7 +31,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "diary")
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 @SQLDelete(sql = "UPDATE record SET deleted_at = NOW() where id=?")
 @SQLRestriction(value = "deleted_at is NULL")
 public class Diary extends BaseEntity {
@@ -45,7 +43,7 @@ public class Diary extends BaseEntity {
 	private User user;
 
 	@Column(name = "diary_date", nullable = false)
-	private LocalDate diaryDate;
+	private LocalDate date;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -62,12 +60,12 @@ public class Diary extends BaseEntity {
 
 	@Builder
 	private Diary(User user,
-		LocalDate diaryDate,
+		LocalDate date,
 		Emotion emotion,
 		String title,
 		String memo) {
 		this.user = user;
-		this.diaryDate = diaryDate;
+		this.date = date;
 		this.emotion = emotion;
 		this.title = title;
 		this.memo = memo;

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -74,4 +74,16 @@ public class Diary extends BaseEntity {
 	public boolean isOwner(User requestingUser) {
 		return this.user.getId().equals(requestingUser.getId());
 	}
+
+	public void updateEmotion(Emotion emotion) {
+		this.emotion = emotion;
+	}
+
+	public void updateTitle(String title) {
+		this.title = title;
+	}
+
+	public void updateMemo(String memo) {
+		this.memo = memo;
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -23,6 +23,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,6 +32,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "diary")
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @SQLDelete(sql = "UPDATE record SET deleted_at = NOW() where id=?")
 @SQLRestriction(value = "deleted_at is NULL")
 public class Diary extends BaseEntity {

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -1,6 +1,8 @@
 package im.toduck.domain.diary.persistence.entity;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -8,6 +10,7 @@ import org.hibernate.annotations.SQLRestriction;
 import im.toduck.domain.user.persistence.entity.Emotion;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.base.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -16,7 +19,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,7 +40,7 @@ public class Diary extends BaseEntity {
 	private User user;
 
 	@Column(nullable = false)
-	private LocalDate date; // 연월일만 저장
+	private LocalDate date;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -44,9 +49,22 @@ public class Diary extends BaseEntity {
 	@Column(length = 50)
 	private String title;
 
-	@Column(length = 256)
-	private String img;
-
 	@Column(length = 2048)
 	private String memo;
+
+	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<DiaryImage> diaryImages = new ArrayList<>();
+
+	@Builder
+	public Diary(User user,
+		LocalDate date,
+		Emotion emotion,
+		String title,
+		String memo) {
+		this.user = user;
+		this.date = date;
+		this.emotion = emotion;
+		this.title = title;
+		this.memo = memo;
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -19,6 +19,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Builder;
@@ -36,6 +37,7 @@ public class Diary extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@ManyToOne
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
@@ -1,0 +1,40 @@
+package im.toduck.domain.diary.persistence.entity;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import im.toduck.global.base.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "diary_images")
+@Getter
+@NoArgsConstructor
+@SQLDelete(sql = "UPDATE record SET deleted_at = NOW() where id=?")
+@SQLRestriction(value = "deleted_at is NULL")
+public class DiaryImage extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "diary_id", nullable = false)
+	private Diary diary;
+
+	@Column(name = "image_url", length = 256, nullable = false)
+	private String imgUrl;
+
+	public DiaryImage(Diary diary, String imgUrl) {
+		this.diary = diary;
+		this.imgUrl = imgUrl;
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
@@ -37,7 +37,7 @@ public class DiaryImage extends BaseEntity {
 	private String url;
 
 	@Builder
-	public DiaryImage(Diary diary, String url) {
+	private DiaryImage(Diary diary, String url) {
 		this.diary = diary;
 		this.url = url;
 	}

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
@@ -12,11 +12,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "diary_images")
+@Table(name = "diary_image_file")
 @Getter
 @NoArgsConstructor
 @SQLDelete(sql = "UPDATE record SET deleted_at = NOW() where id=?")
@@ -30,11 +31,12 @@ public class DiaryImage extends BaseEntity {
 	@JoinColumn(name = "diary_id", nullable = false)
 	private Diary diary;
 
-	@Column(name = "image_url", length = 256, nullable = false)
-	private String imgUrl;
+	@Column(name = "url", length = 512, nullable = false)
+	private String url;
 
-	public DiaryImage(Diary diary, String imgUrl) {
+	@Builder
+	public DiaryImage(Diary diary, String url) {
 		this.diary = diary;
-		this.imgUrl = imgUrl;
+		this.url = url;
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
@@ -1,5 +1,7 @@
 package im.toduck.domain.diary.persistence.entity;
 
+import java.time.LocalDateTime;
+
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -38,5 +40,9 @@ public class DiaryImage extends BaseEntity {
 	public DiaryImage(Diary diary, String url) {
 		this.diary = diary;
 		this.url = url;
+	}
+
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryImageRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryImageRepository.java
@@ -9,4 +9,6 @@ import im.toduck.domain.diary.persistence.entity.DiaryImage;
 
 public interface DiaryImageRepository extends JpaRepository<DiaryImage, Long> {
 	List<DiaryImage> findAllByDiary(Diary diary);
+
+	void deleteAllByDiary(Diary diary);
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryImageRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryImageRepository.java
@@ -1,0 +1,12 @@
+package im.toduck.domain.diary.persistence.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.persistence.entity.DiaryImage;
+
+public interface DiaryImageRepository extends JpaRepository<DiaryImage, Long> {
+	List<DiaryImage> findAllByDiary(Diary diary);
+}

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
@@ -10,5 +10,5 @@ import im.toduck.domain.diary.persistence.entity.Diary;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-	List<Diary> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+	List<Diary> findByUserIdAndDateBetweenOrderByDateDesc(Long userId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
@@ -11,4 +11,6 @@ import im.toduck.domain.diary.persistence.entity.Diary;
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	List<Diary> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+
+	List<Diary> findAllByUserId(Long userId);
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
@@ -11,6 +11,4 @@ import im.toduck.domain.diary.persistence.entity.Diary;
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	List<Diary> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
-
-	List<Diary> findAllByUserId(Long userId);
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
@@ -1,5 +1,8 @@
 package im.toduck.domain.diary.persistence.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +10,5 @@ import im.toduck.domain.diary.persistence.entity.Diary;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+	List<Diary> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -133,23 +133,4 @@ public interface DiaryApi {
 		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
-
-	@Operation(
-		summary = "모든 작성된 일기 검색",
-		description =
-			"""
-				<b>모든 작성된 일기들을 조회합니다.</b><br/><br/>
-				<p>조회 방법 예시: /v1/diary/all</p><br/>
-				<p>검색 결과가 존재하지 않는 경우 빈 배열이 반환됩니다.</p>
-				"""
-	)
-	@ApiResponseExplanations(
-		success = @ApiSuccessResponseExplanation(
-			responseClass = DiaryResponse.class,
-			description = "일기 조회 성공, 모든 작성된 일기들을 반환합니다."
-		)
-	)
-	ResponseEntity<ApiResponse<List<DiaryResponse>>> getAllDiaries(
-		@AuthenticationPrincipal CustomUserDetails user
-	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -133,4 +133,23 @@ public interface DiaryApi {
 		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
+
+	@Operation(
+		summary = "모든 작성된 일기 검색",
+		description =
+			"""
+				<b>모든 작성된 일기들을 조회합니다.</b><br/><br/>
+				<p>조회 방법 예시: /v1/diary/all</p><br/>
+				<p>검색 결과가 존재하지 않는 경우 빈 배열이 반환됩니다.</p>
+				"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = DiaryResponse.class,
+			description = "일기 조회 성공, 모든 작성된 일기들을 반환합니다."
+		)
+	)
+	ResponseEntity<ApiResponse<List<DiaryResponse>>> getAllDiaries(
+		@AuthenticationPrincipal CustomUserDetails user
+	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -1,13 +1,18 @@
 package im.toduck.domain.diary.presentation.api;
 
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.exception.ExceptionCode;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,5 +34,23 @@ public interface DiaryApi {
 	ResponseEntity<ApiResponse<DiaryCreateResponse>> createDiary(
 		@RequestBody @Valid DiaryCreateRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+
+	@Operation(
+		summary = "일기 삭제",
+		description = "일기를 삭제합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "일기 삭제 성공, 빈 content 객체를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_DIARY),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.UNAUTHORIZED_ACCESS_DIARY)
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> deleteDiary(
+		@PathVariable Long diaryId,
+		@AuthenticationPrincipal CustomUserDetails user
 	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -1,0 +1,38 @@
+package im.toduck.domain.diary.presentation.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
+import im.toduck.global.annotation.swagger.ApiResponseExplanations;
+import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.exception.ExceptionCode;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "Diary")
+public interface DiaryApi {
+	@Operation(
+		summary = "일기 생성",
+		description = "일기를 작성합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = DiaryCreateResponse.class,
+			description = "일기 생성 성공, 생성된 일기의 Id를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_EMOTION)
+		}
+	)
+	ResponseEntity<ApiResponse<DiaryCreateResponse>> createDiary(
+		@RequestBody @Valid DiaryCreateRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -1,15 +1,18 @@
 package im.toduck.domain.diary.presentation.api;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -99,12 +102,35 @@ public interface DiaryApi {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_DIARY),
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.UNAUTHORIZED_ACCESS_DIARY),
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.INVALID_DIARY_EMOTION)
-
 		}
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> updateDiary(
 		@PathVariable Long diaryId,
 		@AuthenticationPrincipal DiaryUpdateRequest request,
+		@AuthenticationPrincipal CustomUserDetails user
+	);
+
+	@Operation(
+		summary = "특정 연월에 작성된 일기 검색",
+		description =
+			"""
+				<b>특정 연월에 작성된 일기들을 조회합니다.</b><br/><br/>
+				<p><b>연월 필터를 적용하는 방법:</b></p>
+				<p>예시: /v1/diary?year=2025&month=3</p><br/>
+				<p>- <b>year:</b> 조회 할 연도</p>
+				<p>- <b>month:</b> 조회 할 달</p>
+				<p>검색 결과가 존재하지 않는 경우 빈 배열이 반환됩니다.</p>
+				"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = DiaryResponse.class,
+			description = "일기 조회 성공, 해당 연월에 작성된 일기들을 반환합니다."
+		)
+	)
+	ResponseEntity<ApiResponse<List<DiaryResponse>>> getDiariesByMonth(
+		@RequestParam("year") int year,
+		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -99,10 +99,8 @@ public interface DiaryApi {
 			description = "일기 수정 성공, 빈 content 객체를 반환합니다."
 		),
 		errors = {
-			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.EMPTY_DIARY_EMOTION),
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_DIARY),
-			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.UNAUTHORIZED_ACCESS_DIARY),
-			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.INVALID_DIARY_EMOTION)
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.UNAUTHORIZED_ACCESS_DIARY)
 		}
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> updateDiary(

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -6,10 +6,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
-import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
-import im.toduck.global.exception.ExceptionCode;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,10 +24,7 @@ public interface DiaryApi {
 		success = @ApiSuccessResponseExplanation(
 			responseClass = DiaryCreateResponse.class,
 			description = "일기 생성 성공, 생성된 일기의 Id를 반환합니다."
-		),
-		errors = {
-			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_EMOTION)
-		}
+		)
 	)
 	ResponseEntity<ApiResponse<DiaryCreateResponse>> createDiary(
 		@RequestBody @Valid DiaryCreateRequest request,

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -73,6 +73,7 @@ public interface DiaryApi {
 				}<br/><br/>
 				<p>위 예시는 감정, 제목, 이미지를 수정하며, 메모는 변경하지 않는 경우입니다.</p><br/>
 				<b>필드별 동작 방식:</b><br/>
+				<p>- <b>isChangeEmotion</b>: emotion 값이 변경 됐는지 boolean 값으로 확인합니다. null 값이 들어갈 수 없습니다.</p>
 				<p>- <b>emotion</b>: isChangeEmotion이 true인 경우에만 내용을 수정합니다. null 값이 들어갈 수 없습니다.</p>
 				<p>- <b>title</b>: null이 아닌 경우에만 제목을 수정합니다. null인 경우 기존 제목이 유지됩니다.</p>
 				<p>- <b>memo</b>: null이 아닌 경우에만 메모(일기)를 수정합니다. null인 경우 기존 메모(일기)가 유지됩니다.</p>

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
@@ -51,6 +52,59 @@ public interface DiaryApi {
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> deleteDiary(
 		@PathVariable Long diaryId,
+		@AuthenticationPrincipal CustomUserDetails user
+	);
+
+	@Operation(
+		summary = "일기 수정",
+		description =
+			"""
+				<b>일기 수정 API는 수정이 필요한 필드(날짜 제외)만 포함하여 요청할 수 있습니다.</b><br/><br/>
+				<p>예시 요청:</p><br/>
+				{<br/>
+				"isChangeEmotion": true,<br/>
+				"emotion": "HAPPY",<br/>
+				"title": "수정된 제목입니다.",<br/>
+				"memo": null,<br/>
+				"diaryImageUrls": ["https://cdn.toduck.app/new-image.jpg"]<br/>
+				}<br/><br/>
+				<p>위 예시는 감정, 제목, 이미지를 수정하며, 메모는 변경하지 않는 경우입니다.</p><br/>
+				<b>필드별 동작 방식:</b><br/>
+				<p>- <b>emotion</b>: isChangeEmotion이 true인 경우에만 내용을 수정합니다. null 값이 들어갈 수 없습니다.</p>
+				<p>- <b>title</b>: null이 아닌 경우에만 제목을 수정합니다. null인 경우 기존 제목이 유지됩니다.</p>
+				<p>- <b>memo</b>: null이 아닌 경우에만 메모(일기)를 수정합니다. null인 경우 기존 메모(일기)가 유지됩니다.</p>
+				<p>- <b>diaryImageUrls</b>: null인 경우 이미지를 수정하지 않습니다. 빈 배열([])을 전달하면 이미지를 모두 제거합니다.</p><br/>
+				<b>감정 관련 시나리오 (isChangeEmotion, emotion은 필수값):</b><br/>
+				<p>1. <b>감정 유지</b>: isChangeEmotion = false, emotion = 기존 감정</p>
+				<p>2. <b>감정 변경</b>: isChangeEmotion = true, emotion = 변경할 감정(null인 경우 예외발생)</p><br/>
+				<b>제목 관련 시나리오:</b><br/>
+				<p>1. <b>제목 유지</b>: title = null</p>
+				<p>2. <b>제목 변경</b>: title = 변경할 제목(지우고 싶은 경우 빈 문자열)</p>
+				<b>메모(일기) 관련 시나리오:</b><br/>
+				<p>1. <b>메모 유지</b>: memo = null</p>
+				<p>2. <b>메모 수정</b>: memo = 변경할 내용(지우고 싶은 경우 빈 문자열)</p>
+				<b>이미지 관련 시나리오:</b><br/>
+				<p>1. <b>이미지 유지</b>: diaryImageUrls = null (이미지를 수정하지 않음)</p>
+				<p>2. <b>이미지 추가/수정</b>: diaryImageUrls = [새로운 이미지 URL 리스트]</p>
+				<p>3. <b>이미지 모두 제거</b>: diaryImageUrls = [] (기존 이미지를 모두 제거)</p>
+				<p>4. <b>최대 이미지 초과</b>: diaryImageUrls = [이미지 URL 3개 이상] (예외 발생)</p><br/>
+				"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "일기 수정 성공, 빈 content 객체를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.EMPTY_DIARY_EMOTION),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_DIARY),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.UNAUTHORIZED_ACCESS_DIARY),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.INVALID_DIARY_EMOTION)
+
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> updateDiary(
+		@PathVariable Long diaryId,
+		@AuthenticationPrincipal DiaryUpdateRequest request,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import im.toduck.domain.diary.domain.usecase.DiaryUseCase;
 import im.toduck.domain.diary.presentation.api.DiaryApi;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
@@ -48,6 +50,19 @@ public class DiaryController implements DiaryApi {
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
 		diaryUseCase.deleteDiaryBoard(user.getUserId(), diaryId);
+
+		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@Override
+	@PatchMapping("/{diaryId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> updateDiary(
+		@PathVariable Long diaryId,
+		@RequestBody @Valid DiaryUpdateRequest request,
+		@AuthenticationPrincipal CustomUserDetails user
+	) {
+		diaryUseCase.updateDiary(user.getUserId(), diaryId, request);
 
 		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
 	}

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -53,7 +53,7 @@ public class DiaryController implements DiaryApi {
 		@PathVariable Long diaryId,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
-		diaryUseCase.deleteDiaryBoard(user.getUserId(), diaryId);
+		diaryUseCase.deleteDiary(user.getUserId(), diaryId);
 
 		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
 	}

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -82,4 +82,14 @@ public class DiaryController implements DiaryApi {
 		List<DiaryResponse> diaries = diaryUseCase.getDiariesByMonth(user.getUserId(), year, month);
 		return ResponseEntity.ok(ApiResponse.createSuccess(diaries));
 	}
+
+	@Override
+	@GetMapping("/all")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<List<DiaryResponse>>> getAllDiaries(
+		@AuthenticationPrincipal CustomUserDetails user
+	) {
+		List<DiaryResponse> diaries = diaryUseCase.getAllDiaries(user.getUserId());
+		return ResponseEntity.ok(ApiResponse.createSuccess(diaries));
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -1,0 +1,38 @@
+package im.toduck.domain.diary.presentation.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import im.toduck.domain.diary.domain.usecase.DiaryUseCase;
+import im.toduck.domain.diary.presentation.api.DiaryApi;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/diary")
+public class DiaryController implements DiaryApi {
+
+	private final DiaryUseCase diaryUseCase;
+
+	@Override
+	@PostMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<DiaryCreateResponse>> createDiary(
+		@RequestBody @Valid final DiaryCreateRequest request,
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.createSuccess(diaryUseCase.createDiary(userDetails.getUserId(), request))
+		);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -1,8 +1,12 @@
 package im.toduck.domain.diary.presentation.controller;
 
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,5 +38,17 @@ public class DiaryController implements DiaryApi {
 		return ResponseEntity.ok(
 			ApiResponse.createSuccess(diaryUseCase.createDiary(userDetails.getUserId(), request))
 		);
+	}
+
+	@Override
+	@DeleteMapping("/{diaryId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteDiary(
+		@PathVariable Long diaryId,
+		@AuthenticationPrincipal CustomUserDetails user
+	) {
+		diaryUseCase.deleteDiaryBoard(user.getUserId(), diaryId);
+
+		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -1,16 +1,19 @@
 package im.toduck.domain.diary.presentation.controller;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import im.toduck.domain.diary.domain.usecase.DiaryUseCase;
@@ -18,6 +21,7 @@ import im.toduck.domain.diary.presentation.api.DiaryApi;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -65,5 +69,17 @@ public class DiaryController implements DiaryApi {
 		diaryUseCase.updateDiary(user.getUserId(), diaryId, request);
 
 		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@Override
+	@GetMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<List<DiaryResponse>>> getDiariesByMonth(
+		@RequestParam("year") int year,
+		@RequestParam("month") int month,
+		@AuthenticationPrincipal CustomUserDetails user
+	) {
+		List<DiaryResponse> diaries = diaryUseCase.getDiariesByMonth(user.getUserId(), year, month);
+		return ResponseEntity.ok(ApiResponse.createSuccess(diaries));
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -82,14 +82,4 @@ public class DiaryController implements DiaryApi {
 		List<DiaryResponse> diaries = diaryUseCase.getDiariesByMonth(user.getUserId(), year, month);
 		return ResponseEntity.ok(ApiResponse.createSuccess(diaries));
 	}
-
-	@Override
-	@GetMapping("/all")
-	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<List<DiaryResponse>>> getAllDiaries(
-		@AuthenticationPrincipal CustomUserDetails user
-	) {
-		List<DiaryResponse> diaries = diaryUseCase.getAllDiaries(user.getUserId());
-		return ResponseEntity.ok(ApiResponse.createSuccess(diaries));
-	}
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
@@ -1,0 +1,34 @@
+package im.toduck.domain.diary.presentation.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import im.toduck.domain.user.persistence.entity.Emotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "다이어리 생성 요청 DTO")
+public record DiaryCreateRequest(
+	@NotNull(message = "날짜는 비어있을 수 없습니다.")
+	@Schema(description = "일기 날짜", example = "2025-03-12")
+	LocalDate date,
+
+	@NotNull(message = "감정은 비어있을 수 없습니다.")
+	@Schema(description = "감정", example = "HAPPY")
+	Emotion emotion,
+
+	@Size(max = 16, message = "제목은 16자를 초과할 수 없습니다.")
+	@Schema(description = "일기 제목", example = "슬퍼")
+	String title,
+
+	@Size(max = 200, message = "일기는 200자를 초과할 수 없습니다.")
+	@Schema(description = "문장 기록", example = "출근 전에 지갑을 두고 나오는 바람에 다시 돌아갔다")
+	String memo,
+
+	@Size(max = 2, message = "이미지는 최대 2개까지만 등록할 수 있습니다.")
+	@Schema(description = "이미지 URL 목록", example = "[\"https://cdn.toduck.app/image1.jpg\"]")
+	List<String> diaryImageUrls
+) {
+
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
@@ -1,0 +1,35 @@
+package im.toduck.domain.diary.presentation.dto.request;
+
+import java.util.List;
+
+import im.toduck.domain.user.persistence.entity.Emotion;
+import io.micrometer.common.lang.Nullable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record DiaryUpdateRequest(
+	@NotNull
+	@Schema(description = "감정 변경 여부", example = "true")
+	boolean isChangeEmotion,
+
+	@NotNull
+	@Schema(description = "기존/변경된 감정", example = "HAPPY")
+	Emotion emotion,
+
+	@Nullable
+	@Size(min = 1, max = 50, message = "제목은 공백일 수 없으며 50자 이하여야 합니다.")
+	@Schema(description = "변경된 제목", example = "오늘의 기분은 최고!")
+	String title,
+
+	@Nullable
+	@Size(min = 1, max = 2048, message = "메모는 공백일 수 없으며 2048자 이하여야 합니다.")
+	@Schema(description = "변경된 메모", example = "오늘 하루를 기록해봅니다...")
+	String memo,
+
+	@Nullable
+	@Size(max = 5, message = "이미지는 최대 2개까지만 등록할 수 있습니다.")
+	@Schema(description = "변경된 이미지 URL 목록", example = "[\"https://cdn.app/image1.jpg\"]")
+	List<String> diaryImageUrls
+) {
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "다이어리 수정 요청 DTO")
 public record DiaryUpdateRequest(
 	@NotNull
 	@Schema(description = "감정 변경 여부", example = "true")

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
@@ -18,17 +18,17 @@ public record DiaryUpdateRequest(
 	Emotion emotion,
 
 	@Nullable
-	@Size(min = 1, max = 50, message = "제목은 공백일 수 없으며 50자 이하여야 합니다.")
+	@Size(max = 50, message = "제목은 공백일 수 없으며 50자 이하여야 합니다.")
 	@Schema(description = "변경된 제목", example = "오늘의 기분은 최고!")
 	String title,
 
 	@Nullable
-	@Size(min = 1, max = 2048, message = "메모는 공백일 수 없으며 2048자 이하여야 합니다.")
+	@Size(max = 2048, message = "메모는 공백일 수 없으며 2048자 이하여야 합니다.")
 	@Schema(description = "변경된 메모", example = "오늘 하루를 기록해봅니다...")
 	String memo,
 
 	@Nullable
-	@Size(max = 5, message = "이미지는 최대 2개까지만 등록할 수 있습니다.")
+	@Size(max = 2, message = "이미지는 최대 2개까지만 등록할 수 있습니다.")
 	@Schema(description = "변경된 이미지 URL 목록", example = "[\"https://cdn.app/image1.jpg\"]")
 	List<String> diaryImageUrls
 ) {

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryCreateResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryCreateResponse.java
@@ -1,0 +1,13 @@
+package im.toduck.domain.diary.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "일기 생성 응답 DTO")
+@Builder
+public record DiaryCreateResponse(
+	@Schema(description = "생성된 일기 Id", example = "1")
+	Long diaryId
+) {
+
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryImageDto.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryImageDto.java
@@ -1,0 +1,21 @@
+package im.toduck.domain.diary.presentation.dto.response;
+
+import im.toduck.domain.diary.persistence.entity.DiaryImage;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record DiaryImageDto(
+	@Schema(description = "이미지 Id", example = "1")
+	Long diaryImageId,
+
+	@Schema(description = "이미지 URL", example = "https://cdn.toduck.app/image1.jpg")
+	String url
+) {
+	public static DiaryImageDto fromEntity(DiaryImage diaryImage) {
+		return new DiaryImageDto(
+			diaryImage.getId(),
+			diaryImage.getUrl()
+		);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryImageDto.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryImageDto.java
@@ -1,6 +1,5 @@
 package im.toduck.domain.diary.presentation.dto.response;
 
-import im.toduck.domain.diary.persistence.entity.DiaryImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -12,10 +11,5 @@ public record DiaryImageDto(
 	@Schema(description = "이미지 URL", example = "https://cdn.toduck.app/image1.jpg")
 	String url
 ) {
-	public static DiaryImageDto fromEntity(DiaryImage diaryImage) {
-		return new DiaryImageDto(
-			diaryImage.getId(),
-			diaryImage.getUrl()
-		);
-	}
+
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryResponse.java
@@ -1,0 +1,40 @@
+package im.toduck.domain.diary.presentation.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.user.persistence.entity.Emotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record DiaryResponse(
+	@Schema(description = "날짜", example = "2025-03-21")
+	LocalDate date,
+
+	@Schema(description = "감정", example = "HAPPY")
+	Emotion emotion,
+
+	@Schema(description = "제목", example = "행복한 기분")
+	String title,
+
+	@Schema(description = "메모", example = "오늘은 좋은 일이 있었다")
+	String memo,
+
+	@Schema(description = "일기 이미지 목록")
+	List<DiaryImageDto> diaryImages
+) {
+	public static DiaryResponse fromEntity(Diary diary) {
+		return new DiaryResponse(
+			diary.getDate(),
+			diary.getEmotion(),
+			diary.getTitle(),
+			diary.getMemo(),
+			diary.getDiaryImages().stream()
+				.map(DiaryImageDto::fromEntity)
+				.collect(Collectors.toList())
+		);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryResponse.java
@@ -2,9 +2,7 @@ package im.toduck.domain.diary.presentation.dto.response;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.user.persistence.entity.Emotion;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -26,15 +24,5 @@ public record DiaryResponse(
 	@Schema(description = "일기 이미지 목록")
 	List<DiaryImageDto> diaryImages
 ) {
-	public static DiaryResponse fromEntity(Diary diary) {
-		return new DiaryResponse(
-			diary.getDate(),
-			diary.getEmotion(),
-			diary.getTitle(),
-			diary.getMemo(),
-			diary.getDiaryImages().stream()
-				.map(DiaryImageDto::fromEntity)
-				.collect(Collectors.toList())
-		);
-	}
+
 }

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -82,7 +82,7 @@ public enum ExceptionCode {
 	INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, 40419, "답글은 부모 댓글이 될 수 없습니다."),
 
 	/* 405xx diary */
-	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 45001, "유효하지 않은 감정입니다."),
+	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 40501, "유효하지 않은 감정입니다."),
 
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -82,6 +82,8 @@ public enum ExceptionCode {
 	INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, 40419, "답글은 부모 댓글이 될 수 없습니다."),
 
 	/* 405xx diary */
+	NOT_FOUND_DIARY(HttpStatus.NOT_FOUND, 40501, "일기를 찾을 수 없습니다."),
+	UNAUTHORIZED_ACCESS_DIARY(HttpStatus.FORBIDDEN, 40502, "일기에 접근 권한이 없습니다."),
 
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -95,6 +95,9 @@ public enum ExceptionCode {
 	PRIVATE_ROUTINE(HttpStatus.FORBIDDEN, 43203, "비공개된 루틴입니다.",
 		"요청하신 루틴은 비공개 상태입니다. 접근 권한이 없는 경우 접근할 수 없습니다."),
 
+	/* 450xx diary */
+	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 45001, "유효하지 않은 감정입니다."),
+
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),
 	METHOD_FORBIDDEN(HttpStatus.METHOD_NOT_ALLOWED, 49902, "지원하지 않는 HTTP 메서드를 사용합니다."),

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -82,7 +82,6 @@ public enum ExceptionCode {
 	INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, 40419, "답글은 부모 댓글이 될 수 없습니다."),
 
 	/* 405xx diary */
-	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 40501, "유효하지 않은 감정입니다."),
 
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -84,8 +84,6 @@ public enum ExceptionCode {
 	/* 405xx diary */
 	NOT_FOUND_DIARY(HttpStatus.NOT_FOUND, 40501, "일기를 찾을 수 없습니다."),
 	UNAUTHORIZED_ACCESS_DIARY(HttpStatus.FORBIDDEN, 40502, "일기에 접근 권한이 없습니다."),
-	EMPTY_DIARY_EMOTION(HttpStatus.BAD_REQUEST, 40503, "감정은 null일 수 없습니다."),
-	INVALID_DIARY_EMOTION(HttpStatus.BAD_REQUEST, 40504, "잘못된 감정 값이 입력됐습니다."),
 
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -84,6 +84,8 @@ public enum ExceptionCode {
 	/* 405xx diary */
 	NOT_FOUND_DIARY(HttpStatus.NOT_FOUND, 40501, "일기를 찾을 수 없습니다."),
 	UNAUTHORIZED_ACCESS_DIARY(HttpStatus.FORBIDDEN, 40502, "일기에 접근 권한이 없습니다."),
+	EMPTY_DIARY_EMOTION(HttpStatus.BAD_REQUEST, 40503, "감정은 null일 수 없습니다."),
+	INVALID_DIARY_EMOTION(HttpStatus.BAD_REQUEST, 40504, "잘못된 감정 값이 입력됐습니다."),
 
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -81,6 +81,9 @@ public enum ExceptionCode {
 	NOT_FOUND_PARENT_COMMENT(HttpStatus.NOT_FOUND, 40418, "부모 댓글을 찾을 수 없습니다."),
 	INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, 40419, "답글은 부모 댓글이 될 수 없습니다."),
 
+	/* 405xx diary */
+	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 45001, "유효하지 않은 감정입니다."),
+
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",
 		"일정 기록을 찾을 수 없을 때 발생하는 오류입니다."),
@@ -94,9 +97,6 @@ public enum ExceptionCode {
 		"요청된 날짜에 대한 루틴 변경이 불가능합니다. 루틴의 반복 요일과 현재 날짜를 확인하고 올바른 날짜로 다시 요청해 주세요."),
 	PRIVATE_ROUTINE(HttpStatus.FORBIDDEN, 43203, "비공개된 루틴입니다.",
 		"요청하신 루틴은 비공개 상태입니다. 접근 권한이 없는 경우 접근할 수 없습니다."),
-
-	/* 450xx diary */
-	NOT_FOUND_EMOTION(HttpStatus.NOT_FOUND, 45001, "유효하지 않은 감정입니다."),
 
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),


### PR DESCRIPTION
## ✨ 작업 내용

> Diary 삭제, 수정, 특정 연월 일기 조회 API를 작성했습니다.


**1️⃣ 작업내용1**

- 수정시에 `date` 값은 변하면 안되기 때문에 제외했고 `emotion` 값은 변경할 수 있으나 `NotNull`이기 때문에 예외처리에 신경썼습니다.  다른 변수들은 `null`이 아닌 경우 수정하도록 했지만 `emotion`은 `isChangeEmotion`이 `true`인 경우에만 수정하도록 했습니다. `isChangeEmotion`이 `false`인 경우에도 `emotion` 값에는 `null`이 들어가면 안될 것 같아 그에 대한 예외처리 코드를 DiaryService에 작성했습니다. 자세한 내용은 DiaryApi에 작성했습니다.
  <br/>

**2️⃣ 작업내용2**

- 특정 연월 일기 조회는 year(yyyy)와 month(MM)를 param에 전달하면 해당 달에 작성된 일기들의 정보를 가져옵니다.
    아래 화면에서 사용될 것을 생각하여 만들었습니다.
![image](https://github.com/user-attachments/assets/83cf336b-8665-4b0c-a974-7c101f31ff15)
  <br/>

## ✅ 리뷰 요구사항(선택)

> 일기에는 이미지가 최대 2개까지 들어가는데 지금 코드로는 사진을 2개 올리고 하나만 수정을 할 수 있는지 모르겠습니다.

> 사진은 최대 2개까지 올릴 수 있는데 DiaryUpdateRequest에 `diaryImageUrls`에 `@Size`에 `max`값을 2로 주면 이것만으로 예외처리가 되는지 궁금합니다.

> 일기를 조회할 때 Mapper를 사용하지 않는 방식으로 했는데 이렇게 해도 되는지 궁금합니다.

> 일기를 저장할 때 시간 순서에 따라 차례대로 저장이 될텐데 그럼 조회할 때 따로 정렬을 하지 않아도 정렬된 순서로 값을 가져오는지 궁금합니다.

> 이외에도 부족한 점이 있다면 알려주시면 감사하겠습니다!!!