### PR TITLE
소셜 게시글 이미지가 null/빈 값 에러 해결

### DIFF
--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -142,6 +142,10 @@ public class SocialBoardService {
 
 	@Transactional
 	public void addSocialImageFiles(final List<String> imageUrls, final Social socialBoard) {
+		if (imageUrls == null || imageUrls.isEmpty()) {
+			return;
+		}
+
 		List<SocialImageFile> socialImageFiles = imageUrls.stream()
 			.map(url -> SocialImageFileMapper.toSocialImageFile(socialBoard, url))
 			.toList();

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -91,7 +91,6 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 	@Nested
 	@DisplayName("게시글 작성시")
 	class CreateSocialBoard {
-		String title = "Test title";
 		String content = "Test Content";
 		Boolean isAnonymous = false;
 		List<String> imageUrls = List.of("image1.jpg", "image2.jpg");
@@ -192,10 +191,9 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@ParameterizedTest
 		@NullAndEmptySource
-		@DisplayName("이미지 URL이 null 또는 빈 리스트일 때 게시글 생성에 성공한다")
-		void 이미지URL이_null이거나_빈_리스트일때_게시글_작성_성공한다(List<String> nullAndEmptyImageUrls) {
+		void 이미지URL이_null이거나_빈_리스트일때_게시글_작성에_성공한다(List<String> nullAndEmptyImageUrls) {
 			SocialCreateRequest requestWithoutImages = new SocialCreateRequest(
-				title,
+				null,
 				content,
 				null,
 				isAnonymous,

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,6 +91,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 	@Nested
 	@DisplayName("게시글 작성시")
 	class CreateSocialBoard {
+		String title = "Test title";
 		String content = "Test Content";
 		Boolean isAnonymous = false;
 		List<String> imageUrls = List.of("image1.jpg", "image2.jpg");
@@ -186,6 +188,29 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			assertThatThrownBy(() -> socialBoardUseCase.createSocialBoard(USER.getId(), requestWithPrivateRoutine))
 				.isInstanceOf(CommonException.class)
 				.hasMessage(ExceptionCode.PRIVATE_ROUTINE.getMessage());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@DisplayName("이미지 URL이 null 또는 빈 리스트일 때 게시글 생성에 성공한다")
+		void 이미지URL이_null이거나_빈_리스트일때_게시글_작성_성공한다(List<String> nullAndEmptyImageUrls) {
+			SocialCreateRequest requestWithoutImages = new SocialCreateRequest(
+				title,
+				content,
+				null,
+				isAnonymous,
+				categoryIds,
+				nullAndEmptyImageUrls
+			);
+
+			// when
+			SocialCreateResponse response = socialBoardUseCase.createSocialBoard(USER.getId(), requestWithoutImages);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(response).isNotNull();
+				softly.assertThat(response.socialId()).isNotNull();
+			});
 		}
 
 	}


### PR DESCRIPTION
## ✨ 작업 내용


**1️⃣ 소셜 게시글 이미지 추가 로직 수정**

-  imageUrls가 null 또는 빈 값인 경우, 바로 리턴하도록 수정하여 `NullPointerException` 해결 

## ✅ 리뷰 요구사항
- 질문 있으시면 댓글 남겨주세요!
