### PR TITLE
댓글 이미지 첨부 기능 추가

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -93,6 +93,16 @@ CREATE TABLE comment_likes
     FOREIGN KEY (comment_id) REFERENCES comment (id)
 );
 
+CREATE TABLE comment_image_file
+(
+    id         BIGINT PRIMARY KEY auto_increment,
+    comment_id BIGINT        NOT NULL,
+    url        VARCHAR(1024) NOT NULL,
+    created_at DATETIME      NOT NULL,
+    updated_at DATETIME      NOT NULL,
+    deleted_at DATETIME      NULL,
+    FOREIGN KEY (comment_id) REFERENCES comment (id) ON DELETE CASCADE
+);
 
 CREATE TABLE likes
 (

--- a/src/main/java/im/toduck/domain/social/common/mapper/CommentImageFileMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/CommentImageFileMapper.java
@@ -1,0 +1,16 @@
+package im.toduck.domain.social.common.mapper;
+
+import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentImageFile;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentImageFileMapper {
+	public static CommentImageFile toCommentImageFile(final Comment comment, final String url) {
+		return CommentImageFile.builder()
+			.comment(comment)
+			.url(url)
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/CommentMapper.java
@@ -40,6 +40,8 @@ public class CommentMapper {
 
 	public static CommentDto toCommentDto(
 		final Comment comment,
+		final boolean hasImage,
+		final String imageUrl,
 		final boolean isCommentLiked,
 		final boolean isBlocked
 	) {
@@ -47,6 +49,8 @@ public class CommentMapper {
 			.commentId(comment.getId())
 			.parentCommentId(getParentCommentId(comment))
 			.owner(getOwner(comment, isBlocked))
+			.hasImage(hasImage)
+			.imageUrl(imageUrl)
 			.content(getContent(comment, isBlocked))
 			.commentLikeInfo(getCommentLikeDto(comment, isCommentLiked))
 			.isReply(isReply(comment))

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -12,12 +12,14 @@ import im.toduck.domain.social.common.mapper.SocialCategoryLinkMapper;
 import im.toduck.domain.social.common.mapper.SocialImageFileMapper;
 import im.toduck.domain.social.common.mapper.SocialMapper;
 import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentImageFile;
 import im.toduck.domain.social.persistence.entity.CommentLike;
 import im.toduck.domain.social.persistence.entity.Like;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
 import im.toduck.domain.social.persistence.entity.SocialCategoryLink;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
+import im.toduck.domain.social.persistence.repository.CommentImageFileRepository;
 import im.toduck.domain.social.persistence.repository.CommentLikeRepository;
 import im.toduck.domain.social.persistence.repository.CommentRepository;
 import im.toduck.domain.social.persistence.repository.LikeRepository;
@@ -44,6 +46,7 @@ public class SocialBoardService {
 	private final SocialCategoryLinkRepository socialCategoryLinkRepository;
 	private final CommentRepository commentRepository;
 	private final CommentLikeRepository commentLikeRepository;
+	private final CommentImageFileRepository commentImageFileRepository;
 	private final LikeRepository likeRepository;
 
 	@Transactional(readOnly = true)
@@ -77,6 +80,7 @@ public class SocialBoardService {
 
 		List<Comment> comments = commentRepository.findAllBySocial(socialBoard);
 		comments.forEach(comment -> {
+			commentImageFileRepository.findByComment(comment).ifPresent(CommentImageFile::softDelete);
 			commentLikeRepository.findAllByComment(comment).forEach(CommentLike::softDelete);
 		});
 		comments.forEach(Comment::softDelete);

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -6,16 +6,19 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import im.toduck.domain.social.common.mapper.CommentImageFileMapper;
 import im.toduck.domain.social.common.mapper.CommentLikeMapper;
 import im.toduck.domain.social.common.mapper.CommentMapper;
 import im.toduck.domain.social.common.mapper.ReportMapper;
 import im.toduck.domain.social.common.mapper.SocialLikeMapper;
 import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentImageFile;
 import im.toduck.domain.social.persistence.entity.CommentLike;
 import im.toduck.domain.social.persistence.entity.Like;
 import im.toduck.domain.social.persistence.entity.Report;
 import im.toduck.domain.social.persistence.entity.ReportType;
 import im.toduck.domain.social.persistence.entity.Social;
+import im.toduck.domain.social.persistence.repository.CommentImageFileRepository;
 import im.toduck.domain.social.persistence.repository.CommentLikeRepository;
 import im.toduck.domain.social.persistence.repository.CommentRepository;
 import im.toduck.domain.social.persistence.repository.LikeRepository;
@@ -35,6 +38,7 @@ public class SocialInteractionService {
 	private final LikeRepository likeRepository;
 	private final ReportRepository reportRepository;
 	private final CommentLikeRepository commentLikeRepository;
+	private final CommentImageFileRepository commentImageFileRepository;
 
 	@Transactional
 	public Comment createComment(
@@ -190,5 +194,18 @@ public class SocialInteractionService {
 		comment.decrementLikeCount();
 	}
 
+	@Transactional
+	public void addCommentImageFile(final String imageUrl, final Comment comment) {
+		if (imageUrl == null) {
+			return;
+		}
+		CommentImageFile commentImageFile = CommentImageFileMapper.toCommentImageFile(comment, imageUrl);
+		commentImageFileRepository.save(commentImageFile);
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<CommentImageFile> getCommentImageByComment(final Comment comment) {
+		return commentImageFileRepository.findByComment(comment);
+	}
 }
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -72,8 +72,12 @@ public class SocialInteractionService {
 			throw CommonException.from(ExceptionCode.INVALID_COMMENT_FOR_BOARD);
 		}
 
+		commentImageFileRepository.findByComment(comment)
+			.ifPresent(commentImageFileRepository::delete);
+
 		List<CommentLike> commentLikes = commentLikeRepository.findAllByComment(comment);
 		commentLikeRepository.deleteAll(commentLikes);
+
 		commentRepository.delete(comment);
 	}
 

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
@@ -1,6 +1,7 @@
 package im.toduck.domain.social.domain.usecase;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
@@ -13,6 +14,7 @@ import im.toduck.domain.social.common.mapper.SocialMapper;
 import im.toduck.domain.social.domain.service.SocialBoardService;
 import im.toduck.domain.social.domain.service.SocialInteractionService;
 import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentImageFile;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
@@ -152,9 +154,17 @@ public class SocialBoardUseCase {
 
 		List<CommentDto> commentDtos = comments.stream()
 			.map((comment) -> {
+				Optional<CommentImageFile> commentImageFile = socialInteractionService.getCommentImageByComment(
+					comment
+				);
+				boolean hasImage = commentImageFile.isPresent();
+				String imageUrl = null;
+				if (hasImage) {
+					imageUrl = commentImageFile.get().getUrl();
+				}
 				boolean isCommentLike = socialInteractionService.getCommentIsLiked(user, comment);
 				boolean isBlocked = userService.isBlockedUser(user, comment.getUser());
-				return CommentMapper.toCommentDto(comment, isCommentLike, isBlocked);
+				return CommentMapper.toCommentDto(comment, hasImage, imageUrl, isCommentLike, isBlocked);
 			})
 			.toList();
 

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialInteractionUseCase.java
@@ -48,6 +48,7 @@ public class SocialInteractionUseCase {
 		Comment parentComment = getParentComment(request.parentId());
 
 		Comment comment = socialInteractionService.createComment(user, socialBoard, parentComment, request);
+		socialInteractionService.addCommentImageFile(request.imageUrl(), comment);
 
 		log.info("소셜 게시글 댓글 생성 - UserId: {}, SocialBoardId: {}, CommentId: {}", userId, socialId, comment.getId());
 		return CommentMapper.toCommentCreateResponse(comment);

--- a/src/main/java/im/toduck/domain/social/persistence/entity/CommentImageFile.java
+++ b/src/main/java/im/toduck/domain/social/persistence/entity/CommentImageFile.java
@@ -1,0 +1,46 @@
+package im.toduck.domain.social.persistence.entity;
+
+import java.time.LocalDateTime;
+
+import im.toduck.global.base.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment_image_file")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentImageFile extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "comment_id", nullable = false, unique = true)
+	private Comment comment;
+
+	@Column(nullable = false, length = 1024)
+	private String url;
+
+	@Builder
+	private CommentImageFile(final Comment comment, final String url) {
+		this.comment = comment;
+		this.url = url;
+	}
+
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/im/toduck/domain/social/persistence/repository/CommentImageFileRepository.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/CommentImageFileRepository.java
@@ -1,0 +1,12 @@
+package im.toduck.domain.social.persistence.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import im.toduck.domain.social.persistence.entity.Comment;
+import im.toduck.domain.social.persistence.entity.CommentImageFile;
+
+public interface CommentImageFileRepository extends JpaRepository<CommentImageFile, Long> {
+	Optional<CommentImageFile> findByComment(Comment comment);
+}

--- a/src/main/java/im/toduck/domain/social/presentation/dto/request/CommentCreateRequest.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/request/CommentCreateRequest.java
@@ -11,6 +11,10 @@ public record CommentCreateRequest(
 
 	@Nullable
 	@Schema(description = "부모 댓글 comment id, 대댓글이 아닐시 null", nullable = true, example = "1")
-	Long parentId
+	Long parentId,
+
+	@Nullable
+	@Schema(description = "이미지 URL", nullable = true, example = "https://cdn.toduck.app/example.jpg")
+	String imageUrl
 ) {
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentDto.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/CommentDto.java
@@ -20,6 +20,12 @@ public record CommentDto(
 	@Schema(description = "작성자 정보")
 	OwnerDto owner,
 
+	@Schema(description = "사진 포함 여부", example = "true")
+	Boolean hasImage,
+
+	@Schema(description = "사진 주소", example = "https://cdn.toduck.app/example.jpg")
+	String imageUrl,
+
 	@Schema(description = "댓글 내용", example = "루틴 너무 좋네요!")
 	String content,
 


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ comment_image_file 테이블 추가**
```SQL
CREATE TABLE comment_image_file
(
    id         BIGINT PRIMARY KEY auto_increment,
    comment_id BIGINT        NOT NULL,
    url        VARCHAR(1024) NOT NULL,
   ...
);
```
  <br/>

**2️⃣ 요청/응답에서 이미지 관련 필드 추가**
```JAVA
public record CommentCreateRequest(
        ...
	@Nullable
	@Schema(description = "이미지 URL", nullable = true, example = "https://cdn.toduck.app/example.jpg")
	String imageUrl
) {
}

```

```JAVA
public record CommentDto(
        ...

	@Schema(description = "사진 포함 여부", example = "true")
	Boolean hasImage,

	@Schema(description = "사진 주소", example = "https://cdn.toduck.app/example.jpg")
	String imageUrl,
        ...
) {
}

```
  <br/>

**3️⃣ 게시글/댓글 삭제 시 댓글 이미지 파일 삭제**
- 게시글 삭제 시 (**soft delete**)
- 댓글 삭제 시 (**hard delete**)

  <br/>

## ✅ 리뷰 요구사항
- 궁금한 점 있으시면 댓글 달아주세요!
