### PR TITLE
메서드 파라미터 검증 충돌 해결

### DIFF
--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialBoardController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialBoardController.java
@@ -24,7 +24,6 @@ import im.toduck.domain.social.presentation.dto.response.SocialCategoryResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialDetailResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialResponse;
-import im.toduck.global.annotation.valid.PaginationLimit;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.presentation.dto.response.CursorPaginationResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
@@ -92,7 +91,7 @@ public class SocialBoardController implements SocialBoardApi {
 	public ResponseEntity<ApiResponse<CursorPaginationResponse<SocialResponse>>> getSocials(
 		CustomUserDetails user,
 		Long cursor,
-		@PaginationLimit Integer limit,
+		Integer limit,
 		List<Long> categoryIds
 	) {
 		return ResponseEntity.ok().body(
@@ -118,7 +117,7 @@ public class SocialBoardController implements SocialBoardApi {
 		CustomUserDetails user,
 		@RequestParam(name = "keyword") String keyword,
 		Long cursor,
-		@PaginationLimit Integer limit
+		Integer limit
 	) {
 		return ResponseEntity.ok().body(ApiResponse.createSuccess(
 			socialBoardUseCase.searchSocials(user.getUserId(), keyword, cursor, limit)));


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 메서드 파라미터 검증 충돌 해결**
- 인터페이스와 구현체 간의 어노테이션 불일치로 인해 발생한 
`ConstraintDeclarationException(HV000151)` 오류 수정

**SocialBoardApi**

```JAVA
ResponseEntity<~> getSocials(
    ...
    @Parameter(description = "한 페이지에 표시할 항목 수") @PaginationLimit @RequestParam(required = false) Integer limit,
    ...
);
```
**SocialBoardController (수정전)**

```JAVA
ResponseEntity<~> getSocials(
    ...
    @PaginationLimit Integer limit, 
    ...
);
```


**SocialBoardController (수정후)**

```JAVA
ResponseEntity<~> getSocials(
    ...
    Integer limit, 
    ...
);
```


> **자바 Bean Validation** 스펙에 따라, 메서드 오버라이딩 시 파라미터 제약조건을 재정의하면 안 되므로, 
> 컨트롤러 구현체에서 `@PaginationLimit` 어노테이션을 제거하여 인터페이스에서만 검증 어노테이션을 정의하도록 수정