### PR TITLE
자체 회원가입 유저 id 찾기 및 비밀번호 변경 API 개발

### DIFF
--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleCreateRequest.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleCreateRequest.java
@@ -16,7 +16,6 @@ import im.toduck.domain.schedule.persistence.vo.ScheduleAlram;
 import im.toduck.global.serializer.DayOfWeekListDeserializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -59,7 +58,6 @@ public record ScheduleCreateRequest(
 	ScheduleAlram alarm,
 
 	@JsonDeserialize(using = DayOfWeekListDeserializer.class)
-	@NotEmpty(message = "반	복 요일은 최소 하나 이상 선택되어야 합니다.")
 	@Schema(description = "반복 요일", example = "[\"MONDAY\",\"TUESDAY\"]")
 	List<DayOfWeek> daysOfWeek,
 

--- a/src/main/java/im/toduck/domain/user/domain/service/UserService.java
+++ b/src/main/java/im/toduck/domain/user/domain/service/UserService.java
@@ -34,10 +34,8 @@ public class UserService {
 	}
 
 	@Transactional(readOnly = true)
-	public void validateUserByPhoneNumber(String phoneNumber) {
-		userRepository.findByPhoneNumber(phoneNumber).ifPresent(user -> {
-			throw CommonException.from(ExceptionCode.EXISTS_PHONE_NUMBER);
-		});
+	public Optional<User> findUserByPhoneNumber(String phoneNumber) {
+		return userRepository.findByPhoneNumber(phoneNumber);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/im/toduck/domain/user/domain/usecase/UserAuthUseCase.java
+++ b/src/main/java/im/toduck/domain/user/domain/usecase/UserAuthUseCase.java
@@ -29,6 +29,8 @@ public class UserAuthUseCase {
 	private final UserService userService;
 	private final PasswordEncoder passwordEncoder;
 
+	private static final String MASKING_CHARACTER = "**";
+
 	public void signOut(Long userId, String authHeader, String refreshToken) {
 		jwtService.removeAccessTokenAndRefreshToken(userId, authHeader, refreshToken);
 	}
@@ -52,8 +54,12 @@ public class UserAuthUseCase {
 		phoneNumberService.deleteVerifiedPhoneNumber(phoneNumber);
 		log.info("로그인 id 찾기 성공 phoneNumber: {}, loginId: {}", phoneNumber, user.getLoginId());
 		return LoginIdResponse.builder()
-			.loginId(user.getLoginId())
+			.loginId(maskLoginId(user.getLoginId()))
 			.build();
+	}
+
+	private String maskLoginId(String loginId) {
+		return loginId.substring(0, loginId.length() - MASKING_CHARACTER.length()) + "**";
 	}
 
 	public void verifyLoginIdPhoneNumber(final VerifyLoginIdPhoneNumberRequest request) {

--- a/src/main/java/im/toduck/domain/user/domain/usecase/UserAuthUseCase.java
+++ b/src/main/java/im/toduck/domain/user/domain/usecase/UserAuthUseCase.java
@@ -1,7 +1,21 @@
 package im.toduck.domain.user.domain.usecase;
 
+import static im.toduck.global.regex.UserRegex.*;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
 import im.toduck.domain.auth.domain.service.JwtService;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.domain.user.presentation.dto.request.ChangePasswordRequest;
+import im.toduck.domain.user.presentation.dto.request.VerifyLoginIdPhoneNumberRequest;
+import im.toduck.domain.user.presentation.dto.response.LoginIdResponse;
 import im.toduck.global.annotation.UseCase;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import im.toduck.infra.redis.phonenumber.PhoneNumberService;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -11,8 +25,66 @@ import lombok.extern.slf4j.Slf4j;
 public class UserAuthUseCase {
 
 	private final JwtService jwtService;
+	private final PhoneNumberService phoneNumberService;
+	private final UserService userService;
+	private final PasswordEncoder passwordEncoder;
 
 	public void signOut(Long userId, String authHeader, String refreshToken) {
 		jwtService.removeAccessTokenAndRefreshToken(userId, authHeader, refreshToken);
+	}
+
+	public void sendVerifiedCodeToPhoneNumberForFind(@Pattern(regexp = PHONE_NUMBER_REGEXP) final String phoneNumber) {
+		userService.findUserByPhoneNumber(phoneNumber).orElseThrow(() -> {
+			log.warn("존재하지 않는 유저의 아이디 혹은 비번을 찾을려고함 phoneNumber: {}", phoneNumber);
+			return CommonException.from(ExceptionCode.NOT_EXIST_PHONE_NUMBER);
+		});
+		phoneNumberService.findAlreadySentPhoneNumber(phoneNumber)
+			.ifPresentOrElse(phoneNumberService::reSendVerifiedCodeToPhoneNumber,
+				() -> phoneNumberService.sendVerifiedCodeToPhoneNumber(phoneNumber));
+	}
+
+	public LoginIdResponse findLoginId(@Pattern(regexp = PHONE_NUMBER_REGEXP) final String phoneNumber) {
+		User user = userService.findUserByPhoneNumber(phoneNumber).orElseThrow(() -> {
+			log.warn("존재하지 않는 유저의 아이디 혹은 비번을 찾을려고함 phoneNumber: {}", phoneNumber);
+			return CommonException.from(ExceptionCode.NOT_EXIST_PHONE_NUMBER);
+		});
+		phoneNumberService.validateVerifiedPhoneNumber(phoneNumber);
+		phoneNumberService.deleteVerifiedPhoneNumber(phoneNumber);
+		log.info("로그인 id 찾기 성공 phoneNumber: {}, loginId: {}", phoneNumber, user.getLoginId());
+		return LoginIdResponse.builder()
+			.loginId(user.getLoginId())
+			.build();
+	}
+
+	public void verifyLoginIdPhoneNumber(final VerifyLoginIdPhoneNumberRequest request) {
+		User user = userService.findUserByPhoneNumber(request.phoneNumber()).orElseThrow(() -> {
+			log.warn("존재하지 않는 유저의 아이디 혹은 비번을 찾을려고함 phoneNumber: {}", request.phoneNumber());
+			return CommonException.from(ExceptionCode.NOT_EXIST_PHONE_NUMBER);
+		});
+		if (!user.getLoginId().equals(request.loginId())) {
+			log.warn("로그인 id가 일치하지 않음 phoneNumber: {}, loginId: {}", request.phoneNumber(), request.loginId());
+			throw CommonException.from(ExceptionCode.INVALID_LOGIN_ID);
+		}
+		phoneNumberService.validateVerifiedPhoneNumber(request.phoneNumber());
+		log.info("로그인 id, phoneNumber 인증 성공 phoneNumber: {}, loginId: {}", request.phoneNumber(), request.loginId());
+	}
+
+	@Transactional
+	public void changePassword(final ChangePasswordRequest request) {
+		phoneNumberService.validateVerifiedPhoneNumber(request.phoneNumber());
+
+		User user = userService.findUserByPhoneNumber(request.phoneNumber()).orElseThrow(() -> {
+			log.warn("존재하지 않는 유저의 아이디 혹은 비번을 찾을려고함 phoneNumber: {}", request.phoneNumber());
+			return CommonException.from(ExceptionCode.NOT_EXIST_PHONE_NUMBER);
+		});
+
+		if (!user.getLoginId().equals(request.loginId())) {
+			log.warn("로그인 id가 일치하지 않음 phoneNumber: {}, loginId: {}", request.phoneNumber(), request.loginId());
+			throw CommonException.from(ExceptionCode.INVALID_LOGIN_ID);
+		}
+
+		String encodedPassword = passwordEncoder.encode(request.changedPassword());
+		user.changePassword(encodedPassword);
+		phoneNumberService.deleteVerifiedPhoneNumber(request.phoneNumber());
 	}
 }

--- a/src/main/java/im/toduck/domain/user/persistence/entity/User.java
+++ b/src/main/java/im/toduck/domain/user/persistence/entity/User.java
@@ -83,4 +83,8 @@ public class User extends BaseEntity {
 		}
 		return false;
 	}
+
+	public void changePassword(String encodedPassword) {
+		this.password = encodedPassword;
+	}
 }

--- a/src/main/java/im/toduck/domain/user/presentation/api/UserAuthApi.java
+++ b/src/main/java/im/toduck/domain/user/presentation/api/UserAuthApi.java
@@ -1,17 +1,29 @@
 package im.toduck.domain.user.presentation.api;
 
+import static im.toduck.global.regex.UserRegex.*;
+
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import im.toduck.domain.user.presentation.dto.request.ChangePasswordRequest;
+import im.toduck.domain.user.presentation.dto.request.VerifyLoginIdPhoneNumberRequest;
+import im.toduck.domain.user.presentation.dto.response.LoginIdResponse;
+import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
+import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.exception.ExceptionCode;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 
 @Tag(name = "UserAuth")
 public interface UserAuthApi {
@@ -25,4 +37,71 @@ public interface UserAuthApi {
 		@CookieValue(value = "refreshToken", required = false) String refreshToken,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
+
+	@Operation(
+		summary = "아이디 찾기 혹은 비밀번호 찾기 인증번호 발송",
+		description = "전화번호로 인증번호를 발송합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(description = "인증번호 발송 성공"),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_EXIST_PHONE_NUMBER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.OVER_MAX_MESSAGE_COUNT),
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> sendVerifiedCodeForFind(
+		@RequestParam("phoneNumber") @Pattern(regexp = PHONE_NUMBER_REGEXP) String phoneNumber);
+
+	@Operation(
+		summary = "아이디 찾기",
+		description = "인증된 전화번호로 아이디를 찾습니다."
+			+ "인증 API는 /v1/auth/check-verfied-code api 를 사용해주세요"
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(responseClass = LoginIdResponse.class,
+			description = "로그인 아이디를 응답으로 제공합니다."),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_EXIST_PHONE_NUMBER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_SEND_PHONE_NUMBER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_VERIFIED_PHONE_NUMBER)
+		}
+	)
+	ResponseEntity<ApiResponse<LoginIdResponse>> findLoginId(
+		@RequestParam("phoneNumber") @Pattern(regexp = PHONE_NUMBER_REGEXP) String phoneNumber
+	);
+
+	@Operation(
+		summary = "비밀번호 찾기 전화번호 및 로그인 id 유효성 검사 API",
+		description = "검증된 전화번호 및 로그인 ID 인지 확인합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(description = "전화번호 및 로그인 ID가 유효합니다."),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_EXIST_PHONE_NUMBER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.INVALID_LOGIN_ID),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_SEND_PHONE_NUMBER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_VERIFIED_PHONE_NUMBER)
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> verifyLoginIdPhoneNumber(
+		@RequestBody @Valid VerifyLoginIdPhoneNumberRequest request
+	);
+
+	@Operation(
+		summary = "비밀번호 변경",
+		description = "비밀번호 변경을 수행합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(description = "비밀번호 변경 성공"),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_EXIST_PHONE_NUMBER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.INVALID_LOGIN_ID),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_SEND_PHONE_NUMBER),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_VERIFIED_PHONE_NUMBER)
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> changePassword(
+		@RequestBody @Valid ChangePasswordRequest request
+	);
+
 }

--- a/src/main/java/im/toduck/domain/user/presentation/controller/UserAuthController.java
+++ b/src/main/java/im/toduck/domain/user/presentation/controller/UserAuthController.java
@@ -1,5 +1,7 @@
 package im.toduck.domain.user.presentation.controller;
 
+import static im.toduck.global.regex.UserRegex.*;
+
 import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
@@ -8,15 +10,24 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import im.toduck.domain.user.domain.usecase.UserAuthUseCase;
 import im.toduck.domain.user.presentation.api.UserAuthApi;
+import im.toduck.domain.user.presentation.dto.request.ChangePasswordRequest;
+import im.toduck.domain.user.presentation.dto.request.VerifyLoginIdPhoneNumberRequest;
+import im.toduck.domain.user.presentation.dto.response.LoginIdResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import im.toduck.global.util.CookieUtil;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -40,4 +51,44 @@ public class UserAuthController implements UserAuthApi {
 			.header(HttpHeaders.SET_COOKIE, cookieUtil.deleteCookie("refreshToken").toString())
 			.body(ApiResponse.createSuccessWithNoContent());
 	}
+
+	@Override
+	@GetMapping("/find/verified-code")
+	@PreAuthorize("isAnonymous()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> sendVerifiedCodeForFind(
+		@RequestParam("phoneNumber") @Pattern(regexp = PHONE_NUMBER_REGEXP) String phoneNumber) {
+		userAuthUseCase.sendVerifiedCodeToPhoneNumberForFind(phoneNumber);
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@Override
+	@GetMapping("/find/login-id")
+	@PreAuthorize("isAnonymous()")
+	public ResponseEntity<ApiResponse<LoginIdResponse>> findLoginId(
+		@RequestParam("phoneNumber") @Pattern(regexp = PHONE_NUMBER_REGEXP) String phoneNumber
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.createSuccess(userAuthUseCase.findLoginId(phoneNumber)));
+	}
+
+	@Override
+	@PatchMapping("/find/verify-login-id-phonenumber")
+	@PreAuthorize("isAnonymous()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> verifyLoginIdPhoneNumber(
+		@RequestBody @Valid VerifyLoginIdPhoneNumberRequest request
+	) {
+		userAuthUseCase.verifyLoginIdPhoneNumber(request);
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@Override
+	@PutMapping("/find/change-password")
+	@PreAuthorize("isAnonymous()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> changePassword(
+		@RequestBody @Valid ChangePasswordRequest request
+	) {
+		userAuthUseCase.changePassword(request);
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
+	}
+
 }

--- a/src/main/java/im/toduck/domain/user/presentation/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/im/toduck/domain/user/presentation/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,16 @@
+package im.toduck.domain.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "비밀번호 변경 요청 DTO")
+@Builder
+public record ChangePasswordRequest(
+	@Schema(description = "사용자 아이디", example = "toduck")
+	String loginId,
+	@Schema(description = "변경할 비밀번호", example = "Password2025@")
+	String changedPassword,
+	@Schema(description = "사용자 전화번호", example = "01012345678")
+	String phoneNumber
+) {
+}

--- a/src/main/java/im/toduck/domain/user/presentation/dto/request/VerifyLoginIdPhoneNumberRequest.java
+++ b/src/main/java/im/toduck/domain/user/presentation/dto/request/VerifyLoginIdPhoneNumberRequest.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "로그인 아이디, 전화번호 검증 요청")
+@Builder
+public record VerifyLoginIdPhoneNumberRequest(
+	@Schema(description = "로그인 아이디", example = "toduck")
+	String loginId,
+	@Schema(description = "전화번호", example = "01012345678")
+	String phoneNumber
+) {
+}

--- a/src/main/java/im/toduck/domain/user/presentation/dto/response/LoginIdResponse.java
+++ b/src/main/java/im/toduck/domain/user/presentation/dto/response/LoginIdResponse.java
@@ -1,0 +1,12 @@
+package im.toduck.domain.user.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "로그인 아이디 응답 DTO")
+@Builder
+public record LoginIdResponse(
+	@Schema(description = "로그인 아이디", example = "toduck")
+	String loginId
+) {
+}

--- a/src/main/java/im/toduck/global/config/security/SecurityConfig.java
+++ b/src/main/java/im/toduck/global/config/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
 		"/api-docs/**", "/v3/api-docs/**", "/docs/open-api-3.0.1.yaml", "/swagger-ui/**", "/swagger", "/docs",
 		"/exception-codes"};
 	private static final String[] PUBLIC_ENDPOINTS = {"/", "/error"};
-	private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**"};
+	private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/users/find/**"};
 
 	private final CorsConfigurationSource corsConfigurationSource;
 	private final AccessDeniedHandler accessDeniedHandler;

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -47,6 +47,10 @@ public enum ExceptionCode {
 	INVALID_ID_TOKEN(HttpStatus.FORBIDDEN, 40118, "유효하지 않은 ID 토큰입니다.", "ID 토큰이 유효하지 않을 때 발생하는 오류입니다."),
 	ABNORMAL_ID_TOKEN(HttpStatus.FORBIDDEN, 40119, "비정상적인 ID 토큰입니다.", "ID 토큰 공개키로 암호화 도중에 발생하는 오류입니다."),
 	NOT_MATCHED_PUBLIC_KEY(HttpStatus.NOT_FOUND, 40120, "일치하는 공개키를 찾을 수 없습니다.", "KID 와 공개키가 일치하지 않을 때 발생하는 오류입니다."),
+	NOT_EXIST_PHONE_NUMBER(HttpStatus.BAD_REQUEST, 40121, "가입된 전화번호가 아닙니다.",
+		"자체 회원가입에서 ID 찾기 혹은 비밀번호 찾기를 위한 인증번호 요청에서 회원으로 등록되지 않은 전화번호이어서 발생하는 오류입니다."),
+	INVALID_LOGIN_ID(HttpStatus.BAD_REQUEST, 40122, "유효하지 않은 아이디입니다.",
+		"비밀번호 찾기를 위한 인증번호 요청에서 회원ID와 일치하지 않는 로그인 아이디이어서 발생하는 오류입니다."),
 
 	/* 402xx */
 	NOT_FOUND_USER(HttpStatus.NOT_FOUND, 40201, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/im/toduck/infra/redis/phonenumber/PhoneNumberService.java
+++ b/src/main/java/im/toduck/infra/redis/phonenumber/PhoneNumberService.java
@@ -12,4 +12,6 @@ public interface PhoneNumberService {
 	void validateVerifiedCode(PhoneNumber phoneNumberEntity, String verifiedCode);
 
 	void validateVerifiedPhoneNumber(String phoneNumber);
+
+	void deleteVerifiedPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/im/toduck/infra/redis/phonenumber/PhoneNumberServiceImpl.java
+++ b/src/main/java/im/toduck/infra/redis/phonenumber/PhoneNumberServiceImpl.java
@@ -63,4 +63,9 @@ public class PhoneNumberServiceImpl implements PhoneNumberService {
 			throw CommonException.from(ExceptionCode.NOT_VERIFIED_PHONE_NUMBER);
 		}
 	}
+
+	@Override
+	public void deleteVerifiedPhoneNumber(String phoneNumber) {
+		phoneNumberRepository.deleteById(phoneNumber);
+	}
 }


### PR DESCRIPTION
## ✨ 작업 내용

> 해당 안내는 지워주세요.  
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.  
> 스크린샷을 적극적으로 활용해 주세요.

**1️⃣ 기존 휴대폰 인증 후 회원가입 성공하면 전화번호 인증 정보 강제 삭제하도록 수정 **

- 전화번호 인증 정보가 ttl 로 시간이 지나면 삭제되도록 했지만, id 찾기 와 비밀번호 변경 시 필요한 전화번호 인증에 재사용 될것을 염두하여 수정했습니다.


**2️⃣ 유저 id 찾기**

> 기존 인증번호 발송 api를 재사용 안한 이유는 기존 api 는 유저가 있는지 검증 후 있으면 에러를 반환하므로 해당 인증 번호 발송 api 를 재사용하기에는 비즈니스 니즈가 다르다고 판단하에 새로 api 를 구현했습니다.

유저 id 찾기 과정
1. 전화번호 인증 번호 발송
2. 전화번호 인증 번호 검증
3. 검증된 전화번호라면 유저 id 찾기 성공

  <br/>

**3️⃣ 비밀번호 변경**


비밀번호 변경 과정 

1. 전화번호 인증 번호 발송
2. 전화번호 인증 번호 검증
3. 검증 된 전화번호와 유저 id 를 보내서 비밀번호 변경이 가능한지 확인 (api로 제공)
4. 유저 id 와 검증된 전화번호 그리고 비밀번호를 보내면 해당 비밀번호로 인코딩 후 유저의 비밀번호를 변경함

  <br/>

## ✅ 리뷰 요구사항(선택)

> 해당 안내는 지워주세요.
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.  
> 작성하지 않는다면 항목을 지워주세요.  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
