### PR TITLE
소셜 프로필 조회 API 개발

### DIFF
--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -14,6 +14,7 @@ import im.toduck.domain.routine.presentation.dto.response.MyRoutineAvailableList
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadListResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
+import im.toduck.domain.social.presentation.dto.response.UserProfileRoutineListResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.helper.DaysOfWeekBitmask;
 import lombok.NoArgsConstructor;
@@ -117,6 +118,28 @@ public class RoutineMapper {
 			.category(routine.getCategory())
 			.title(routine.getTitle())
 			.memo(routine.getMemoValue())
+			.build();
+	}
+
+	public static UserProfileRoutineListResponse toUserProfileRoutineListResponse(final List<Routine> routines) {
+		List<UserProfileRoutineListResponse.UserProfileRoutineResponse> routineResponses = routines.stream()
+			.map(RoutineMapper::toUserProfileRoutineRecordReadResponse)
+			.toList();
+
+		return UserProfileRoutineListResponse.builder()
+			.routines(routineResponses)
+			.build();
+	}
+
+	private static UserProfileRoutineListResponse.UserProfileRoutineResponse toUserProfileRoutineRecordReadResponse(
+		final Routine routine
+	) {
+		return UserProfileRoutineListResponse.UserProfileRoutineResponse.builder()
+			.routineId(routine.getId())
+			.category(routine.getCategory())
+			.title(routine.getTitle())
+			.memo(routine.getMemoValue())
+			.time(routine.getTime())
 			.build();
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -57,6 +57,10 @@ public class RoutineService {
 		return routineRepository.findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByUpdatedAtDesc(user);
 	}
 
+	public List<Routine> getSocialProfileRoutines(final User user) {
+		return routineRepository.findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByTimeAsc(user);
+	}
+
 	@Transactional
 	public void remove(final Routine routine) {
 		routine.delete();

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
@@ -16,5 +16,7 @@ public interface RoutineRepository extends JpaRepository<Routine, Long>, Routine
 
 	List<Routine> findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByUpdatedAtDesc(User user);
 
+	List<Routine> findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByTimeAsc(User user);
+
 	Optional<Routine> findByIdAndUserAndDeletedAtIsNull(Long id, User user);
 }

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialProfileMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialProfileMapper.java
@@ -1,0 +1,25 @@
+package im.toduck.domain.social.common.mapper;
+
+import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SocialProfileMapper {
+	public static SocialProfileResponse toSocialProfileResponse(
+		final String nickname,
+		final int followingCount,
+		final int followerCount,
+		final int postCount,
+		final boolean isMe
+
+	) {
+		return SocialProfileResponse.builder()
+			.nickname(nickname)
+			.followingCount(followingCount)
+			.followerCount(followerCount)
+			.postCount(postCount)
+			.isMe(isMe)
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -215,5 +215,17 @@ public class SocialBoardService {
 	public int countSocialPostsByUserId(final Long userId) {
 		return (int)socialRepository.countByUserId(userId);
 	}
+
+	@Transactional(readOnly = true)
+	public List<Social> getSocialsByUserId(
+		final Long profileUserId,
+		final Long authUserId,
+		final Long cursor,
+		final Integer limit
+	) {
+		PageRequest pageRequest = PageRequest.of(PaginationUtil.FIRST_PAGE_INDEX, limit);
+
+		return socialRepository.findUserSocials(profileUserId, cursor, pageRequest);
+	}
 }
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -210,5 +210,10 @@ public class SocialBoardService {
 		PageRequest pageRequest = PageRequest.of(PaginationUtil.FIRST_PAGE_INDEX, limit);
 		return socialRepository.searchSocialsExcludingBlocked(cursor, userId, keyword, pageRequest);
 	}
+
+	@Transactional(readOnly = true)
+	public int countSocialPostsByUserId(final Long userId) {
+		return (int)socialRepository.countByUserId(userId);
+	}
 }
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialInteractionService.java
@@ -211,5 +211,10 @@ public class SocialInteractionService {
 	public Optional<CommentImageFile> getCommentImageByComment(final Comment comment) {
 		return commentImageFileRepository.findByComment(comment);
 	}
+
+	@Transactional(readOnly = true)
+	public int countCommentsBySocial(final Social social) {
+		return commentRepository.countBySocial(social);
+	}
 }
 

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
@@ -227,9 +227,9 @@ public class SocialBoardUseCase {
 			.limit(actualLimit)
 			.map(sb -> {
 				List<SocialImageFile> imageFiles = socialBoardService.getSocialImagesBySocial(sb);
-				List<Comment> comments = socialInteractionService.getCommentsBySocial(sb);
+				int commentCounts = socialInteractionService.countCommentsBySocial(sb);
 				boolean isSocialBoardLiked = socialInteractionService.getSocialBoardIsLiked(user, sb);
-				return SocialMapper.toSocialResponse(sb, imageFiles, comments.size(), isSocialBoardLiked);
+				return SocialMapper.toSocialResponse(sb, imageFiles, commentCounts, isSocialBoardLiked);
 			})
 			.toList();
 	}

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 import org.springframework.transaction.annotation.Transactional;
 
+import im.toduck.domain.routine.common.mapper.RoutineMapper;
+import im.toduck.domain.routine.domain.service.RoutineService;
+import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.social.common.mapper.SocialMapper;
 import im.toduck.domain.social.common.mapper.SocialProfileMapper;
 import im.toduck.domain.social.domain.service.SocialBoardService;
@@ -12,6 +15,7 @@ import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialResponse;
+import im.toduck.domain.social.presentation.dto.response.UserProfileRoutineListResponse;
 import im.toduck.domain.user.domain.service.FollowService;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
@@ -33,6 +37,7 @@ public class SocialProfileUseCase {
 	private final FollowService followService;
 	private final SocialBoardService socialBoardService;
 	private final SocialInteractionService socialInteractionService;
+	private final RoutineService routineService;
 
 	@Transactional(readOnly = true)
 	public SocialProfileResponse getUserProfile(final Long profileUserId, final Long authUserId) {
@@ -64,9 +69,10 @@ public class SocialProfileUseCase {
 		User profileUser = userService.getUserById(profileUserId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
+		// TODO: profileUser의 프로필 공개 여부 필드 추가 후 처리 예외 처리
+
 		User authUser = userService.getUserById(authUserId)
-			.orElseThrow(
-				() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
 		int actualLimit = PaginationUtil.resolveLimit(limit, DEFAULT_PROFILE_SOCIAL_PAGE_SIZE);
 		int fetchLimit = PaginationUtil.calculateTotalFetchSize(actualLimit);
@@ -105,5 +111,18 @@ public class SocialProfileUseCase {
 				return SocialMapper.toSocialResponse(social, imageFiles, commentCount, isLikedByRequestingUser);
 			})
 			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public UserProfileRoutineListResponse readUserAvailableRoutines(final Long profileUserId, final Long authUserId) {
+		User profileUser = userService.getUserById(profileUserId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		// TODO: profileUser의 프로필 공개 여부 필드 추가 후 처리 예외 처리
+
+		List<Routine> routines = routineService.getSocialProfileRoutines(profileUser);
+
+		log.info("사용자 ID {}의 공개 루틴 목록 조회 - 요청자 Id: {}", profileUserId, authUserId);
+		return RoutineMapper.toUserProfileRoutineListResponse(routines);
 	}
 }

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
@@ -1,0 +1,44 @@
+package im.toduck.domain.social.domain.usecase;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.social.common.mapper.SocialProfileMapper;
+import im.toduck.domain.social.domain.service.SocialBoardService;
+import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
+import im.toduck.domain.user.domain.service.FollowService;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.annotation.UseCase;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class SocialProfileUseCase {
+	private final UserService userService;
+	private final FollowService followService;
+	private final SocialBoardService socialBoardService;
+
+	@Transactional(readOnly = true)
+	public SocialProfileResponse getUserProfile(final Long profileUserId, final Long authUserId) {
+		User profileUser = userService.getUserById(profileUserId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		int followingCount = followService.countFollowing(profileUserId);
+		int followerCount = followService.countFollowers(profileUserId);
+		int postCount = socialBoardService.countSocialPostsByUserId(profileUserId);
+		boolean isMe = profileUserId.equals(authUserId);
+
+		log.info("프로필 조회 - 요청자 UserId: {}, 대상 UserId: {}", authUserId, profileUserId);
+		return SocialProfileMapper.toSocialProfileResponse(
+			profileUser.getNickname(),
+			followingCount,
+			followerCount,
+			postCount,
+			isMe
+		);
+	}
+}

--- a/src/main/java/im/toduck/domain/social/persistence/repository/CommentRepository.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/CommentRepository.java
@@ -18,4 +18,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 	List<Comment> findCommentsBySocial(@Param("social") Social social);
 
 	List<Comment> findAllBySocial(Social socialBoard);
+
+	int countBySocial(Social social);
 }

--- a/src/main/java/im/toduck/domain/social/persistence/repository/SocialRepository.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/SocialRepository.java
@@ -1,9 +1,13 @@
 package im.toduck.domain.social.persistence.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.repository.querydsl.SocialRepositoryCustom;
 
 public interface SocialRepository extends JpaRepository<Social, Long>, SocialRepositoryCustom {
+	@Query("select count(s) from Social s where s.user.id = :userId and s.deletedAt is null")
+	long countByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustom.java
@@ -20,4 +20,10 @@ public interface SocialRepositoryCustom {
 		String keyword,
 		Pageable pageable
 	);
+
+	List<Social> findUserSocials(
+		Long profileUserId,
+		Long cursor,
+		Pageable pageable
+	);
 }

--- a/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustomImpl.java
@@ -69,6 +69,24 @@ public class SocialRepositoryCustomImpl implements SocialRepositoryCustom {
 		return applyPagination(query, pageable).fetch();
 	}
 
+	@Override
+	public List<Social> findUserSocials(
+		Long profileUserId,
+		Long cursor,
+		Pageable pageable
+	) {
+		JPAQuery<Social> query = queryFactory
+			.selectFrom(qSocial)
+			.leftJoin(qSocial.user).fetchJoin()
+			.where(
+				qSocial.deletedAt.isNull(),
+				qSocial.user.id.eq(profileUserId),
+				cursorCondition(cursor)
+			);
+
+		return applyPagination(query, pageable).fetch();
+	}
+
 	private BooleanExpression keywordCondition(String keyword) {
 		if (keyword == null || keyword.isEmpty()) {
 			return null;

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
@@ -2,14 +2,22 @@ package im.toduck.domain.social.presentation.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
+import im.toduck.domain.social.presentation.dto.response.SocialResponse;
+import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.annotation.valid.PaginationLimit;
+import im.toduck.global.exception.ExceptionCode;
 import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.presentation.dto.response.CursorPaginationResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Social Profile")
@@ -28,5 +36,35 @@ public interface SocialProfileApi {
 	ResponseEntity<ApiResponse<SocialProfileResponse>> getUserProfile(
 		@PathVariable Long userId,
 		@AuthenticationPrincipal CustomUserDetails authUser
+	);
+
+	@Operation(
+		summary = "특정 유저가 작성한 게시글 목록 조회",
+		description = """
+			<b>특정 유저(userId)가 작성한 소셜 게시글 목록을 커서 기반 페이지네이션으로 조회합니다.</b><br/><br/>
+			<p><b>커서 페이지네이션 사용법:</b></p>
+			<p>Notion > API 개요 > 페이지네이션을 확인해주세요.</p><br/>
+			<p><b>파라미터:</b><br/>
+			<p>- <b>userId:</b> 조회할 대상 유저의 ID (Path Variable)</p>
+			<p>- <b>cursor:</b> 조회를 시작할 커서 값 (게시글 ID)</p>
+			<p>- <b>limit:</b> 한 페이지에 표시할 게시글 수</p><br/>
+			<p>차단한 유저의 게시글은 조회되지 않습니다.</p>
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = SocialResponse.class,
+			description = "특정 유저의 게시글 목록 조회 성공, 커서 기반으로 조회된 게시글 목록을 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_USER)
+		}
+	)
+	@GetMapping("/{userId}/socials")
+	ResponseEntity<ApiResponse<CursorPaginationResponse<SocialResponse>>> getUserSocials(
+		@Parameter(description = "게시글을 조회할 유저 ID") @PathVariable Long userId,
+		@AuthenticationPrincipal CustomUserDetails authUser,
+		@Parameter(description = "조회를 시작할 커서 값 (게시글 ID)") @RequestParam(required = false) Long cursor,
+		@Parameter(description = "한 페이지에 표시할 항목 수") @PaginationLimit @RequestParam(required = false) Integer limit
 	);
 }

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
@@ -1,0 +1,24 @@
+package im.toduck.domain.social.presentation.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Social Profile")
+public interface SocialProfileApi {
+
+	@Operation(
+		summary = "유저 프로필 조회",
+		description = "userId를 이용하여 사용자의 프로필 정보를 조회합니다."
+	)
+	ResponseEntity<ApiResponse<SocialProfileResponse>> getUserProfile(
+		@PathVariable Long userId,
+		@AuthenticationPrincipal CustomUserDetails authUser
+	);
+}

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
@@ -5,6 +5,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
+import im.toduck.global.annotation.swagger.ApiResponseExplanations;
+import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +18,12 @@ public interface SocialProfileApi {
 	@Operation(
 		summary = "유저 프로필 조회",
 		description = "userId를 이용하여 사용자의 프로필 정보를 조회합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = SocialProfileResponse.class,
+			description = "소셜 유저 프로필 조회 성공, 유저 프로필 정보를 반환합니다."
+		)
 	)
 	ResponseEntity<ApiResponse<SocialProfileResponse>> getUserProfile(
 		@PathVariable Long userId,

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
@@ -6,8 +6,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineAvailableListResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialResponse;
+import im.toduck.domain.social.presentation.dto.response.UserProfileRoutineListResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -66,5 +68,24 @@ public interface SocialProfileApi {
 		@AuthenticationPrincipal CustomUserDetails authUser,
 		@Parameter(description = "조회를 시작할 커서 값 (게시글 ID)") @RequestParam(required = false) Long cursor,
 		@Parameter(description = "한 페이지에 표시할 항목 수") @PaginationLimit @RequestParam(required = false) Integer limit
+	);
+
+	@Operation(
+		summary = "특정 유저의 공개된 루틴 목록 조회",
+		description = "userId에 해당하는 사용자의 루틴 목록 중, **공개(isPublic=true) 상태이고 삭제되지 않은 루틴**만 조회합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = MyRoutineAvailableListResponse.class,
+			description = "루틴 목록 조회 성공. 루틴 시간(time) 기준으로 오름차순 정렬됩니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_USER)
+		}
+	)
+	@GetMapping("/{userId}/routines")
+	ResponseEntity<ApiResponse<UserProfileRoutineListResponse>> getUserProfileRoutines(
+		@Parameter(description = "루틴 목록을 조회할 유저 ID") @PathVariable Long userId,
+		@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails authUser
 	);
 }

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
@@ -13,6 +13,7 @@ import im.toduck.domain.social.domain.usecase.SocialProfileUseCase;
 import im.toduck.domain.social.presentation.api.SocialProfileApi;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialResponse;
+import im.toduck.domain.social.presentation.dto.response.UserProfileRoutineListResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.presentation.dto.response.CursorPaginationResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
@@ -22,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1/profiles")
 public class SocialProfileController implements SocialProfileApi {
-
 	private final SocialProfileUseCase socialProfileUseCase;
 
 	@Override
@@ -52,5 +52,19 @@ public class SocialProfileController implements SocialProfileApi {
 			limit
 		);
 		return ResponseEntity.ok(ApiResponse.createSuccess(userSocials));
+	}
+
+	@Override
+	@GetMapping("/{userId}/routines")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<UserProfileRoutineListResponse>> getUserProfileRoutines(
+		@PathVariable Long userId,
+		@AuthenticationPrincipal CustomUserDetails authUser
+	) {
+		UserProfileRoutineListResponse response = socialProfileUseCase.readUserAvailableRoutines(
+			userId,
+			authUser.getUserId()
+		);
+		return ResponseEntity.ok(ApiResponse.createSuccess(response));
 	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
@@ -1,0 +1,32 @@
+package im.toduck.domain.social.presentation.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import im.toduck.domain.social.presentation.api.SocialProfileApi;
+import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/profiles")
+public class SocialProfileController implements SocialProfileApi {
+
+	@Override
+	@GetMapping("/{userId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<SocialProfileResponse>> getUserProfile(
+		@PathVariable Long userId,
+		@AuthenticationPrincipal CustomUserDetails authUser
+	) {
+		SocialProfileResponse profileResponse = null; // TODO : 팔로우 기능 추가후 작성
+		return ResponseEntity.ok(ApiResponse.createSuccess(profileResponse));
+	}
+}

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import im.toduck.domain.social.domain.usecase.SocialProfileUseCase;
 import im.toduck.domain.social.presentation.api.SocialProfileApi;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
 import im.toduck.global.presentation.ApiResponse;
@@ -19,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/v1/profiles")
 public class SocialProfileController implements SocialProfileApi {
 
+	private final SocialProfileUseCase socialProfileUseCase;
+
 	@Override
 	@GetMapping("/{userId}")
 	@PreAuthorize("isAuthenticated()")
@@ -26,7 +29,7 @@ public class SocialProfileController implements SocialProfileApi {
 		@PathVariable Long userId,
 		@AuthenticationPrincipal CustomUserDetails authUser
 	) {
-		SocialProfileResponse profileResponse = null; // TODO : 팔로우 기능 추가후 작성
+		SocialProfileResponse profileResponse = socialProfileUseCase.getUserProfile(userId, authUser.getUserId());
 		return ResponseEntity.ok(ApiResponse.createSuccess(profileResponse));
 	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
@@ -6,12 +6,15 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import im.toduck.domain.social.domain.usecase.SocialProfileUseCase;
 import im.toduck.domain.social.presentation.api.SocialProfileApi;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
+import im.toduck.domain.social.presentation.dto.response.SocialResponse;
 import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.presentation.dto.response.CursorPaginationResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 
@@ -31,5 +34,23 @@ public class SocialProfileController implements SocialProfileApi {
 	) {
 		SocialProfileResponse profileResponse = socialProfileUseCase.getUserProfile(userId, authUser.getUserId());
 		return ResponseEntity.ok(ApiResponse.createSuccess(profileResponse));
+	}
+
+	@Override
+	@GetMapping("/{userId}/socials")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<CursorPaginationResponse<SocialResponse>>> getUserSocials(
+		@PathVariable Long userId,
+		@AuthenticationPrincipal CustomUserDetails authUser,
+		@RequestParam(required = false) Long cursor,
+		@RequestParam(required = false) Integer limit
+	) {
+		CursorPaginationResponse<SocialResponse> userSocials = socialProfileUseCase.getUserSocials(
+			userId,
+			authUser.getUserId(),
+			cursor,
+			limit
+		);
+		return ResponseEntity.ok(ApiResponse.createSuccess(userSocials));
 	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
@@ -1,13 +1,26 @@
 package im.toduck.domain.social.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record SocialProfileResponse(
+	@Schema(description = "사용자 닉네임", example = "뽀덕이")
 	String nickname,
+
+	@Schema(description = "프로필 이미지 URL", example = "https://cdn.toduck.app/profile.jpg")
+	String profileImageUrl,
+
+	@Schema(description = "팔로잉 수", example = "12")
 	int followingCount,
+
+	@Schema(description = "팔로워 수", example = "261")
 	int followerCount,
+
+	@Schema(description = "게시물 수", example = "315")
 	int postCount,
+
+	@Schema(description = "현재 사용자의 프로필인지 여부", example = "false")
 	boolean isMe
 ) {
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
@@ -1,10 +1,13 @@
 package im.toduck.domain.social.presentation.dto.response;
 
+import lombok.Builder;
+
+@Builder
 public record SocialProfileResponse(
 	String nickname,
-	Long followingCount,
-	Long followerCount,
-	Long postCount,
+	int followingCount,
+	int followerCount,
+	int postCount,
 	boolean isMe
 ) {
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
@@ -1,0 +1,10 @@
+package im.toduck.domain.social.presentation.dto.response;
+
+public record SocialProfileResponse(
+	String nickname,
+	Long followingCount,
+	Long followerCount,
+	Long postCount,
+	boolean isMe
+) {
+}

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
@@ -1,0 +1,41 @@
+package im.toduck.domain.social.presentation.dto.response;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+
+import im.toduck.domain.person.persistence.entity.PlanCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "사용자 프로필 루틴 목록 응답 DTO")
+@Builder
+public record UserProfileRoutineListResponse(
+	@Schema(description = "루틴 목록")
+	List<UserProfileRoutineResponse> routines
+) {
+	@Schema(description = "사용자 프로필 루틴 목록 내부 DTO")
+	@Builder
+	public record UserProfileRoutineResponse(
+		@Schema(description = "루틴 Id", example = "1")
+		Long routineId,
+
+		@Schema(description = "루틴 카테고리", example = "MEDICINE")
+		PlanCategory category,
+
+		@Schema(description = "루틴 제목", example = "하루 물 1L 이상 마시기")
+		String title,
+
+		@Schema(description = "루틴 메모", example = "눈 뜨자마자 한 잔")
+		String memo,
+
+		@JsonSerialize(using = LocalTimeSerializer.class)
+		@JsonFormat(pattern = "HH:mm")
+		@Schema(description = "루틴 시간 (null 이면 종일 루틴)", type = "string", example = "07:30")
+		LocalTime time
+	) {
+	}
+}

--- a/src/main/java/im/toduck/domain/user/domain/service/FollowService.java
+++ b/src/main/java/im/toduck/domain/user/domain/service/FollowService.java
@@ -34,4 +34,14 @@ public class FollowService {
 	public boolean isFollowing(final User follower, final User followed) {
 		return followRepository.existsByFollowerAndFollowed(follower, followed);
 	}
+
+	@Transactional(readOnly = true)
+	public int countFollowing(final Long userId) {
+		return (int)followRepository.countByFollower_Id(userId);
+	}
+
+	@Transactional(readOnly = true)
+	public int countFollowers(final Long userId) {
+		return (int)followRepository.countByFollowed_Id(userId);
+	}
 }

--- a/src/main/java/im/toduck/domain/user/persistence/repository/FollowRepository.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/FollowRepository.java
@@ -11,4 +11,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 	boolean existsByFollowerAndFollowed(User follower, User followed);
 
 	Optional<Follow> findByFollowerAndFollowed(User follower, User followed);
+
+	long countByFollower_Id(Long followerId);
+
+	long countByFollowed_Id(Long followedId);
 }

--- a/src/test/java/im/toduck/builder/BuilderSupporter.java
+++ b/src/test/java/im/toduck/builder/BuilderSupporter.java
@@ -15,6 +15,7 @@ import im.toduck.domain.social.persistence.repository.SocialCategoryRepository;
 import im.toduck.domain.social.persistence.repository.SocialImageFileRepository;
 import im.toduck.domain.social.persistence.repository.SocialRepository;
 import im.toduck.domain.user.persistence.repository.BlockRepository;
+import im.toduck.domain.user.persistence.repository.FollowRepository;
 import im.toduck.domain.user.persistence.repository.UserRepository;
 import im.toduck.infra.redis.phonenumber.PhoneNumberRepository;
 
@@ -62,6 +63,9 @@ public class BuilderSupporter {
 
 	@Autowired
 	private ScheduleRecordRepository scheduleRecordRepository;
+
+	@Autowired
+	private FollowRepository followRepository;
 
 	public UserRepository userRepository() {
 		return userRepository;
@@ -117,6 +121,10 @@ public class BuilderSupporter {
 
 	public ScheduleRecordRepository scheduleRecordRepository() {
 		return scheduleRecordRepository;
+	}
+
+	public FollowRepository followRepository() {
+		return followRepository;
 	}
 
 }

--- a/src/test/java/im/toduck/builder/TestFixtureBuilder.java
+++ b/src/test/java/im/toduck/builder/TestFixtureBuilder.java
@@ -17,6 +17,7 @@ import im.toduck.domain.social.persistence.entity.SocialCategory;
 import im.toduck.domain.social.persistence.entity.SocialCategoryLink;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
 import im.toduck.domain.user.persistence.entity.Block;
+import im.toduck.domain.user.persistence.entity.Follow;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.infra.redis.phonenumber.PhoneNumber;
 
@@ -91,4 +92,11 @@ public class TestFixtureBuilder {
 		return bs.scheduleRecordRepository().save(scheduleRecord);
 	}
 
+	public Follow buildFollow(final User follower, final User followed) {
+		Follow follow = Follow.builder()
+			.follower(follower)
+			.followed(followed)
+			.build();
+		return bs.followRepository().save(follow);
+	}
 }

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
@@ -1,0 +1,84 @@
+package im.toduck.domain.social.domain.usecase;
+
+import static im.toduck.fixtures.user.UserFixtures.*;
+import static im.toduck.global.exception.ExceptionCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import im.toduck.UseCaseTest;
+import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.exception.CommonException;
+
+public class SocialProfileUseCaseTest extends UseCaseTest {
+
+	@Autowired
+	private SocialProfileUseCase socialProfileUseCase;
+
+	private User profileUser;
+	private User authUser;
+
+	@BeforeEach
+	void setUp() {
+		profileUser = testFixtureBuilder.buildUser(GENERAL_USER());
+		authUser = testFixtureBuilder.buildUser(GENERAL_USER());
+	}
+
+	@Nested
+	@DisplayName("SocialProfile 조회시")
+	class GetUserProfileTests {
+
+		@Test
+		void 프로필_조회를_할_수_있다() {
+			// given
+			int followingCount = 3;
+			int followerCount = 2;
+			int postCount = 4;
+
+			// profileUser가 팔로우한 수 생성 (followingCount)
+			for (int i = 0; i < followingCount; i++) {
+				User followed = testFixtureBuilder.buildUser(GENERAL_USER());
+				testFixtureBuilder.buildFollow(profileUser, followed);
+			}
+
+			// profileUser를 팔로우하는 수 생성 (followerCount)
+			for (int i = 0; i < followerCount; i++) {
+				User follower = testFixtureBuilder.buildUser(GENERAL_USER());
+				testFixtureBuilder.buildFollow(follower, profileUser);
+			}
+
+			// profileUser가 작성한 게시글 생성 (postCount)
+			for (int i = 0; i < postCount; i++) {
+				testFixtureBuilder.buildSocial(
+					im.toduck.fixtures.social.SocialFixtures.SINGLE_SOCIAL(profileUser, false));
+			}
+
+			// when
+			SocialProfileResponse response = socialProfileUseCase.getUserProfile(profileUser.getId(), authUser.getId());
+
+			// then
+			assertThat(response).isNotNull();
+			assertThat(response.nickname()).isEqualTo(profileUser.getNickname());
+			assertThat(response.followingCount()).isEqualTo(followingCount);
+			assertThat(response.followerCount()).isEqualTo(followerCount);
+			assertThat(response.postCount()).isEqualTo(postCount);
+			assertThat(response.isMe()).isFalse();
+		}
+
+		@Test
+		void 존재하지_않는_사용자_프로필_조회에_실패한다() {
+			// given
+			Long nonExistentUserId = -1L;
+
+			// when & then
+			assertThatThrownBy(() -> socialProfileUseCase.getUserProfile(nonExistentUserId, authUser.getId()))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(NOT_FOUND_USER.getMessage());
+		}
+	}
+}

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
@@ -1,8 +1,12 @@
 package im.toduck.domain.social.domain.usecase;
 
+import static im.toduck.fixtures.social.SocialFixtures.*;
 import static im.toduck.fixtures.user.UserFixtures.*;
 import static im.toduck.global.exception.ExceptionCode.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,23 +14,28 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import im.toduck.UseCaseTest;
+import im.toduck.ServiceTest;
+import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
+import im.toduck.domain.social.presentation.dto.response.SocialResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.exception.CommonException;
+import im.toduck.global.presentation.dto.response.CursorPaginationResponse;
 
-public class SocialProfileUseCaseTest extends UseCaseTest {
+public class SocialProfileUseCaseTest extends ServiceTest {
 
 	@Autowired
 	private SocialProfileUseCase socialProfileUseCase;
 
-	private User profileUser;
-	private User authUser;
+	private User PROFILE_USER;
+	private User AUTH_USER;
+	private User OHTER_USER;
 
 	@BeforeEach
 	void setUp() {
-		profileUser = testFixtureBuilder.buildUser(GENERAL_USER());
-		authUser = testFixtureBuilder.buildUser(GENERAL_USER());
+		PROFILE_USER = testFixtureBuilder.buildUser(GENERAL_USER());
+		AUTH_USER = testFixtureBuilder.buildUser(GENERAL_USER());
+		OHTER_USER = testFixtureBuilder.buildUser(GENERAL_USER());
 	}
 
 	@Nested
@@ -43,31 +52,46 @@ public class SocialProfileUseCaseTest extends UseCaseTest {
 			// profileUser가 팔로우한 수 생성 (followingCount)
 			for (int i = 0; i < followingCount; i++) {
 				User followed = testFixtureBuilder.buildUser(GENERAL_USER());
-				testFixtureBuilder.buildFollow(profileUser, followed);
+				testFixtureBuilder.buildFollow(PROFILE_USER, followed);
 			}
 
 			// profileUser를 팔로우하는 수 생성 (followerCount)
 			for (int i = 0; i < followerCount; i++) {
 				User follower = testFixtureBuilder.buildUser(GENERAL_USER());
-				testFixtureBuilder.buildFollow(follower, profileUser);
+				testFixtureBuilder.buildFollow(follower, PROFILE_USER);
 			}
 
 			// profileUser가 작성한 게시글 생성 (postCount)
 			for (int i = 0; i < postCount; i++) {
 				testFixtureBuilder.buildSocial(
-					im.toduck.fixtures.social.SocialFixtures.SINGLE_SOCIAL(profileUser, false));
+					im.toduck.fixtures.social.SocialFixtures.SINGLE_SOCIAL(PROFILE_USER, false));
 			}
 
 			// when
-			SocialProfileResponse response = socialProfileUseCase.getUserProfile(profileUser.getId(), authUser.getId());
+			SocialProfileResponse response = socialProfileUseCase.getUserProfile(
+				PROFILE_USER.getId(),
+				AUTH_USER.getId()
+			);
 
 			// then
 			assertThat(response).isNotNull();
-			assertThat(response.nickname()).isEqualTo(profileUser.getNickname());
+			assertThat(response.nickname()).isEqualTo(PROFILE_USER.getNickname());
 			assertThat(response.followingCount()).isEqualTo(followingCount);
 			assertThat(response.followerCount()).isEqualTo(followerCount);
 			assertThat(response.postCount()).isEqualTo(postCount);
 			assertThat(response.isMe()).isFalse();
+		}
+
+		@Test
+		void 자신의_프로필_조회시_isMe가_true이다() {
+			// when
+			SocialProfileResponse response = socialProfileUseCase.getUserProfile(
+				PROFILE_USER.getId(),
+				PROFILE_USER.getId()
+			);
+
+			// then
+			assertThat(response.isMe()).isTrue();
 		}
 
 		@Test
@@ -76,9 +100,111 @@ public class SocialProfileUseCaseTest extends UseCaseTest {
 			Long nonExistentUserId = -1L;
 
 			// when & then
-			assertThatThrownBy(() -> socialProfileUseCase.getUserProfile(nonExistentUserId, authUser.getId()))
+			assertThatThrownBy(() -> socialProfileUseCase.getUserProfile(nonExistentUserId, AUTH_USER.getId()))
 				.isInstanceOf(CommonException.class)
 				.hasMessageContaining(NOT_FOUND_USER.getMessage());
 		}
+	}
+
+	@Nested
+	@DisplayName("특정 유저의 Social 게시글 목록 조회시")
+	class GetUserSocialsTests {
+
+		@Test
+		void 유저가_작성한_게시글_목록을_페이지네이션으로_조회한다() {
+			// given
+			int totalPosts = 15;
+			int limit = 10;
+
+			List<Social> profileUserSocials = testFixtureBuilder.buildSocials(
+				MULTIPLE_SOCIALS(PROFILE_USER, totalPosts));
+
+			testFixtureBuilder.buildSocial(SINGLE_SOCIAL(OHTER_USER, false));
+
+			// when
+			CursorPaginationResponse<SocialResponse> response = socialProfileUseCase.getUserSocials(
+				PROFILE_USER.getId(),
+				AUTH_USER.getId(), null, limit);
+
+			// then
+			Social firstExpectedSocial = profileUserSocials.get(totalPosts - 1);
+			Social lastExpectedSocialOnPage = profileUserSocials.get(totalPosts - limit);
+
+			assertSoftly(softly -> {
+				softly.assertThat(response.hasMore()).isTrue();
+				softly.assertThat(response.results()).hasSize(limit);
+				softly.assertThat(response.nextCursor()).isEqualTo(lastExpectedSocialOnPage.getId());
+
+				response.results().forEach(socialResponse ->
+					softly.assertThat(socialResponse.owner().ownerId()).isEqualTo(PROFILE_USER.getId())
+				);
+
+				softly.assertThat(response.results().get(0).socialId()).isEqualTo(firstExpectedSocial.getId());
+			});
+		}
+
+		@Test
+		void 커서를_사용하여_다음_페이지를_조회한다() {
+			// given
+			int totalPosts = 15;
+			int limit = 10;
+			List<Social> profileUserSocials = testFixtureBuilder.buildSocials(
+				MULTIPLE_SOCIALS(PROFILE_USER, totalPosts)
+			);
+			Long cursor = profileUserSocials.get(totalPosts - limit).getId();
+
+			// when
+			CursorPaginationResponse<SocialResponse> nextPage = socialProfileUseCase.getUserSocials(
+				PROFILE_USER.getId(),
+				AUTH_USER.getId(),
+				cursor,
+				limit
+			);
+
+			// then
+			int remainingPosts = totalPosts - limit;
+			Social oldestSocial = profileUserSocials.get(0);
+
+			assertSoftly(softly -> {
+				softly.assertThat(nextPage.hasMore()).isFalse();
+				softly.assertThat(nextPage.results()).hasSize(remainingPosts);
+				softly.assertThat(nextPage.nextCursor()).isNull();
+
+				softly.assertThat(nextPage.results().get(remainingPosts - 1).socialId())
+					.isEqualTo(oldestSocial.getId());
+			});
+		}
+
+		@Test
+		void 게시글이_없는_경우_빈_목록을_반환한다() {
+			// when
+			CursorPaginationResponse<SocialResponse> response = socialProfileUseCase.getUserSocials(
+				PROFILE_USER.getId(),
+				AUTH_USER.getId(),
+				null,
+				10
+			);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(response.hasMore()).isFalse();
+				softly.assertThat(response.results()).isEmpty();
+				softly.assertThat(response.nextCursor()).isNull();
+			});
+		}
+
+		@Test
+		void 존재하지_않는_사용자의_게시글_조회_시_예외가_발생한다() {
+			// given
+			Long nonExistentUserId = -1L;
+
+			// when & then
+			assertThatThrownBy(
+				() -> socialProfileUseCase.getUserSocials(nonExistentUserId, AUTH_USER.getId(), null, 10))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(NOT_FOUND_USER.getMessage());
+		}
+
+		// TODO: 차단 로직 구현 시 차단된 사용자의 게시글 조회 테스트 추가
 	}
 }

--- a/src/test/java/im/toduck/fixtures/RoutineFixtures.java
+++ b/src/test/java/im/toduck/fixtures/RoutineFixtures.java
@@ -10,6 +10,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.vo.PlanCategoryColor;
+import im.toduck.domain.routine.persistence.vo.RoutineMemo;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.helper.DaysOfWeekBitmask;
 
@@ -62,6 +63,7 @@ public class RoutineFixtures {
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)))
 			.time(NOON_TIME)
 			.color(PlanCategoryColor.from("#00FF00"))
+			.memo(RoutineMemo.from("주말 점심 루틴 메모"))
 			.isPublic(true)
 			.build();
 	}


### PR DESCRIPTION
## ✨ 작업 내용

> 해당 PR의 api는 총 3개입니다!
> 게시글 목록 조회, 게시글 단건 조회, 게시글 검색 시 N+1 문제가 발생하는 것을 인지하고 있으며, 추후 PR에서 수정하겠습니다!

**1️⃣ 소셜 프로필 - 유저 정보 조회**

![스크린샷 2025-03-29 오후 7 25 25](https://github.com/user-attachments/assets/d03d07fd-1abd-46b8-9466-58a1df250729)
- 배지는 1차 출시 계획에서 제외됨
  <br/>

**2️⃣  소셜 프로필 - 유저 공개 루틴 목록 조회**
![스크린샷 2025-03-29 오후 7 26 18](https://github.com/user-attachments/assets/e453e4a0-89f7-448a-af8b-911c1fa17f8e)
- 루틴 공유수는 다음 PR에서 추가 후 적용할 예정
  <br/>

**3️⃣ 소셜 프로필 - 유저 작성 게시글 조회**
![스크린샷 2025-03-29 오후 7 26 51](https://github.com/user-attachments/assets/227abd74-539f-4a5a-90e9-0ee69e8994cb)

  <br/>

## ✅ 리뷰 요구사항
- 궁금한 점 있으면 댓글 남겨주세요!