### PR TITLE
Diary CRUD API 오류 수정

### DIFF
--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -31,6 +31,7 @@ public class DiaryMapper {
 
 	public static DiaryResponse fromDiary(Diary diary) {
 		return new DiaryResponse(
+			diary.getId(),
 			diary.getDate(),
 			diary.getEmotion(),
 			diary.getTitle(),

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -91,7 +91,7 @@ public class DiaryService {
 		final int month
 	) {
 		LocalDate startDate = LocalDate.of(year, month, 1);
-		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth()).plusDays(1);
 
 		List<Diary> diaries = diaryRepository.findByUserIdAndDateBetweenOrderByDateDesc(userId, startDate, endDate);
 

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -99,4 +99,8 @@ public class DiaryService {
 			.map(DiaryMapper::fromDiary)
 			.toList();
 	}
+
+	public Diary getDiaryByDate(Long userId, LocalDate date) {
+		return diaryRepository.findByUserIdAndDate(userId, date);
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -30,6 +30,10 @@ public class DiaryUseCase {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
+		Diary checkDiary = diaryService.getDiaryByDate(userId, request.date());
+		if (checkDiary != null) {
+			throw CommonException.from(ExceptionCode.EXISTS_DATE_DIARY);
+		}
 		Diary diary = diaryService.createDiary(user, request);
 		diaryService.addDiaryImageFiles(request.diaryImageUrls(), diary);
 

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -31,7 +31,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "diary")
 @Getter
 @NoArgsConstructor
-@SQLDelete(sql = "UPDATE record SET deleted_at = NOW() where id=?")
+@SQLDelete(sql = "UPDATE diary SET deleted_at = NOW() where id=?")
 @SQLRestriction(value = "deleted_at is NULL")
 public class Diary extends BaseEntity {
 	@Id

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "diary_image_file")
 @Getter
 @NoArgsConstructor
-@SQLDelete(sql = "UPDATE record SET deleted_at = NOW() where id=?")
+@SQLDelete(sql = "UPDATE diary SET deleted_at = NOW() where id=?")
 @SQLRestriction(value = "deleted_at is NULL")
 public class DiaryImage extends BaseEntity {
 	@Id

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryImage.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "diary_image_file")
 @Getter
 @NoArgsConstructor
-@SQLDelete(sql = "UPDATE diary SET deleted_at = NOW() where id=?")
+@SQLDelete(sql = "UPDATE diary_image_file SET deleted_at = NOW() where id=?")
 @SQLRestriction(value = "deleted_at is NULL")
 public class DiaryImage extends BaseEntity {
 	@Id

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
@@ -7,8 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import im.toduck.domain.diary.persistence.entity.Diary;
+import jakarta.validation.constraints.NotNull;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	List<Diary> findByUserIdAndDateBetweenOrderByDateDesc(Long userId, LocalDate startDate, LocalDate endDate);
+
+	Diary findByUserIdAndDate(Long userId, @NotNull(message = "날짜는 비어있을 수 없습니다.") LocalDate date);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -89,7 +89,7 @@ public interface DiaryApi {
 				<p>2. <b>메모 수정</b>: memo = 변경할 내용(지우고 싶은 경우 빈 문자열)</p>
 				<b>이미지 관련 시나리오:</b><br/>
 				<p>1. <b>이미지 유지</b>: diaryImageUrls = null (이미지를 수정하지 않음)</p>
-				<p>2. <b>이미지 추가/수정</b>: diaryImageUrls = [새로운 이미지 URL 리스트]</p>
+				<p>2. <b>이미지 추가/수정</b>: diaryImageUrls = [새로운 이미지 URL 리스트] (유지되는 이미지도 다시 첨부)</p>
 				<p>3. <b>이미지 모두 제거</b>: diaryImageUrls = [] (기존 이미지를 모두 제거)</p>
 				<p>4. <b>최대 이미지 초과</b>: diaryImageUrls = [이미지 URL 3개 이상] (예외 발생)</p><br/>
 				"""

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -105,7 +105,7 @@ public interface DiaryApi {
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> updateDiary(
 		@PathVariable Long diaryId,
-		@AuthenticationPrincipal DiaryUpdateRequest request,
+		@RequestBody @Valid DiaryUpdateRequest request,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
 

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -41,9 +41,9 @@ public class DiaryController implements DiaryApi {
 		@RequestBody @Valid final DiaryCreateRequest request,
 		@AuthenticationPrincipal final CustomUserDetails userDetails
 	) {
-		return ResponseEntity.ok(
-			ApiResponse.createSuccess(diaryUseCase.createDiary(userDetails.getUserId(), request))
-		);
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(diaryUseCase.createDiary(userDetails.getUserId(), request))
+			);
 	}
 
 	@Override

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
@@ -19,7 +19,7 @@ public record DiaryCreateRequest(
 	LocalDate date,
 
 	@NotNull(message = "감정은 비어있을 수 없습니다.")
-	@Schema(description = "감정", example = "HAPPY")
+	@Schema(description = "감정", example = "SAD")
 	Emotion emotion,
 
 	@Size(max = 16, message = "제목은 16자를 초과할 수 없습니다.")

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
@@ -3,6 +3,9 @@ package im.toduck.domain.diary.presentation.dto.request;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+
 import im.toduck.domain.user.persistence.entity.Emotion;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -11,6 +14,7 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "다이어리 생성 요청 DTO")
 public record DiaryCreateRequest(
 	@NotNull(message = "날짜는 비어있을 수 없습니다.")
+	@JsonDeserialize(using = LocalDateDeserializer.class)
 	@Schema(description = "일기 날짜", example = "2025-03-12")
 	LocalDate date,
 

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
@@ -12,7 +12,7 @@ import jakarta.validation.constraints.Size;
 public record DiaryUpdateRequest(
 	@NotNull
 	@Schema(description = "감정 변경 여부", example = "true")
-	boolean isChangeEmotion,
+	Boolean isChangeEmotion,
 
 	@NotNull
 	@Schema(description = "기존/변경된 감정", example = "SAD")

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
@@ -15,17 +15,17 @@ public record DiaryUpdateRequest(
 	boolean isChangeEmotion,
 
 	@NotNull
-	@Schema(description = "기존/변경된 감정", example = "HAPPY")
+	@Schema(description = "기존/변경된 감정", example = "SAD")
 	Emotion emotion,
 
 	@Nullable
 	@Size(max = 50, message = "제목은 공백일 수 없으며 50자 이하여야 합니다.")
-	@Schema(description = "변경된 제목", example = "오늘의 기분은 최고!")
+	@Schema(description = "변경된 제목", example = "버그를 만났어")
 	String title,
 
 	@Nullable
 	@Size(max = 2048, message = "메모는 공백일 수 없으며 2048자 이하여야 합니다.")
-	@Schema(description = "변경된 메모", example = "오늘 하루를 기록해봅니다...")
+	@Schema(description = "변경된 메모", example = "슬퍼짐")
 	String memo,
 
 	@Nullable

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryUpdateRequest.java
@@ -15,7 +15,7 @@ public record DiaryUpdateRequest(
 	Boolean isChangeEmotion,
 
 	@NotNull
-	@Schema(description = "기존/변경된 감정", example = "SAD")
+	@Schema(description = "기존/변경된 감정", example = "HAPPY")
 	Emotion emotion,
 
 	@Nullable
@@ -25,7 +25,7 @@ public record DiaryUpdateRequest(
 
 	@Nullable
 	@Size(max = 2048, message = "메모는 공백일 수 없으며 2048자 이하여야 합니다.")
-	@Schema(description = "변경된 메모", example = "슬퍼짐")
+	@Schema(description = "변경된 메모", example = "버그 수정할 생각에 기분이 좋음")
 	String memo,
 
 	@Nullable

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryResponse.java
@@ -3,12 +3,19 @@ package im.toduck.domain.diary.presentation.dto.response;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+
 import im.toduck.domain.user.persistence.entity.Emotion;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record DiaryResponse(
+	@Schema(description = "일기 번호", example = "1")
+	Long diaryId,
+
+	@JsonSerialize(using = LocalDateSerializer.class)
 	@Schema(description = "날짜", example = "2025-03-21")
 	LocalDate date,
 

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -84,6 +84,7 @@ public enum ExceptionCode {
 	/* 405xx diary */
 	NOT_FOUND_DIARY(HttpStatus.NOT_FOUND, 40501, "일기를 찾을 수 없습니다."),
 	UNAUTHORIZED_ACCESS_DIARY(HttpStatus.FORBIDDEN, 40502, "일기에 접근 권한이 없습니다."),
+	EXISTS_DATE_DIARY(HttpStatus.CONFLICT, 40503, "이미 해당 날짜에 일기가 존재합니다."),
 
 	/* 411xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 41101, "일정 기록을 찾을 수 없습니다.",


### PR DESCRIPTION
## ✨ 작업 내용

> 로컬 서버에서 테스트 했을 때 발생한 오류들을 수정했습니다.

**1️⃣ 작업내용1**

- 일기 목록을 조회할 때 일기 번호도 함께 전달하도록 수정했습니다.

- JSON 데이터를 LocalDate 타입으로 변환할 수 있도록 `@JsonDeserialize(using = LocalDateDeserializer.class)` 어노테이션을 추가했습니다.

- 일기는 하루에 하나만 존재하므로 이미 일기가 작성된 날에 다시 create를 요청할 경우 오류를 추가했습니다.

- 여러 오타들을 수정했습니다.

  <br/>

## ✅ 리뷰 요구사항(선택)

> 해당 안내는 지워주세요.
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.  
> 작성하지 않는다면 항목을 지워주세요.  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
