### PR TITLE
특정 연월 일기 개수 (전월 대비) 조회 API

### DIFF
--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -4,6 +4,7 @@ import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
+import im.toduck.domain.diary.presentation.dto.response.MonthDiaryResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -40,5 +41,9 @@ public class DiaryMapper {
 				.map(DiaryImageFileMapper::fromDiaryImage)
 				.toList()
 		);
+	}
+
+	public static MonthDiaryResponse toMonthDiaryResponse(int thisMonthCount, int lastMonthCount) {
+		return new MonthDiaryResponse(thisMonthCount - lastMonthCount);
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -103,4 +103,12 @@ public class DiaryService {
 	public Diary getDiaryByDate(Long userId, LocalDate date) {
 		return diaryRepository.findByUserIdAndDate(userId, date);
 	}
+
+	@Transactional(readOnly = true)
+	public int getDiaryCountByMonth(final Long userId, final int year, final int month) {
+		LocalDate startDate = LocalDate.of(year, month, 1);
+		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth()).plusDays(1);
+
+		return diaryRepository.countByUserIdAndDateBetween(userId, startDate, endDate);
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -87,4 +87,11 @@ public class DiaryUseCase {
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		return diaryService.getDiariesByMonth(userId, year, month);
 	}
+
+	@Transactional
+	public int getDiaryCountByMonth(Long userId, int year, int month) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+		return diaryService.getDiaryCountByMonth(userId, year, month);
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -11,6 +11,7 @@ import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
+import im.toduck.domain.diary.presentation.dto.response.MonthDiaryResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.annotation.UseCase;
@@ -90,7 +91,7 @@ public class DiaryUseCase {
 	}
 
 	@Transactional(readOnly = true)
-	public int getDiaryCountByMonth(Long userId, int year, int month) {
+	public MonthDiaryResponse getDiaryCountByMonth(Long userId, int year, int month) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		int lastMonth = month - 1;
@@ -101,6 +102,6 @@ public class DiaryUseCase {
 		}
 		int thisMonthCount = diaryService.getDiaryCountByMonth(userId, year, month);
 		int lastMonthCount = diaryService.getDiaryCountByMonth(userId, lastYear, lastMonth);
-		return thisMonthCount - lastMonthCount;
+		return DiaryMapper.toMonthDiaryResponse(thisMonthCount, lastMonthCount);
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -2,6 +2,8 @@ package im.toduck.domain.diary.domain.usecase;
 
 import java.util.List;
 
+import org.springframework.transaction.annotation.Transactional;
+
 import im.toduck.domain.diary.common.mapper.DiaryMapper;
 import im.toduck.domain.diary.domain.service.DiaryService;
 import im.toduck.domain.diary.persistence.entity.Diary;
@@ -14,7 +16,6 @@ import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.annotation.UseCase;
 import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -81,14 +82,14 @@ public class DiaryUseCase {
 		return diary.isOwner(user);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public List<DiaryResponse> getDiariesByMonth(final Long userId, final int year, final int month) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		return diaryService.getDiariesByMonth(userId, year, month);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public int getDiaryCountByMonth(Long userId, int year, int month) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -93,6 +93,14 @@ public class DiaryUseCase {
 	public int getDiaryCountByMonth(Long userId, int year, int month) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-		return diaryService.getDiaryCountByMonth(userId, year, month);
+		int lastMonth = month - 1;
+		int lastYear = year;
+		if (lastMonth == 0) {
+			lastMonth = 12;
+			lastYear--;
+		}
+		int thisMonthCount = diaryService.getDiaryCountByMonth(userId, year, month);
+		int lastMonthCount = diaryService.getDiaryCountByMonth(userId, lastYear, lastMonth);
+		return thisMonthCount - lastMonthCount;
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -1,5 +1,6 @@
 package im.toduck.domain.diary.domain.usecase;
 
+import java.time.YearMonth;
 import java.util.List;
 
 import org.springframework.transaction.annotation.Transactional;
@@ -94,14 +95,14 @@ public class DiaryUseCase {
 	public MonthDiaryResponse getDiaryCountByMonth(Long userId, int year, int month) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-		int lastMonth = month - 1;
-		int lastYear = year;
-		if (lastMonth == 0) {
-			lastMonth = 12;
-			lastYear--;
-		}
-		int thisMonthCount = diaryService.getDiaryCountByMonth(userId, year, month);
-		int lastMonthCount = diaryService.getDiaryCountByMonth(userId, lastYear, lastMonth);
+
+		YearMonth currentMonth = YearMonth.of(year, month);
+		YearMonth previousMonth = currentMonth.minusMonths(1);
+
+		int thisMonthCount = diaryService.getDiaryCountByMonth(userId, currentMonth.getYear(),
+			currentMonth.getMonthValue());
+		int lastMonthCount = diaryService.getDiaryCountByMonth(userId, previousMonth.getYear(),
+			previousMonth.getMonthValue());
 		return DiaryMapper.toMonthDiaryResponse(thisMonthCount, lastMonthCount);
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
@@ -14,4 +14,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	List<Diary> findByUserIdAndDateBetweenOrderByDateDesc(Long userId, LocalDate startDate, LocalDate endDate);
 
 	Diary findByUserIdAndDate(Long userId, @NotNull(message = "날짜는 비어있을 수 없습니다.") LocalDate date);
+
+	int countByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -132,4 +132,28 @@ public interface DiaryApi {
 		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
+
+	@Operation(
+		summary = "특정 연월에 작성된 일기 개수 검색",
+		description =
+			"""
+				<b>특정 연월에 작성된 일기의 개수를 조회합니다.</b><br/><br/>
+				<p><b>연월 필터를 적용하는 방법:</b></p>
+				<p>예시: /v1/diary/count?year=2025&month=3</p><br/>
+				<p>- <b>year:</b> 조회 할 연도</p>
+				<p>- <b>month:</b> 조회 할 달</p>
+				<p>검색 결과가 존재하지 않는 경우 0이 반환됩니다.</p>
+				"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = DiaryResponse.class,
+			description = "일기 조회 성공, 해당 연월에 작성된 일기의 개수를 반환합니다."
+		)
+	)
+	ResponseEntity<ApiResponse<Integer>> getDiaryCountByMonth(
+		@RequestParam("year") int year,
+		@RequestParam("month") int month,
+		@AuthenticationPrincipal CustomUserDetails user
+	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -134,21 +134,20 @@ public interface DiaryApi {
 	);
 
 	@Operation(
-		summary = "특정 연월에 작성된 일기 개수 검색",
+		summary = "특정 연월의 일기 개수 증감 (전월 대비)",
 		description =
 			"""
-				<b>특정 연월에 작성된 일기의 개수를 조회합니다.</b><br/><br/>
+				<b>특정 연월과 전월의 일기 개수를 비교하여 그 차이를 조회합니다.</b><br/><br/>
 				<p><b>연월 필터를 적용하는 방법:</b></p>
 				<p>예시: /v1/diary/count?year=2025&month=3</p><br/>
 				<p>- <b>year:</b> 조회 할 연도</p>
 				<p>- <b>month:</b> 조회 할 달</p>
-				<p>검색 결과가 존재하지 않는 경우 0이 반환됩니다.</p>
 				"""
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
-			responseClass = DiaryResponse.class,
-			description = "일기 조회 성공, 해당 연월에 작성된 일기의 개수를 반환합니다."
+			responseClass = ApiResponse.class,
+			description = "일기 조회 성공, 특정 연월의 일기 개수 증감(전월 대비)을 반환합니다."
 		)
 	)
 	ResponseEntity<ApiResponse<Integer>> getDiaryCountByMonth(

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -13,6 +13,7 @@ import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
+import im.toduck.domain.diary.presentation.dto.response.MonthDiaryResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -146,11 +147,11 @@ public interface DiaryApi {
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
-			responseClass = ApiResponse.class,
+			responseClass = MonthDiaryResponse.class,
 			description = "일기 조회 성공, 특정 연월의 일기 개수 증감(전월 대비)을 반환합니다."
 		)
 	)
-	ResponseEntity<ApiResponse<Integer>> getDiaryCountByMonth(
+	ResponseEntity<ApiResponse<MonthDiaryResponse>> getDiaryCountByMonth(
 		@RequestParam("year") int year,
 		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -91,14 +91,7 @@ public class DiaryController implements DiaryApi {
 		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
-		int lastMonth = month - 1;
-		int lastYear = year;
-		if (lastMonth == 0) {
-			lastMonth = 12;
-			lastYear--;
-		}
-		int lastMonthDiaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), lastYear, lastMonth);
-		int thisMonthDiaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), year, month);
-		return ResponseEntity.ok(ApiResponse.createSuccess(thisMonthDiaryCount - lastMonthDiaryCount));
+		int monthDiaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), year, month);
+		return ResponseEntity.ok(ApiResponse.createSuccess(monthDiaryCount));
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -91,7 +91,14 @@ public class DiaryController implements DiaryApi {
 		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
-		int diaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), year, month);
-		return ResponseEntity.ok(ApiResponse.createSuccess(diaryCount));
+		int lastMonth = month - 1;
+		int lastYear = year;
+		if (lastMonth == 0) {
+			lastMonth = 12;
+			lastYear--;
+		}
+		int lastMonthDiaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), lastYear, lastMonth);
+		int thisMonthDiaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), year, month);
+		return ResponseEntity.ok(ApiResponse.createSuccess(thisMonthDiaryCount - lastMonthDiaryCount));
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -22,6 +22,7 @@ import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
+import im.toduck.domain.diary.presentation.dto.response.MonthDiaryResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -86,12 +87,13 @@ public class DiaryController implements DiaryApi {
 	@GetMapping("/count")
 	@PreAuthorize("isAuthenticated()")
 	@Override
-	public ResponseEntity<ApiResponse<Integer>> getDiaryCountByMonth(
+	public ResponseEntity<ApiResponse<MonthDiaryResponse>> getDiaryCountByMonth(
 		@RequestParam("year") int year,
 		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
-		int monthDiaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), year, month);
-		return ResponseEntity.ok(ApiResponse.createSuccess(monthDiaryCount));
+		MonthDiaryResponse monthDiaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), year, month);
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(monthDiaryCount));
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -82,4 +82,16 @@ public class DiaryController implements DiaryApi {
 		List<DiaryResponse> diaries = diaryUseCase.getDiariesByMonth(user.getUserId(), year, month);
 		return ResponseEntity.ok(ApiResponse.createSuccess(diaries));
 	}
+
+	@GetMapping("/count")
+	@PreAuthorize("isAuthenticated()")
+	@Override
+	public ResponseEntity<ApiResponse<Integer>> getDiaryCountByMonth(
+		@RequestParam("year") int year,
+		@RequestParam("month") int month,
+		@AuthenticationPrincipal CustomUserDetails user
+	) {
+		int diaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), year, month);
+		return ResponseEntity.ok(ApiResponse.createSuccess(diaryCount));
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/MonthDiaryResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/MonthDiaryResponse.java
@@ -1,6 +1,9 @@
 package im.toduck.domain.diary.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MonthDiaryResponse(
+	@Schema(description = "특정 연월의 일기 개수 증감 (전월 대비)", example = "1")
 	Integer count
 ) {
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/MonthDiaryResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/MonthDiaryResponse.java
@@ -1,0 +1,6 @@
+package im.toduck.domain.diary.presentation.dto.response;
+
+public record MonthDiaryResponse(
+	Integer count
+) {
+}


### PR DESCRIPTION
## ✨ 작업 내용

> 일기 화면 통계 부분에 사용될 API 입니다.

**1️⃣ 작업내용1**

- 연월을 입력하면 해당 월과 전월의 일기의 개수 차이를 알려줍니다.


## ✅ 리뷰 요구사항(선택)
> 매핑 이름 더 나은 게 있을까요?
