### PR TITLE
게시글 검색 시 카테고리 필터 추가

### DIFF
--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialMapper.java
@@ -9,6 +9,7 @@ import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
 import im.toduck.domain.social.presentation.dto.response.CommentDto;
 import im.toduck.domain.social.presentation.dto.response.OwnerDto;
+import im.toduck.domain.social.presentation.dto.response.SocialCategoryResponse.SocialCategoryDto;
 import im.toduck.domain.social.presentation.dto.response.SocialCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialDetailResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialImageDto;
@@ -66,6 +67,7 @@ public class SocialMapper {
 	public static SocialResponse toSocialResponse(
 		Social socialBoard,
 		List<SocialImageFile> imageFiles,
+		List<SocialCategoryDto> socialCategoryDtos,
 		int commentCount,
 		boolean isLiked
 	) {
@@ -79,6 +81,7 @@ public class SocialMapper {
 			.images(getImageDtos(imageFiles))
 			.socialLikeInfo(getSocialLikeDto(socialBoard, isLiked))
 			.commentCount(commentCount)
+			.categories(socialCategoryDtos)
 			.createdAt(socialBoard.getCreatedAt())
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -201,14 +201,16 @@ public class SocialBoardService {
 		return socialCategoryRepository.findAll();
 	}
 
+	@Transactional(readOnly = true)
 	public List<Social> searchSocialsWithFilters(
 		final Long userId,
 		final String keyword,
 		final Long cursor,
-		final int limit
+		final int limit,
+		final List<Long> categoryIds
 	) {
 		PageRequest pageRequest = PageRequest.of(PaginationUtil.FIRST_PAGE_INDEX, limit);
-		return socialRepository.searchSocialsExcludingBlocked(cursor, userId, keyword, pageRequest);
+		return socialRepository.searchSocialsExcludingBlocked(cursor, userId, keyword, categoryIds, pageRequest);
 	}
 }
 

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialCategoryService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialCategoryService.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 
 import im.toduck.domain.social.common.mapper.SocialCategoryMapper;
 import im.toduck.domain.social.persistence.entity.Social;
-import im.toduck.domain.social.persistence.entity.SocialCategory;
 import im.toduck.domain.social.persistence.entity.SocialCategoryLink;
 import im.toduck.domain.social.persistence.repository.SocialCategoryLinkRepository;
 import im.toduck.domain.social.presentation.dto.response.SocialCategoryResponse.SocialCategoryDto;
@@ -20,11 +19,9 @@ public class SocialCategoryService {
 	private final SocialCategoryLinkRepository socialCategoryLinkRepository;
 
 	public List<SocialCategoryDto> getSocialCategoryDtosBySocial(final Social social) {
-		List<SocialCategoryLink> socialCategoryLinks = socialCategoryLinkRepository.findAllBySocial(social);
-		List<SocialCategory> socialCategories = socialCategoryLinks.stream()
+		List<SocialCategoryLink> socialCategoryLinks = socialCategoryLinkRepository.findAllBySocial(social); // 1. 링크 조회
+		return socialCategoryLinks.stream()
 			.map(SocialCategoryLink::getSocialCategory)
-			.toList();
-		return socialCategories.stream()
 			.map(SocialCategoryMapper::toSocialCategoryDto)
 			.toList();
 	}

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialCategoryService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialCategoryService.java
@@ -1,0 +1,31 @@
+package im.toduck.domain.social.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import im.toduck.domain.social.common.mapper.SocialCategoryMapper;
+import im.toduck.domain.social.persistence.entity.Social;
+import im.toduck.domain.social.persistence.entity.SocialCategory;
+import im.toduck.domain.social.persistence.entity.SocialCategoryLink;
+import im.toduck.domain.social.persistence.repository.SocialCategoryLinkRepository;
+import im.toduck.domain.social.presentation.dto.response.SocialCategoryResponse.SocialCategoryDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SocialCategoryService {
+	private final SocialCategoryLinkRepository socialCategoryLinkRepository;
+
+	public List<SocialCategoryDto> getSocialCategoryDtosBySocial(final Social social) {
+		List<SocialCategoryLink> socialCategoryLinks = socialCategoryLinkRepository.findAllBySocial(social);
+		List<SocialCategory> socialCategories = socialCategoryLinks.stream()
+			.map(SocialCategoryLink::getSocialCategory)
+			.toList();
+		return socialCategories.stream()
+			.map(SocialCategoryMapper::toSocialCategoryDto)
+			.toList();
+	}
+}

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCase.java
@@ -250,7 +250,8 @@ public class SocialBoardUseCase {
 		final Long userId,
 		final String keyword,
 		final Long cursor,
-		final Integer limit
+		final Integer limit,
+		final List<Long> categoryIds
 	) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
@@ -258,11 +259,14 @@ public class SocialBoardUseCase {
 		int actualLimit = PaginationUtil.resolveLimit(limit, DEFAULT_SOCIAL_PAGE_SIZE);
 		int fetchLimit = PaginationUtil.calculateTotalFetchSize(actualLimit);
 
+		validateCategories(userId, categoryIds);
+
 		List<Social> searchResults = socialBoardService.searchSocialsWithFilters(
 			userId,
 			keyword,
 			cursor,
-			fetchLimit
+			fetchLimit,
+			categoryIds
 		);
 
 		boolean hasMore = PaginationUtil.hasMore(searchResults, actualLimit);

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
@@ -1,5 +1,7 @@
 package im.toduck.domain.social.domain.usecase;
 
+import static im.toduck.domain.social.presentation.dto.response.SocialCategoryResponse.*;
+
 import java.util.List;
 
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +12,7 @@ import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.social.common.mapper.SocialMapper;
 import im.toduck.domain.social.common.mapper.SocialProfileMapper;
 import im.toduck.domain.social.domain.service.SocialBoardService;
+import im.toduck.domain.social.domain.service.SocialCategoryService;
 import im.toduck.domain.social.domain.service.SocialInteractionService;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
@@ -38,6 +41,7 @@ public class SocialProfileUseCase {
 	private final SocialBoardService socialBoardService;
 	private final SocialInteractionService socialInteractionService;
 	private final RoutineService routineService;
+	private final SocialCategoryService socialCategoryService;
 
 	@Transactional(readOnly = true)
 	public SocialProfileResponse getUserProfile(final Long profileUserId, final Long authUserId) {
@@ -107,8 +111,15 @@ public class SocialProfileUseCase {
 				int commentCount = socialInteractionService.countCommentsBySocial(social);
 				boolean isLikedByRequestingUser = socialInteractionService.getSocialBoardIsLiked(requestingUser,
 					social);
-
-				return SocialMapper.toSocialResponse(social, imageFiles, commentCount, isLikedByRequestingUser);
+				List<SocialCategoryDto> socialCategoryDtos = socialCategoryService.getSocialCategoryDtosBySocial(
+					social);
+				return SocialMapper.toSocialResponse(
+					social,
+					imageFiles,
+					socialCategoryDtos,
+					commentCount,
+					isLikedByRequestingUser
+				);
 			})
 			.toList();
 	}

--- a/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustom.java
@@ -18,6 +18,7 @@ public interface SocialRepositoryCustom {
 		Long cursor,
 		Long currentUserId,
 		String keyword,
+		List<Long> categoryIds,
 		Pageable pageable
 	);
 }

--- a/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustomImpl.java
@@ -122,10 +122,14 @@ public class SocialRepositoryCustomImpl implements SocialRepositoryCustom {
 
 	private void applyCategoryFilter(JPAQuery<Social> query, List<Long> categoryIds) {
 		if (categoryIds != null && !categoryIds.isEmpty()) {
-			query.join(qSocialCategoryLink).on(qSocialCategoryLink.social.eq(qSocial))
-				.join(qSocialCategory).on(qSocialCategoryLink.socialCategory.eq(qSocialCategory))
-				.where(qSocialCategory.id.in(categoryIds));
-			query.distinct();
+			for (Long categoryId : categoryIds) {
+				query.where(qSocial.id.in(
+					queryFactory
+						.select(qSocialCategoryLink.social.id)
+						.from(qSocialCategoryLink)
+						.where(qSocialCategoryLink.socialCategory.id.eq(categoryId))
+				));
+			}
 		}
 	}
 }

--- a/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustomImpl.java
@@ -40,12 +40,7 @@ public class SocialRepositoryCustomImpl implements SocialRepositoryCustom {
 				cursorCondition(cursor)
 			);
 
-		if (categoryIds != null && !categoryIds.isEmpty()) {
-			query.join(qSocialCategoryLink).on(qSocialCategoryLink.social.eq(qSocial))
-				.join(qSocialCategory).on(qSocialCategoryLink.socialCategory.eq(qSocialCategory))
-				.where(qSocialCategory.id.in(categoryIds));
-			query.distinct();
-		}
+		applyCategoryFilter(query, categoryIds);
 
 		return applyPagination(query, pageable).fetch();
 	}
@@ -55,6 +50,7 @@ public class SocialRepositoryCustomImpl implements SocialRepositoryCustom {
 		Long cursor,
 		Long currentUserId,
 		String keyword,
+		List<Long> categoryIds,
 		Pageable pageable
 	) {
 		JPAQuery<Social> query = queryFactory
@@ -65,6 +61,8 @@ public class SocialRepositoryCustomImpl implements SocialRepositoryCustom {
 				cursorCondition(cursor),
 				keywordCondition(keyword)
 			);
+
+		applyCategoryFilter(query, categoryIds);
 
 		return applyPagination(query, pageable).fetch();
 	}
@@ -102,5 +100,14 @@ public class SocialRepositoryCustomImpl implements SocialRepositoryCustom {
 			.orderBy(qSocial.id.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize());
+	}
+
+	private void applyCategoryFilter(JPAQuery<Social> query, List<Long> categoryIds) {
+		if (categoryIds != null && !categoryIds.isEmpty()) {
+			query.join(qSocialCategoryLink).on(qSocialCategoryLink.social.eq(qSocial))
+				.join(qSocialCategory).on(qSocialCategoryLink.socialCategory.eq(qSocialCategory))
+				.where(qSocialCategory.id.in(categoryIds));
+			query.distinct();
+		}
 	}
 }

--- a/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/querydsl/SocialRepositoryCustomImpl.java
@@ -122,14 +122,11 @@ public class SocialRepositoryCustomImpl implements SocialRepositoryCustom {
 
 	private void applyCategoryFilter(JPAQuery<Social> query, List<Long> categoryIds) {
 		if (categoryIds != null && !categoryIds.isEmpty()) {
-			for (Long categoryId : categoryIds) {
-				query.where(qSocial.id.in(
-					queryFactory
-						.select(qSocialCategoryLink.social.id)
-						.from(qSocialCategoryLink)
-						.where(qSocialCategoryLink.socialCategory.id.eq(categoryId))
-				));
-			}
+			query
+				.join(qSocialCategoryLink).on(qSocialCategoryLink.social.eq(qSocial))
+				.where(qSocialCategoryLink.socialCategory.id.in(categoryIds))
+				.groupBy(qSocial.id)
+				.having(qSocialCategoryLink.socialCategory.id.countDistinct().eq((long)categoryIds.size()));
 		}
 	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialBoardApi.java
@@ -197,8 +197,20 @@ public interface SocialBoardApi {
 	ResponseEntity<ApiResponse<SocialCategoryResponse>> getAllCategories();
 
 	@Operation(
-		summary = "게시글 검색",
-		description = "키워드로 게시글을 검색합니다."
+		summary = "게시글 검색 (카테고리 필터 가능)",
+		description = """
+			<b>키워드로 게시글을 검색하며, 선택적으로 카테고리 필터를 적용할 수 있습니다.</b><br/><br/>
+			<p><b>카테고리 필터를 적용하는 방법:</b></p>
+			<p>예시: /v1/socials/search?keyword=검색어&limit=10&categoryIds=1,2</p><br/>
+			<p><b>커서 페이지네이션 사용법:</b></p>
+			<p>Notion > API 개요 > 페이지네이션을 확인해주세요.</p><br/>
+			<p><b>파라미터:</b><br/>
+			<p>- <b>keyword:</b> 검색할 키워드 (필수)</p>
+			<p>- <b>cursor:</b> 조회를 시작할 커서 값 (게시글 ID)</p>
+			<p>- <b>limit:</b> 한 페이지에 표시할 게시글 수</p>
+			<p>- <b>categoryIds:</b> 필터링할 카테고리 ID 목록 (쉼표로 구분, 선택)</p><br/>
+			<p>공유할 루틴이 존재하지 않는 경우 <b>routine</b> 필드에 <b>null</b>이 반환됩니다.</p>
+			"""
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
@@ -210,7 +222,8 @@ public interface SocialBoardApi {
 		@AuthenticationPrincipal CustomUserDetails user,
 		@RequestParam(name = "keyword") @NotBlank String keyword,
 		@Parameter(description = "조회를 시작할 커서 값") @RequestParam(required = false) Long cursor,
-		@Parameter(description = "한 페이지에 표시할 항목 수") @PaginationLimit @RequestParam(required = false) Integer limit
+		@Parameter(description = "한 페이지에 표시할 항목 수") @PaginationLimit @RequestParam(required = false) Integer limit,
+		@Parameter(description = "카테고리 ID 목록 (필터링 시)") @RequestParam(required = false) List<Long> categoryIds
 	);
 
 }

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialBoardController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialBoardController.java
@@ -117,9 +117,10 @@ public class SocialBoardController implements SocialBoardApi {
 		CustomUserDetails user,
 		@RequestParam(name = "keyword") String keyword,
 		Long cursor,
-		Integer limit
+		Integer limit,
+		List<Long> categoryIds
 	) {
 		return ResponseEntity.ok().body(ApiResponse.createSuccess(
-			socialBoardUseCase.searchSocials(user.getUserId(), keyword, cursor, limit)));
+			socialBoardUseCase.searchSocials(user.getUserId(), keyword, cursor, limit, categoryIds)));
 	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialResponse.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
+import im.toduck.domain.social.presentation.dto.response.SocialCategoryResponse.SocialCategoryDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -39,6 +40,9 @@ public record SocialResponse(
 
 	@Schema(description = "댓글 수", example = "1")
 	int commentCount,
+
+	@Schema(description = "카테고리 목록")
+	List<SocialCategoryDto> categories,
 
 	@Schema(description = "게시글 작성 시간", type = "string", pattern = "yyyy-MM-dd HH:mm", example = "2024-09-11 10:30")
 	@JsonSerialize(using = LocalDateTimeSerializer.class)

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialBoardUseCaseTest.java
@@ -34,7 +34,6 @@ import im.toduck.domain.social.persistence.entity.Comment;
 import im.toduck.domain.social.persistence.entity.Like;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.entity.SocialCategory;
-import im.toduck.domain.social.persistence.entity.SocialCategoryLink;
 import im.toduck.domain.social.persistence.entity.SocialImageFile;
 import im.toduck.domain.social.persistence.repository.CommentLikeRepository;
 import im.toduck.domain.social.persistence.repository.CommentRepository;
@@ -59,6 +58,7 @@ import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
 import im.toduck.global.presentation.dto.response.CursorPaginationResponse;
 
+@Transactional
 public class SocialBoardUseCaseTest extends ServiceTest {
 	private User USER;
 
@@ -308,36 +308,48 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 		Social SOCIAL_BOARD;
 		String updateContent = "This is a test update.";
 		Boolean isAnonymous = true;
-		List<SocialCategory> categories = testFixtureBuilder.buildCategories(MULTIPLE_CATEGORIES(2));
-		List<Long> validCategoryIds = List.of(categories.get(0).getId(), categories.get(1).getId());
 		List<Long> invalidCategoryIds = List.of(-1L);
 		List<String> imageUrls = List.of("updatedImage1.jpg", "updatedImage2.jpg");
+		List<SocialCategory> createdCategories;
+		List<Long> validCategoryIds;
+
+		enum CategoryUpdateScenario {
+			NO_CHANGE,
+			USE_SETUP_IDS,
+			USE_EMPTY_LIST
+		}
 
 		@BeforeEach
 		void setUp() {
+			createdCategories = testFixtureBuilder.buildCategories(MULTIPLE_CATEGORIES(2));
+			validCategoryIds = createdCategories.stream().map(SocialCategory::getId).toList();
 			SOCIAL_BOARD = testFixtureBuilder.buildSocial(SINGLE_SOCIAL(USER, false));
+			testFixtureBuilder.buildSocialCategoryLinks(createdCategories.get(0), SOCIAL_BOARD);
+			testFixtureBuilder.buildSocialCategoryLinks(createdCategories.get(1), SOCIAL_BOARD);
 		}
 
-		// 여러 케이스를 위한 데이터 제공 메소드
 		static Stream<Arguments> provideUpdateRequests() {
 			return Stream.of(
-				Arguments.of(null, null, null, null),
-				Arguments.of(null, null, null, List.of()),
-				Arguments.of(null, null, null, List.of("updatedImage.jpg")),
-				Arguments.of(null, null, List.of(1L), null),
-				Arguments.of(null, null, List.of(1L), List.of("updatedIm age.jpg")),
-				Arguments.of(null, true, null, null),
-				Arguments.of(null, false, null, List.of("updatedIm age.jpg")),
-				Arguments.of(null, false, List.of(1L), null),
-				Arguments.of(null, false, List.of(1L), List.of("updatedImage.jpg")),
-				Arguments.of("Updated Content", null, null, null),
-				Arguments.of("Updated Content", null, null, List.of("updatedImage.jpg")),
-				Arguments.of("Updated Content", null, List.of(1L), null),
-				Arguments.of("Updated Content", null, List.of(1L), List.of("updatedImage.jpg")),
-				Arguments.of("Updated Content", true, null, null),
-				Arguments.of("Updated Content", true, null, List.of()),
-				Arguments.of("Updated Content", true, List.of(1L), null),
-				Arguments.of("Updated Content", true, List.of(1L), List.of("updatedImage.jpg"))
+				Arguments.of(null, null, CategoryUpdateScenario.NO_CHANGE, null),
+				Arguments.of(null, null, CategoryUpdateScenario.NO_CHANGE, List.of()),
+				Arguments.of(null, null, CategoryUpdateScenario.NO_CHANGE, List.of("updatedImage.jpg")),
+				Arguments.of(null, null, CategoryUpdateScenario.USE_SETUP_IDS, null),
+				Arguments.of(null, null, CategoryUpdateScenario.USE_SETUP_IDS, List.of("updatedIm age.jpg")),
+				Arguments.of(null, true, CategoryUpdateScenario.NO_CHANGE, null),
+				Arguments.of(null, false, CategoryUpdateScenario.NO_CHANGE, List.of("updatedIm age.jpg")),
+				Arguments.of(null, false, CategoryUpdateScenario.USE_SETUP_IDS, null),
+				Arguments.of(null, false, CategoryUpdateScenario.USE_SETUP_IDS, List.of("updatedImage.jpg")),
+				Arguments.of("Updated Content", null, CategoryUpdateScenario.NO_CHANGE, null),
+				Arguments.of("Updated Content", null, CategoryUpdateScenario.NO_CHANGE, List.of("updatedImage.jpg")),
+				Arguments.of("Updated Content", null, CategoryUpdateScenario.USE_SETUP_IDS, null),
+				Arguments.of("Updated Content", null, CategoryUpdateScenario.USE_SETUP_IDS,
+					List.of("updatedImage.jpg")),
+				Arguments.of("Updated Content", true, CategoryUpdateScenario.NO_CHANGE, null),
+				Arguments.of("Updated Content", true, CategoryUpdateScenario.NO_CHANGE, List.of()),
+				Arguments.of("Updated Content", true, CategoryUpdateScenario.USE_SETUP_IDS, null),
+				Arguments.of("Updated Content", true, CategoryUpdateScenario.USE_SETUP_IDS,
+					List.of("updatedImage.jpg")),
+				Arguments.of("Use Empty List", null, CategoryUpdateScenario.USE_EMPTY_LIST, null)
 			);
 		}
 
@@ -346,90 +358,79 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 		void 주어진_요청에_따라_게시글을_수정할_수_있다(
 			String updatedContent,
 			Boolean updatedIsAnonymous,
-			List<Long> updatedCategoryIds,
+			CategoryUpdateScenario categoryScenario,
 			List<String> updatedImageUrls
 		) {
-			// given
 			String originalContent = SOCIAL_BOARD.getContent();
 			Boolean originalIsAnonymous = SOCIAL_BOARD.getIsAnonymous();
 			List<SocialImageFile> originalImages = socialImageFileRepository.findAllBySocial(SOCIAL_BOARD);
-			List<SocialCategoryLink> originalCategories = socialCategoryLinkRepository.findAllBySocial(SOCIAL_BOARD);
+			List<Long> originalCategoryIds = socialCategoryLinkRepository.findAllBySocial(SOCIAL_BOARD)
+				.stream()
+				.map(link -> link.getSocialCategory().getId())
+				.toList();
+
+			List<Long> categoryIdsToUpdate = switch (categoryScenario) {
+				case USE_SETUP_IDS -> this.validCategoryIds;
+				case USE_EMPTY_LIST -> List.of();
+				default -> null;
+			};
 
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				true,
-				null,
+				true, null, true, null,
 				updatedContent,
 				updatedIsAnonymous,
-				updatedCategoryIds,
+				categoryIdsToUpdate,
 				updatedImageUrls
 			);
 
-			// when
+			if (categoryScenario == CategoryUpdateScenario.USE_EMPTY_LIST) {
+				assertThatThrownBy(
+					() -> socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_BOARD.getId(), updateRequest))
+					.isInstanceOf(CommonException.class)
+					.hasMessage(ExceptionCode.EMPTY_SOCIAL_CATEGORY_LIST.getMessage());
+				return;
+			}
+
 			socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_BOARD.getId(), updateRequest);
 
-			// then
 			Social updatedSocialBoard = socialRepository.findById(SOCIAL_BOARD.getId()).orElseThrow();
+
 			assertSoftly(softly -> {
-				if (updatedContent == null) {
-					softly.assertThat(updatedSocialBoard.getContent()).isEqualTo(originalContent);
-				} else {
-					softly.assertThat(updatedSocialBoard.getContent()).isEqualTo(updatedContent);
-				}
+				softly.assertThat(updatedSocialBoard.getContent())
+					.isEqualTo(updatedContent == null ? originalContent : updatedContent);
+				softly.assertThat(updatedSocialBoard.getIsAnonymous())
+					.isEqualTo(updatedIsAnonymous == null ? originalIsAnonymous : updatedIsAnonymous);
 
-				if (updatedIsAnonymous == null) {
-					softly.assertThat(updatedSocialBoard.getIsAnonymous()).isEqualTo(originalIsAnonymous);
-				} else {
-					softly.assertThat(updatedSocialBoard.getIsAnonymous()).isEqualTo(updatedIsAnonymous);
-				}
-
+				List<String> currentImageUrls = socialImageFileRepository.findAllBySocial(updatedSocialBoard)
+					.stream().map(SocialImageFile::getUrl).toList();
 				if (updatedImageUrls == null) {
-					softly.assertThat(socialImageFileRepository.findAllBySocial(updatedSocialBoard))
-						.hasSize(originalImages.size())
-						.extracting(SocialImageFile::getUrl)
-						.containsExactlyInAnyOrderElementsOf(
-							originalImages.stream().map(SocialImageFile::getUrl).toList()
-						);
+					List<String> originalImageUrls = originalImages.stream().map(SocialImageFile::getUrl).toList();
+					softly.assertThat(currentImageUrls)
+						.containsExactlyInAnyOrderElementsOf(originalImageUrls);
 				} else {
-					softly.assertThat(socialImageFileRepository.findAllBySocial(updatedSocialBoard))
-						.hasSize(updatedImageUrls.size())
-						.extracting(SocialImageFile::getUrl)
-						.containsAll(updatedImageUrls);
+					softly.assertThat(currentImageUrls)
+						.containsExactlyInAnyOrderElementsOf(updatedImageUrls);
 				}
 
-				if (updatedCategoryIds == null) {
-					softly.assertThat(socialCategoryLinkRepository.findAllBySocial(updatedSocialBoard))
-						.hasSize(originalCategories.size())
-						.extracting(link -> link.getSocialCategory().getId())
-						.containsExactlyInAnyOrderElementsOf(
-							originalCategories.stream().map(link -> link.getSocialCategory().getId()).toList()
-						);
+				List<Long> currentCategoryIds = socialCategoryLinkRepository.findAllBySocial(updatedSocialBoard)
+					.stream()
+					.map(link -> link.getSocialCategory().getId())
+					.toList();
+				if (categoryIdsToUpdate == null) {
+					softly.assertThat(currentCategoryIds).containsExactlyInAnyOrderElementsOf(originalCategoryIds);
 				} else {
-					softly.assertThat(socialCategoryLinkRepository.findAllBySocial(updatedSocialBoard))
-						.hasSize(updatedCategoryIds.size())
-						.extracting(link -> link.getSocialCategory().getId())
-						.containsAll(updatedCategoryIds);
+					softly.assertThat(currentCategoryIds).containsExactlyInAnyOrderElementsOf(categoryIdsToUpdate);
 				}
 			});
 		}
 
 		@Test
 		void 존재하지_않는_게시글을_수정하려고_하면_예외가_발생한다() {
-			// given
 			Long nonExistentSocialBoardId = -1L;
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				true,
-				null,
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				true, null, true, null,
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when & then
 			assertThatThrownBy(
 				() -> socialBoardUseCase.updateSocialBoard(USER.getId(), nonExistentSocialBoardId, updateRequest))
 				.isInstanceOf(CommonException.class)
@@ -438,20 +439,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void 존재하지_않거나_권한이_없는_루틴_ID인_경우_수정에_실패한다() {
-			// given
 			Long invalidRoutineId = -1L;
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				false,
-				invalidRoutineId,
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				true, null, false, invalidRoutineId,
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when & then
 			assertThatThrownBy(
 				() -> socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_BOARD.getId(), updateRequest))
 				.isInstanceOf(CommonException.class)
@@ -460,30 +452,18 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void isChangeRoutine이_true이고_routineId가_null인_경우_해당_게시글의_공유_루틴을_제거한다() {
-			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
 			Social SOCIAL_WITH_ROUTINE = testFixtureBuilder.buildSocial(
 				SINGLE_SOCIAL_WITH_ROUTINE(USER, ROUTINE, false)
 			);
-
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				true,
-				null,
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				true, null, true, null,
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when
 			socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_WITH_ROUTINE.getId(), updateRequest);
 
-			// then
 			Social socialBoard = socialRepository.findById(SOCIAL_WITH_ROUTINE.getId())
 				.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SOCIAL_BOARD));
-
 			assertSoftly(softly -> {
 				softly.assertThat(socialBoard.getContent()).isEqualTo(updateRequest.content());
 				softly.assertThat(socialBoard.getRoutine()).isNull();
@@ -493,48 +473,27 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void isChangeRoutine이_false이고_routineId가_null이_아닌_경우_validation에_실패한다() {
-			// given
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				false,
-				1L,
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				true, null, false, 1L,
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when & then
 			assertFalse(updateRequest.isValidRoutineIdWhenRemoved());
 		}
 
 		@Test
 		void isChangeRoutine이_false인_경우_해당_게시글의_공유_루틴을_변경하지_않는다() {
-			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutine(WEEKDAY_MORNING_ROUTINE(USER));
 			Social SOCIAL_WITH_ROUTINE = testFixtureBuilder.buildSocial(
 				SINGLE_SOCIAL_WITH_ROUTINE(USER, ROUTINE, false)
 			);
-
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				false,
-				null,
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				true, null, false, null,
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when
 			socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_WITH_ROUTINE.getId(), updateRequest);
 
-			// then
 			Social socialBoard = socialRepository.findById(SOCIAL_WITH_ROUTINE.getId())
 				.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SOCIAL_BOARD));
-
 			assertSoftly(softly -> {
 				softly.assertThat(socialBoard.getContent()).isEqualTo(updateRequest.content());
 				softly.assertThat(socialBoard.getRoutine().getId()).isEqualTo(ROUTINE.getId());
@@ -544,25 +503,14 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void isChangeTitle이_true이고_title이_유효한_경우_제목을_변경한다() {
-			// given
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				"새로운 제목",
-				false,
-				null,
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				true, "새로운 제목", false, null,
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when
 			socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_BOARD.getId(), updateRequest);
 
-			// then
 			Social socialBoard = socialRepository.findById(SOCIAL_BOARD.getId())
 				.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SOCIAL_BOARD));
-
 			assertSoftly(softly -> {
 				softly.assertThat(socialBoard.getTitle()).isEqualTo(updateRequest.title());
 				softly.assertThat(socialBoard.getContent()).isEqualTo(updateRequest.content());
@@ -572,25 +520,14 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void isChangeTitle이_false이고_title이_null인_경우_제목을_변경하지_않는다() {
-			// given
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				false,
-				null,
-				false,
-				null,
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				false, null, false, null,
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when
 			socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_BOARD.getId(), updateRequest);
 
-			// then
 			Social socialBoard = socialRepository.findById(SOCIAL_BOARD.getId())
 				.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_SOCIAL_BOARD));
-
 			assertSoftly(softly -> {
 				softly.assertThat(socialBoard.getTitle()).isEqualTo(SOCIAL_BOARD.getTitle());
 				softly.assertThat(socialBoard.getContent()).isEqualTo(updateRequest.content());
@@ -600,38 +537,20 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void isChangeTitle이_false이고_title이_null이_아닌_경우_validation에_실패한다() {
-			// given
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				false,
-				"제목이 없어야 합니다",
-				false,
-				null,
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				false, "제목이 없어야 합니다", false, null,
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when & then
 			assertFalse(updateRequest.isValidTitleWhenRemoved());
 		}
 
 		@Test
 		void 게시글_소유자가_아닌_경우_수정에_실패한다() {
-			// given
 			User ANOTHER_USER = testFixtureBuilder.buildUser(GENERAL_USER());
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				false,
-				null,
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				true, null, false, null,
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when & then
 			assertThatThrownBy(
 				() -> socialBoardUseCase.updateSocialBoard(ANOTHER_USER.getId(), SOCIAL_BOARD.getId(), updateRequest))
 				.isInstanceOf(CommonException.class)
@@ -640,19 +559,10 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void 유효하지_않은_카테고리_ID가_포함된_경우_수정에_실패한다() {
-			// given
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				false,
-				null,
-				updateContent,
-				isAnonymous,
-				invalidCategoryIds,
-				imageUrls
+				true, null, false, null,
+				updateContent, isAnonymous, invalidCategoryIds, imageUrls
 			);
-
-			// when & then
 			assertThatThrownBy(
 				() -> socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_BOARD.getId(), updateRequest))
 				.isInstanceOf(CommonException.class)
@@ -661,19 +571,10 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void 카테고리_ID_리스트가_빈_경우_수정에_실패한다() {
-			// given
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				false,
-				null,
-				updateContent,
-				isAnonymous,
-				List.of(),
-				imageUrls
+				true, null, false, null,
+				updateContent, isAnonymous, List.of(), imageUrls
 			);
-
-			// when & then
 			assertThatThrownBy(
 				() -> socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_BOARD.getId(), updateRequest))
 				.isInstanceOf(CommonException.class)
@@ -682,20 +583,11 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 
 		@Test
 		void 비공개_루틴으로_게시글_수정시_실패한다() {
-			// given
 			Routine PRIVATE_ROUTINE = testFixtureBuilder.buildRoutine(PRIVATE_ROUTINE(USER));
 			SocialUpdateRequest updateRequest = new SocialUpdateRequest(
-				true,
-				null,
-				false,
-				PRIVATE_ROUTINE.getId(),
-				updateContent,
-				isAnonymous,
-				validCategoryIds,
-				imageUrls
+				true, null, false, PRIVATE_ROUTINE.getId(),
+				updateContent, isAnonymous, validCategoryIds, imageUrls
 			);
-
-			// when & then
 			assertThatThrownBy(
 				() -> socialBoardUseCase.updateSocialBoard(USER.getId(), SOCIAL_BOARD.getId(), updateRequest))
 				.isInstanceOf(CommonException.class)
@@ -994,6 +886,19 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 	@Nested
 	@DisplayName("소셜 게시글 검색시")
 	class SearchSocials {
+
+		// 카테고리 필터 테스트를 위한 카테고리 미리 생성
+		List<SocialCategory> categories;
+		Long category1Id;
+		Long category2Id;
+
+		@BeforeEach
+		void setupCategories() {
+			categories = testFixtureBuilder.buildCategories(MULTIPLE_CATEGORIES(2));
+			category1Id = categories.get(0).getId();
+			category2Id = categories.get(1).getId();
+		}
+
 		@Test
 		void 키워드가_제목에_포함된_게시글을_조회한다() {
 			// given
@@ -1008,16 +913,19 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 			Integer limit = 10;
 
 			// when
+			// searchSocials 호출 시 마지막 인자로 null (또는 Collections.emptyList()) 추가
 			CursorPaginationResponse<SocialResponse> response = socialBoardUseCase.searchSocials(
 				USER.getId(),
 				keyword,
 				cursor,
-				limit
+				limit,
+				null
 			);
 
 			List<Long> expectedIds = socials.stream()
 				.filter(social -> social.getTitle() != null && social.getTitle().contains(keyword))
 				.map(Social::getId)
+				.sorted(Comparator.reverseOrder())
 				.toList();
 
 			// then
@@ -1025,7 +933,7 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 				softly.assertThat(response).isNotNull();
 				softly.assertThat(response.results())
 					.extracting(SocialResponse::socialId)
-					.containsExactlyInAnyOrderElementsOf(expectedIds);
+					.containsExactlyElementsOf(expectedIds); // 순서까지 검증
 			});
 		}
 
@@ -1047,20 +955,110 @@ public class SocialBoardUseCaseTest extends ServiceTest {
 				USER.getId(),
 				keyword,
 				cursor,
-				limit
+				limit,
+				null
 			);
 
 			// then
 			List<Long> expectedIds = socials.stream()
 				.filter(social -> social.getContent() != null && social.getContent().contains(keyword))
 				.map(Social::getId)
+				.sorted(Comparator.reverseOrder()) // ID 역순 정렬 추가 (Repository 정렬과 일치)
 				.toList();
 
 			assertSoftly(softly -> {
 				softly.assertThat(response).isNotNull();
 				softly.assertThat(response.results())
 					.extracting(SocialResponse::socialId)
-					.containsExactlyInAnyOrderElementsOf(expectedIds);
+					.containsExactlyElementsOf(expectedIds); // 순서까지 검증
+			});
+		}
+
+		@Test
+		void 키워드와_카테고리_필터를_함께_적용하여_게시글을_조회한다() {
+			// given
+			String keyword = "운동";
+
+			// 카테고리1에 속하고 키워드 포함 게시글 2개
+			Social social1_cat1 = testFixtureBuilder.buildSocial(SINGLE_SOCIAL_WITH_CONTENT(USER, "오늘의 운동 루틴"));
+			Social social2_cat1 = testFixtureBuilder.buildSocial(SINGLE_SOCIAL_WITH_CONTENT(USER, "운동 계획 중요"));
+			testFixtureBuilder.buildSocialCategoryLinks(categories.get(0), social1_cat1);
+			testFixtureBuilder.buildSocialCategoryLinks(categories.get(0), social2_cat1);
+
+			// 카테고리2에 속하고 키워드 포함 게시글 1개
+			Social social3_cat2 = testFixtureBuilder.buildSocial(SINGLE_SOCIAL_WITH_CONTENT(USER, "주말 운동 기록"));
+			testFixtureBuilder.buildSocialCategoryLinks(categories.get(1), social3_cat2);
+
+			// 카테고리1에 속하지만 키워드 미포함 게시글 1개
+			Social social4_cat1 = testFixtureBuilder.buildSocial(SINGLE_SOCIAL_WITH_CONTENT(USER, "독서 기록"));
+			testFixtureBuilder.buildSocialCategoryLinks(categories.get(0), social4_cat1);
+
+			Long cursor = null;
+			Integer limit = 10;
+			List<Long> filterCategoryIds = List.of(category1Id); // 카테고리1로 필터링
+
+			// when
+			CursorPaginationResponse<SocialResponse> response = socialBoardUseCase.searchSocials(
+				USER.getId(),
+				keyword,
+				cursor,
+				limit,
+				filterCategoryIds // 카테고리 필터 적용
+			);
+
+			List<Long> expectedIds = List.of(social2_cat1.getId(), social1_cat1.getId()); // ID 역순 정렬
+
+			assertSoftly(softly -> {
+				softly.assertThat(response).isNotNull();
+				softly.assertThat(response.results()).hasSize(2);
+				softly.assertThat(response.results())
+					.extracting(SocialResponse::socialId)
+					.containsExactlyElementsOf(expectedIds);
+			});
+		}
+
+		@Test
+		void 검색시_유효하지_않은_카테고리ID가_포함되면_예외가_발생한다() {
+			// given
+			String keyword = "테스트";
+			Long cursor = null;
+			Integer limit = 10;
+			List<Long> invalidCategoryIds = List.of(category1Id, -999L); // 유효하지 않은 ID 포함
+
+			// when & then
+			assertThatThrownBy(() -> socialBoardUseCase.searchSocials(
+				USER.getId(), keyword, cursor, limit, invalidCategoryIds))
+				.isInstanceOf(CommonException.class)
+				.hasMessage(ExceptionCode.NOT_FOUND_SOCIAL_CATEGORY.getMessage());
+		}
+
+		@Test
+		void 키워드와_카테고리가_모두_일치하는_게시글이_없으면_빈_결과를_반환한다() {
+			// given
+			String keyword = "존재하지않는키워드";
+
+			Social social1_cat1 = testFixtureBuilder.buildSocial(SINGLE_SOCIAL_WITH_CONTENT(USER, "오늘의 운동 루틴"));
+			testFixtureBuilder.buildSocialCategoryLinks(categories.get(0), social1_cat1);
+
+			Long cursor = null;
+			Integer limit = 10;
+			List<Long> filterCategoryIds = List.of(category1Id);
+
+			// when
+			CursorPaginationResponse<SocialResponse> response = socialBoardUseCase.searchSocials(
+				USER.getId(),
+				keyword,
+				cursor,
+				limit,
+				filterCategoryIds
+			);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(response).isNotNull();
+				softly.assertThat(response.results()).isEmpty();
+				softly.assertThat(response.hasMore()).isFalse();
+				softly.assertThat(response.nextCursor()).isNull();
 			});
 		}
 	}


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 게시글 검색 시 카테고리 필터 기능 추가**
- 사용자가 게시글을 검색할 때 특정 카테고리를 기준으로 필터링할 수 있는 기능 추가
  <br/>

**2️⃣ 카테고리 필터링 조건 변경 (AND 조건 적용)**
- 여러 카테고리를 동시에 필터링할 경우, 선택된 모든 카테고리를 만족하는 게시글만 조회되도록 수정
    * (기존 문제: `SLEEP`, `MEMORY` 필터 적용 시, 둘 중 하나의 카테고리만 포함된 게시글도 함께 조회되는 문제)

## ✅ 리뷰 요구사항
- 궁금한 점이 있으면 댓글 남겨주세요!

