### PR TITLE
루틴 공유 api 개발

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -32,6 +32,7 @@ CREATE TABLE routine
     is_public        BOOLEAN                                             NOT NULL,
     reminder_minutes INT UNSIGNED                                        NULL,
     memo             TEXT                                                NULL,
+    shared_count     INT UNSIGNED       DEFAULT 0                        NOT NULL,
     created_at       DATETIME                                            NOT NULL,
     updated_at       DATETIME                                            NOT NULL,
     deleted_at       DATETIME                                            NULL,

--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -126,13 +126,8 @@ public class RoutineMapper {
 			.map(RoutineMapper::toUserProfileRoutineRecordReadResponse)
 			.toList();
 
-		int totalSharedCount = routines.stream()
-			.mapToInt(Routine::getSharedCount)
-			.sum();
-
 		return UserProfileRoutineListResponse.builder()
 			.routines(routineResponses)
-			.totalSharedCount(totalSharedCount)
 			.build();
 	}
 

--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -126,8 +126,13 @@ public class RoutineMapper {
 			.map(RoutineMapper::toUserProfileRoutineRecordReadResponse)
 			.toList();
 
+		int totalSharedCount = routines.stream()
+			.mapToInt(Routine::getSharedCount)
+			.sum();
+
 		return UserProfileRoutineListResponse.builder()
 			.routines(routineResponses)
+			.totalSharedCount(totalSharedCount)
 			.build();
 	}
 
@@ -140,6 +145,7 @@ public class RoutineMapper {
 			.title(routine.getTitle())
 			.memo(routine.getMemoValue())
 			.time(routine.getTime())
+			.sharedCount(routine.getSharedCount())
 			.build();
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -76,4 +76,9 @@ public class RoutineService {
 	public void incrementSharedCountAtomically(final Routine sourceRoutine) {
 		routineRepository.incrementSharedCountAtomically(sourceRoutine.getId());
 	}
+
+	@Transactional(readOnly = true)
+	public int getTotalRoutineShareCount(final User user) {
+		return routineRepository.sumRoutineSharedCountByUser(user);
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -61,9 +61,19 @@ public class RoutineService {
 		return routineRepository.findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByTimeAsc(user);
 	}
 
+	@Transactional(readOnly = true)
+	public Optional<Routine> findAvailablePublicRoutineById(final Long routineId) {
+		return routineRepository.findByIdAndIsPublicTrueAndDeletedAtIsNull(routineId);
+	}
+
 	@Transactional
 	public void remove(final Routine routine) {
 		routine.delete();
 		routineRepository.save(routine);
+	}
+
+	@Transactional
+	public void incrementSharedCountAtomically(final Routine sourceRoutine) {
+		routineRepository.incrementSharedCountAtomically(sourceRoutine.getId());
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -113,4 +113,8 @@ public class Routine extends BaseEntity {
 	public Boolean isInDeletedState() {
 		return deletedAt != null;
 	}
+
+	public void increaseSharedCount() {
+		sharedCount++;
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -114,7 +114,4 @@ public class Routine extends BaseEntity {
 		return deletedAt != null;
 	}
 
-	public void increaseSharedCount() {
-		sharedCount++;
-	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -3,6 +3,8 @@ package im.toduck.domain.routine.persistence.entity;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import org.hibernate.annotations.ColumnDefault;
+
 import im.toduck.domain.person.persistence.entity.PlanCategory;
 import im.toduck.domain.routine.common.converter.DaysOfWeekBitmaskConverter;
 import im.toduck.domain.routine.persistence.vo.PlanCategoryColor;
@@ -64,6 +66,10 @@ public class Routine extends BaseEntity {
 	@Convert(converter = DaysOfWeekBitmaskConverter.class)
 	@Column(name = "days_of_week", nullable = false)
 	private DaysOfWeekBitmask daysOfWeekBitmask;
+
+	@Column(name = "shared_count", nullable = false)
+	@ColumnDefault("0")
+	private Integer sharedCount = 0;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import im.toduck.domain.routine.persistence.entity.Routine;
@@ -19,4 +22,10 @@ public interface RoutineRepository extends JpaRepository<Routine, Long>, Routine
 	List<Routine> findAllByUserAndIsPublicTrueAndDeletedAtIsNullOrderByTimeAsc(User user);
 
 	Optional<Routine> findByIdAndUserAndDeletedAtIsNull(Long id, User user);
+
+	Optional<Routine> findByIdAndIsPublicTrueAndDeletedAtIsNull(Long routineId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("UPDATE Routine r SET r.sharedCount = r.sharedCount + 1 WHERE r.id = :id")
+	void incrementSharedCountAtomically(@Param("id") Long id);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
@@ -28,4 +28,13 @@ public interface RoutineRepository extends JpaRepository<Routine, Long>, Routine
 	@Modifying(clearAutomatically = true)
 	@Query("UPDATE Routine r SET r.sharedCount = r.sharedCount + 1 WHERE r.id = :id")
 	void incrementSharedCountAtomically(@Param("id") Long id);
+
+	@Query(
+		"SELECT COALESCE(SUM(r.sharedCount), 0) "
+			+ "FROM Routine r "
+			+ "WHERE r.user = :user "
+			+ "AND r.isPublic = true "
+			+ "AND r.deletedAt IS NULL"
+	)
+	int sumRoutineSharedCountByUser(@Param("user") User user);
 }

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialProfileMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialProfileMapper.java
@@ -11,7 +11,8 @@ public class SocialProfileMapper {
 		final int followingCount,
 		final int followerCount,
 		final int postCount,
-		final boolean isMe
+		final boolean isMe,
+		final boolean isFollowing
 
 	) {
 		return SocialProfileResponse.builder()
@@ -20,6 +21,7 @@ public class SocialProfileMapper {
 			.followerCount(followerCount)
 			.postCount(postCount)
 			.isMe(isMe)
+			.isFollowing(isFollowing)
 			.build();
 	}
 }

--- a/src/main/java/im/toduck/domain/social/common/mapper/SocialProfileMapper.java
+++ b/src/main/java/im/toduck/domain/social/common/mapper/SocialProfileMapper.java
@@ -11,6 +11,7 @@ public class SocialProfileMapper {
 		final int followingCount,
 		final int followerCount,
 		final int postCount,
+		final int totalRoutineShareCount,
 		final boolean isMe,
 		final boolean isFollowing
 
@@ -20,6 +21,7 @@ public class SocialProfileMapper {
 			.followingCount(followingCount)
 			.followerCount(followerCount)
 			.postCount(postCount)
+			.totalRoutineShareCount(totalRoutineShareCount)
 			.isMe(isMe)
 			.isFollowing(isFollowing)
 			.build();

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
@@ -43,6 +43,8 @@ public class SocialProfileUseCase {
 
 	@Transactional(readOnly = true)
 	public SocialProfileResponse getUserProfile(final Long profileUserId, final Long authUserId) {
+		User authUser = userService.getUserById(authUserId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		User profileUser = userService.getUserById(profileUserId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
@@ -50,6 +52,7 @@ public class SocialProfileUseCase {
 		int followerCount = followService.countFollowers(profileUserId);
 		int postCount = socialBoardService.countSocialPostsByUserId(profileUserId);
 		boolean isMe = profileUserId.equals(authUserId);
+		boolean isFollowing = !isMe && followService.isFollowing(authUser, profileUser);
 
 		log.info("프로필 조회 - 요청자 UserId: {}, 대상 UserId: {}", authUserId, profileUserId);
 		return SocialProfileMapper.toSocialProfileResponse(
@@ -57,7 +60,8 @@ public class SocialProfileUseCase {
 			followingCount,
 			followerCount,
 			postCount,
-			isMe
+			isMe,
+			isFollowing
 		);
 	}
 

--- a/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
+++ b/src/main/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCase.java
@@ -51,6 +51,7 @@ public class SocialProfileUseCase {
 		int followingCount = followService.countFollowing(profileUserId);
 		int followerCount = followService.countFollowers(profileUserId);
 		int postCount = socialBoardService.countSocialPostsByUserId(profileUserId);
+		int totalRoutineShareCount = routineService.getTotalRoutineShareCount(profileUser);
 		boolean isMe = profileUserId.equals(authUserId);
 		boolean isFollowing = !isMe && followService.isFollowing(authUser, profileUser);
 
@@ -60,6 +61,7 @@ public class SocialProfileUseCase {
 			followingCount,
 			followerCount,
 			postCount,
+			totalRoutineShareCount,
 			isMe,
 			isFollowing
 		);

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
@@ -2,11 +2,13 @@ package im.toduck.domain.social.presentation.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineAvailableListResponse;
+import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialResponse;
 import im.toduck.domain.social.presentation.dto.response.UserProfileRoutineListResponse;
@@ -21,6 +23,7 @@ import im.toduck.global.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "Social Profile")
 public interface SocialProfileApi {
@@ -62,7 +65,6 @@ public interface SocialProfileApi {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_USER)
 		}
 	)
-	@GetMapping("/{userId}/socials")
 	ResponseEntity<ApiResponse<CursorPaginationResponse<SocialResponse>>> getUserSocials(
 		@Parameter(description = "게시글을 조회할 유저 ID") @PathVariable Long userId,
 		@AuthenticationPrincipal CustomUserDetails authUser,
@@ -83,9 +85,31 @@ public interface SocialProfileApi {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_USER)
 		}
 	)
-	@GetMapping("/{userId}/routines")
 	ResponseEntity<ApiResponse<UserProfileRoutineListResponse>> getUserProfileRoutines(
 		@Parameter(description = "루틴 목록을 조회할 유저 ID") @PathVariable Long userId,
 		@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails authUser
+	);
+
+	@Operation(
+		summary = "루틴 저장 (공유 루틴 추가)",
+		description = """
+			<b>다른 사용자의 공개된 루틴을 내 목록으로 저장(공유)합니다.</b><br/><br/>
+			<p>다른 사용자의 프로필 등에서 발견한 유용한 루틴을 자신의 루틴 목록에 추가(저장)할 때 사용됩니다.</p><br/>
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "루틴 저장 성공. 응답 본문은 없습니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_ROUTINE),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.PRIVATE_ROUTINE),
+		}
+	)
+	ResponseEntity<ApiResponse<RoutineCreateResponse>> saveSharedRoutine(
+		@Parameter(description = "저장할 루틴의 ID", required = true, example = "1")
+		@PathVariable final Long routineId,
+		@Parameter(hidden = true) @AuthenticationPrincipal final CustomUserDetails authUser,
+		@RequestBody @Valid final RoutineCreateRequest request
 	);
 }

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
@@ -99,7 +99,7 @@ public interface SocialProfileApi {
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
-			description = "루틴 저장 성공. 응답 본문은 없습니다."
+			description = "루틴 저장 성공. 생성된 루틴의 Id를 반환합니다."
 		),
 		errors = {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_ROUTINE),

--- a/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
+++ b/src/main/java/im/toduck/domain/social/presentation/controller/SocialProfileController.java
@@ -5,10 +5,14 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
+import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.social.domain.usecase.SocialProfileUseCase;
 import im.toduck.domain.social.presentation.api.SocialProfileApi;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
@@ -66,5 +70,18 @@ public class SocialProfileController implements SocialProfileApi {
 			authUser.getUserId()
 		);
 		return ResponseEntity.ok(ApiResponse.createSuccess(response));
+	}
+
+	@Override
+	@PostMapping("/shared-routines/{routineId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<RoutineCreateResponse>> saveSharedRoutine(
+		@PathVariable Long routineId,
+		@AuthenticationPrincipal CustomUserDetails authUser,
+		@RequestBody RoutineCreateRequest request
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.createSuccess(socialProfileUseCase.saveSharedRoutine(authUser.getUserId(), routineId, request))
+		);
 	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/request/ReportCreateRequest.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/request/ReportCreateRequest.java
@@ -20,7 +20,7 @@ public record ReportCreateRequest(
 ) {
 
 	@AssertTrue(message = "신고 유형이 'OTHER'일 때 사유는 필수 입력 항목입니다.")
-	public boolean isReasonRequiredForOtherType() {
+	private boolean isReasonRequiredForOtherType() {
 		if (reportType == ReportType.OTHER) {
 			return reason != null && !reason.isBlank();
 		}
@@ -28,7 +28,7 @@ public record ReportCreateRequest(
 	}
 
 	@AssertTrue(message = "신고 유형이 'OTHER'가 아닌 경우 사유는 입력할 수 없습니다.")
-	public boolean isReasonNotAllowedForNonOtherType() {
+	private boolean isReasonNotAllowedForNonOtherType() {
 		if (reportType != ReportType.OTHER) {
 			return reason == null || reason.isBlank();
 		}

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
@@ -21,6 +21,9 @@ public record SocialProfileResponse(
 	int postCount,
 
 	@Schema(description = "현재 사용자의 프로필인지 여부", example = "false")
-	boolean isMe
+	boolean isMe,
+
+	@Schema(description = "팔로잉 여부", example = "true")
+	boolean isFollowing
 ) {
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/SocialProfileResponse.java
@@ -20,6 +20,9 @@ public record SocialProfileResponse(
 	@Schema(description = "게시물 수", example = "315")
 	int postCount,
 
+	@Schema(description = "총 루틴 공유 수", example = "1304")
+	int totalRoutineShareCount,
+
 	@Schema(description = "현재 사용자의 프로필인지 여부", example = "false")
 	boolean isMe,
 

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
@@ -15,7 +15,10 @@ import lombok.Builder;
 @Builder
 public record UserProfileRoutineListResponse(
 	@Schema(description = "루틴 목록")
-	List<UserProfileRoutineResponse> routines
+	List<UserProfileRoutineResponse> routines,
+
+	@Schema(description = "루틴 공유 수 총합", example = "1304")
+	int totalSharedCount
 ) {
 	@Schema(description = "사용자 프로필 루틴 목록 내부 DTO")
 	@Builder
@@ -31,6 +34,9 @@ public record UserProfileRoutineListResponse(
 
 		@Schema(description = "루틴 메모", example = "눈 뜨자마자 한 잔")
 		String memo,
+
+		@Schema(description = "루틴 공유 수", example = "455")
+		int sharedCount,
 
 		@JsonSerialize(using = LocalTimeSerializer.class)
 		@JsonFormat(pattern = "HH:mm")

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
@@ -15,10 +15,7 @@ import lombok.Builder;
 @Builder
 public record UserProfileRoutineListResponse(
 	@Schema(description = "루틴 목록")
-	List<UserProfileRoutineResponse> routines,
-
-	@Schema(description = "루틴 공유 수 총합", example = "1304")
-	int totalSharedCount
+	List<UserProfileRoutineResponse> routines
 ) {
 	@Schema(description = "사용자 프로필 루틴 목록 내부 DTO")
 	@Builder

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
@@ -286,7 +286,6 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 			// given
 			int routineCount = 3;
 			List<Routine> routines = new ArrayList<>();
-			final int[] totalSharedCountArray = {0};
 
 			// 리플렉션을 이용한 필드 값 변경
 			Field sharedCountField = Routine.class.getDeclaredField("sharedCount");
@@ -301,13 +300,10 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 				entityManager.merge(routine);
 				entityManager.flush();
 
-				totalSharedCountArray[0] += sharedCount;
 				routines.add(routine);
 			}
 
 			entityManager.clear();
-
-			final int expectedTotalSharedCount = totalSharedCountArray[0];
 
 			// when
 			UserProfileRoutineListResponse response = socialProfileUseCase.readUserAvailableRoutines(
@@ -319,7 +315,6 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 			assertSoftly(softly -> {
 				softly.assertThat(response).isNotNull();
 				softly.assertThat(response.routines()).hasSize(routineCount);
-				softly.assertThat(response.totalSharedCount()).isEqualTo(expectedTotalSharedCount);
 
 				final Map<Long, Integer> routineIdToSharedCount = new HashMap<>();
 				for (int i = 0; i < routineCount; i++) {
@@ -335,7 +330,7 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 		}
 
 		@Test
-		void 루틴이_없는_경우_빈_목록을_반환하며_총_공유수는_0이다() {
+		void 루틴이_없는_경우_빈_목록을_반환한다() {
 			// when
 			UserProfileRoutineListResponse response = socialProfileUseCase.readUserAvailableRoutines(
 				PROFILE_USER.getId(),
@@ -346,7 +341,6 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 			assertSoftly(softly -> {
 				softly.assertThat(response).isNotNull();
 				softly.assertThat(response.routines()).isEmpty();
-				softly.assertThat(response.totalSharedCount()).isZero();
 			});
 		}
 

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
@@ -400,7 +400,7 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 		}
 
 		@Test
-		void 저장하는_사용자를_찾지_못하면_예외를_던진다() {
+		void 저장하는_사용자를_찾지_못하면_루틴_저장에_실패한다() {
 			// given
 			Long nonExistentUserId = -1L;
 			Long sourceRoutineId = SOURCE_ROUTINE_IS_PUBLIC.getId();
@@ -413,7 +413,7 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 		}
 
 		@Test
-		void 원본_루틴을_찾지_못하면_예외를_던진다() {
+		void 원본_루틴을_찾지_못하면_루틴_저장에_실패한다() {
 			// given
 			Long nonExistentRoutineId = -99L;
 
@@ -425,7 +425,7 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 		}
 
 		@Test
-		void 원본_루틴이_비공개이면_예외를_던진다() {
+		void 원본_루틴이_비공개이면_루틴_저장에_실패한다() {
 			// when & then
 			assertThatThrownBy(
 				() -> socialProfileUseCase.saveSharedRoutine(SOURCE_ROUTINE_IS_PRIVATE.getId(), AUTH_USER.getId(),

--- a/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/social/domain/usecase/SocialProfileUseCaseTest.java
@@ -1,12 +1,15 @@
 package im.toduck.domain.social.domain.usecase;
 
 import static im.toduck.fixtures.RoutineFixtures.*;
+import static im.toduck.fixtures.RoutineFixtures.PRIVATE_ROUTINE;
 import static im.toduck.fixtures.social.SocialFixtures.*;
 import static im.toduck.fixtures.user.UserFixtures.*;
 import static im.toduck.global.exception.ExceptionCode.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +20,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import im.toduck.ServiceTest;
+import im.toduck.domain.person.persistence.entity.PlanCategory;
 import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.repository.RoutineRepository;
+import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
+import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialResponse;
@@ -30,6 +37,9 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 
 	@Autowired
 	private SocialProfileUseCase socialProfileUseCase;
+
+	@Autowired
+	private RoutineRepository routineRepository;
 
 	private User PROFILE_USER;
 	private User AUTH_USER;
@@ -275,6 +285,89 @@ public class SocialProfileUseCaseTest extends ServiceTest {
 				softly.assertThat(response).isNotNull();
 				softly.assertThat(response.routines()).isEmpty();
 			});
+		}
+	}
+
+	@Nested
+	class SaveSharedRoutineTests {
+		private RoutineCreateRequest request;
+		private Routine SOURCE_ROUTINE_IS_PUBLIC;
+		private Routine SOURCE_ROUTINE_IS_PRIVATE;
+
+		@BeforeEach
+		void setUp() {
+			request = new RoutineCreateRequest(
+				"Morning Exercise",
+				PlanCategory.COMPUTER,
+				"#FF5733",
+				LocalTime.of(7, 0),
+				true,
+				List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY),
+				30,
+				"30 minutes jogging"
+			);
+
+			SOURCE_ROUTINE_IS_PUBLIC = testFixtureBuilder.buildRoutine(WEEKEND_NOON_ROUTINE(PROFILE_USER));
+			SOURCE_ROUTINE_IS_PRIVATE = testFixtureBuilder.buildRoutine(PRIVATE_ROUTINE(PROFILE_USER));
+		}
+
+		@Test
+		void 공유_루틴_저장을_성공한다() {
+			// given
+			int initialSharedCount = SOURCE_ROUTINE_IS_PUBLIC.getSharedCount();
+
+			// when
+			RoutineCreateResponse response = socialProfileUseCase.saveSharedRoutine(
+				AUTH_USER.getId(),
+				SOURCE_ROUTINE_IS_PUBLIC.getId(),
+				request
+			);
+
+			// then
+			assertThat(response.routineId()).isNotNull();
+
+			Routine newlyCreatedRoutine = routineRepository.findById(response.routineId()).orElseThrow();
+			assertThat(newlyCreatedRoutine.getUser().getId()).isEqualTo(AUTH_USER.getId());
+			assertThat(newlyCreatedRoutine.getSharedCount()).isZero();
+
+			Routine updatedSourceRoutine = routineRepository.findById(SOURCE_ROUTINE_IS_PUBLIC.getId()).orElseThrow();
+
+			assertThat(updatedSourceRoutine.getSharedCount()).isEqualTo(initialSharedCount + 1);
+		}
+
+		@Test
+		void 저장하는_사용자를_찾지_못하면_예외를_던진다() {
+			// given
+			Long nonExistentUserId = -1L;
+			Long sourceRoutineId = SOURCE_ROUTINE_IS_PUBLIC.getId();
+
+			// when & then
+			assertThatThrownBy(
+				() -> socialProfileUseCase.saveSharedRoutine(nonExistentUserId, sourceRoutineId, request))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(NOT_FOUND_USER.getMessage());
+		}
+
+		@Test
+		void 원본_루틴을_찾지_못하면_예외를_던진다() {
+			// given
+			Long nonExistentRoutineId = -99L;
+
+			// when & then
+			assertThatThrownBy(
+				() -> socialProfileUseCase.saveSharedRoutine(AUTH_USER.getId(), nonExistentRoutineId, request))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(NOT_FOUND_ROUTINE.getMessage());
+		}
+
+		@Test
+		void 원본_루틴이_비공개이면_예외를_던진다() {
+			// when & then
+			assertThatThrownBy(
+				() -> socialProfileUseCase.saveSharedRoutine(SOURCE_ROUTINE_IS_PRIVATE.getId(), AUTH_USER.getId(),
+					request))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(NOT_FOUND_ROUTINE.getMessage());
 		}
 	}
 }


### PR DESCRIPTION
## ✨ 작업 내용


**1️⃣ 루틴 공유 횟수 필드 추가**
```SQL
CREATE TABLE routine
(
    ...
    shared_count     INT UNSIGNED       DEFAULT 0                        NOT NULL,
    ...
);
```

  <br/>

**2️⃣ 루틴 공유 API 개발**
- 사진에서 보여지는 버튼을 통해 공개 되어진 루틴을 저장 
    - 사진에서 보여지는 것처럼 내용, 시간, 반복, 공개 여부, 메모 등은 모두 수정 가능하므로 원본 루틴의 값을 사용해 새로운 루틴을 만들지 않고, `RoutineCreateRequest` 로 값을 받아 생성한 후 원본 루틴의 공유 횟수만 증가하도록 했습니다!

![스크린샷 2025-04-04 오후 5 19 35](https://github.com/user-attachments/assets/3e0d3e4c-7a51-4bbf-b447-43059262fa0c)

  <br/>

**3️⃣ 소셜 프로필의 공개 루틴 조회시 루틴 공유 수 필드 추가**
```JAVA
public record UserProfileRoutineListResponse(
	... 
	@Schema(description = "루틴 공유 수 총합", example = "1304")
	int totalSharedCount
) {
	public record UserProfileRoutineResponse(
		... 
		@Schema(description = "루틴 공유 수", example = "455")
		int sharedCount,
                 ... 
	) {
	}
}

```

## ✅ 리뷰 요구사항
- 궁금한 점이 있다면 댓글 남겨주세요!
- 게시글 신고 dto 검증 필드 관련, 소셜 프로필 팔로우 여부 살짝 끼워넣기 했습니다..ㅎ 
