### PR TITLE
월별 일기 조회 API 응답 구조 변경

### DIFF
--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -47,7 +47,7 @@ public class DiaryMapper {
 	}
 
 	public static DiaryListResponse toListDiaryResponse(List<DiaryResponse> diaries) {
-		return new DiaryListResponse(diaries);
+		return DiaryListResponse.toListDiaryResponse(diaries);
 	}
 
 	public static MonthDiaryResponse toMonthDiaryResponse(int thisMonthCount, int lastMonthCount) {

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -1,8 +1,11 @@
 package im.toduck.domain.diary.common.mapper;
 
+import java.util.List;
+
 import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.diary.presentation.dto.response.DiaryListResponse;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.domain.diary.presentation.dto.response.MonthDiaryResponse;
 import im.toduck.domain.user.persistence.entity.User;
@@ -41,6 +44,10 @@ public class DiaryMapper {
 				.map(DiaryImageFileMapper::fromDiaryImage)
 				.toList()
 		);
+	}
+
+	public static DiaryListResponse toListDiaryResponse(List<DiaryResponse> diaries) {
+		return new DiaryListResponse(diaries);
 	}
 
 	public static MonthDiaryResponse toMonthDiaryResponse(int thisMonthCount, int lastMonthCount) {

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -11,6 +11,7 @@ import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
+import im.toduck.domain.diary.presentation.dto.response.DiaryListResponse;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.domain.diary.presentation.dto.response.MonthDiaryResponse;
 import im.toduck.domain.user.domain.service.UserService;
@@ -85,10 +86,11 @@ public class DiaryUseCase {
 	}
 
 	@Transactional(readOnly = true)
-	public List<DiaryResponse> getDiariesByMonth(final Long userId, final int year, final int month) {
+	public DiaryListResponse getDiariesByMonth(final Long userId, final int year, final int month) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-		return diaryService.getDiariesByMonth(userId, year, month);
+		List<DiaryResponse> diaries = diaryService.getDiariesByMonth(userId, year, month);
+		return DiaryListResponse.from(diaries);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryUseCase.java
@@ -90,7 +90,7 @@ public class DiaryUseCase {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 		List<DiaryResponse> diaries = diaryService.getDiariesByMonth(userId, year, month);
-		return DiaryListResponse.from(diaries);
+		return DiaryMapper.toListDiaryResponse(diaries);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryApi.java
@@ -1,6 +1,5 @@
 package im.toduck.domain.diary.presentation.api;
 
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
@@ -12,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
-import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
+import im.toduck.domain.diary.presentation.dto.response.DiaryListResponse;
 import im.toduck.domain.diary.presentation.dto.response.MonthDiaryResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
@@ -124,11 +123,11 @@ public interface DiaryApi {
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
-			responseClass = DiaryResponse.class,
+			responseClass = DiaryListResponse.class,
 			description = "일기 조회 성공, 해당 연월에 작성된 일기들을 반환합니다."
 		)
 	)
-	ResponseEntity<ApiResponse<List<DiaryResponse>>> getDiariesByMonth(
+	ResponseEntity<ApiResponse<DiaryListResponse>> getDiariesByMonth(
 		@RequestParam("year") int year,
 		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryController.java
@@ -1,6 +1,5 @@
 package im.toduck.domain.diary.presentation.controller;
 
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
@@ -21,7 +20,7 @@ import im.toduck.domain.diary.presentation.api.DiaryApi;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryCreateResponse;
-import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
+import im.toduck.domain.diary.presentation.dto.response.DiaryListResponse;
 import im.toduck.domain.diary.presentation.dto.response.MonthDiaryResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
@@ -75,13 +74,14 @@ public class DiaryController implements DiaryApi {
 	@Override
 	@GetMapping
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<List<DiaryResponse>>> getDiariesByMonth(
+	public ResponseEntity<ApiResponse<DiaryListResponse>> getDiariesByMonth(
 		@RequestParam("year") int year,
 		@RequestParam("month") int month,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
-		List<DiaryResponse> diaries = diaryUseCase.getDiariesByMonth(user.getUserId(), year, month);
-		return ResponseEntity.ok(ApiResponse.createSuccess(diaries));
+		DiaryListResponse response = diaryUseCase.getDiariesByMonth(user.getUserId(), year, month);
+
+		return ResponseEntity.ok(ApiResponse.createSuccess(response));
 	}
 
 	@GetMapping("/count")
@@ -93,6 +93,7 @@ public class DiaryController implements DiaryApi {
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
 		MonthDiaryResponse monthDiaryCount = diaryUseCase.getDiaryCountByMonth(user.getUserId(), year, month);
+
 		return ResponseEntity.ok()
 			.body(ApiResponse.createSuccess(monthDiaryCount));
 	}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryListResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryListResponse.java
@@ -3,11 +3,18 @@ package im.toduck.domain.diary.presentation.dto.response;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
 @Schema(description = "월별 일기 목록 응답")
+@Builder
 public record DiaryListResponse(
 	@Schema(description = "일기 목록")
 	List<DiaryResponse> diaryDtos
 ) {
+	public static DiaryListResponse toListDiaryResponse(List<DiaryResponse> diaries) {
+		return DiaryListResponse.builder()
+			.diaryDtos(diaries)
+			.build();
+	}
 }
 

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryListResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryListResponse.java
@@ -1,0 +1,16 @@
+package im.toduck.domain.diary.presentation.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "월별 일기 목록 응답")
+public record DiaryListResponse(
+	@Schema(description = "일기 목록")
+	List<DiaryResponse> diaryDtos
+) {
+	public static DiaryListResponse from(List<DiaryResponse> diaries) {
+		return new DiaryListResponse(diaries);
+	}
+}
+

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryListResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryListResponse.java
@@ -9,8 +9,5 @@ public record DiaryListResponse(
 	@Schema(description = "일기 목록")
 	List<DiaryResponse> diaryDtos
 ) {
-	public static DiaryListResponse from(List<DiaryResponse> diaries) {
-		return new DiaryListResponse(diaries);
-	}
 }
 


### PR DESCRIPTION
## ✨ 작업 내용

> Diary Response를 List에 담아서 반환하도록 수정했습니다.

**1️⃣ 작업내용1**

- 설명1
  <br/>

**2️⃣ 작업내용2**

- 설명1
  <br/>

**3️⃣ 작업내용3**

- 설명1
  <br/>

## ✅ 리뷰 요구사항(선택)

> 해당 안내는 지워주세요.
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.  
> 작성하지 않는다면 항목을 지워주세요.  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
