### PR TITLE
특정 연월의 집중 평균 조회 API와 수정사항

### DIFF
--- a/src/main/java/im/toduck/domain/concentration/common/mapper/ConcentrationMapper.java
+++ b/src/main/java/im/toduck/domain/concentration/common/mapper/ConcentrationMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import im.toduck.domain.concentration.persistence.entity.Concentration;
 import im.toduck.domain.concentration.presentation.dto.request.ConcentrationRequest;
 import im.toduck.domain.concentration.presentation.dto.response.ConcentrationListResponse;
+import im.toduck.domain.concentration.presentation.dto.response.ConcentrationPercentResponse;
 import im.toduck.domain.concentration.presentation.dto.response.ConcentrationResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.AccessLevel;
@@ -36,5 +37,11 @@ public class ConcentrationMapper {
 
 	public static ConcentrationListResponse toListConcentrationResponse(List<ConcentrationResponse> concentrations) {
 		return ConcentrationListResponse.from(concentrations);
+	}
+
+	public static ConcentrationPercentResponse toConcentrationPercentResponse(int percent) {
+		return ConcentrationPercentResponse.builder()
+			.percent(percent)
+			.build();
 	}
 }

--- a/src/main/java/im/toduck/domain/concentration/domain/service/ConcentrationService.java
+++ b/src/main/java/im/toduck/domain/concentration/domain/service/ConcentrationService.java
@@ -40,4 +40,14 @@ public class ConcentrationService {
 
 		return concentrationRepository.findByUserAndDateBetween(user, startDate, endDate);
 	}
+
+	public int getMonthConcentrationPercent(Long userId, YearMonth yearMonth) {
+		Integer totalPercentage = concentrationRepository.getAverageConcentrationPercentageByMonth(userId, yearMonth);
+
+		if (totalPercentage == null) {
+			return 0;
+		}
+
+		return totalPercentage;
+	}
 }

--- a/src/main/java/im/toduck/domain/concentration/domain/service/ConcentrationService.java
+++ b/src/main/java/im/toduck/domain/concentration/domain/service/ConcentrationService.java
@@ -1,6 +1,7 @@
 package im.toduck.domain.concentration.domain.service;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -33,9 +34,9 @@ public class ConcentrationService {
 	}
 
 	@Transactional
-	public List<Concentration> getMonthlyConcentration(User user, String yearMonth) {
-		LocalDate startDate = LocalDate.parse(yearMonth + "-01");
-		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+	public List<Concentration> getMonthlyConcentration(User user, YearMonth yearMonth) {
+		LocalDate startDate = yearMonth.atDay(1);
+		LocalDate endDate = yearMonth.atEndOfMonth();
 
 		return concentrationRepository.findByUserAndDateBetween(user, startDate, endDate);
 	}

--- a/src/main/java/im/toduck/domain/concentration/domain/usecase/ConcentrationUseCase.java
+++ b/src/main/java/im/toduck/domain/concentration/domain/usecase/ConcentrationUseCase.java
@@ -8,6 +8,7 @@ import im.toduck.domain.concentration.domain.service.ConcentrationService;
 import im.toduck.domain.concentration.persistence.entity.Concentration;
 import im.toduck.domain.concentration.presentation.dto.request.ConcentrationRequest;
 import im.toduck.domain.concentration.presentation.dto.response.ConcentrationListResponse;
+import im.toduck.domain.concentration.presentation.dto.response.ConcentrationPercentResponse;
 import im.toduck.domain.concentration.presentation.dto.response.ConcentrationResponse;
 import im.toduck.domain.concentration.presentation.dto.response.ConcentrationSaveResponse;
 import im.toduck.domain.user.domain.service.UserService;
@@ -49,5 +50,14 @@ public class ConcentrationUseCase {
 			.toList();
 
 		return ConcentrationMapper.toListConcentrationResponse(dtos);
+	}
+
+	public ConcentrationPercentResponse getMonthConcentrationPercent(Long userId, YearMonth yearMonth) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		int percent = concentrationService.getMonthConcentrationPercent(userId, yearMonth);
+
+		return ConcentrationMapper.toConcentrationPercentResponse(percent);
 	}
 }

--- a/src/main/java/im/toduck/domain/concentration/domain/usecase/ConcentrationUseCase.java
+++ b/src/main/java/im/toduck/domain/concentration/domain/usecase/ConcentrationUseCase.java
@@ -1,5 +1,6 @@
 package im.toduck.domain.concentration.domain.usecase;
 
+import java.time.YearMonth;
 import java.util.List;
 
 import im.toduck.domain.concentration.common.mapper.ConcentrationMapper;
@@ -37,7 +38,7 @@ public class ConcentrationUseCase {
 	}
 
 	@Transactional
-	public ConcentrationListResponse getMonthlyConcentration(Long userId, String yearMonth) {
+	public ConcentrationListResponse getMonthlyConcentration(Long userId, YearMonth yearMonth) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 

--- a/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepository.java
+++ b/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepository.java
@@ -1,27 +1,18 @@
 package im.toduck.domain.concentration.persistence.repository;
 
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import im.toduck.domain.concentration.persistence.entity.Concentration;
 import im.toduck.domain.user.persistence.entity.User;
 
 @Repository
-public interface ConcentrationRepository extends JpaRepository<Concentration, Long> {
+public interface ConcentrationRepository extends JpaRepository<Concentration, Long>, ConcentrationRepositoryCustom {
 	Optional<Concentration> findByUserAndDate(User user, LocalDate date);
 
 	List<Concentration> findByUserAndDateBetween(User user, LocalDate startDate, LocalDate endDate);
-
-	@Query("SELECT AVG(c.targetCount * 100 / c.settingCount) "
-		+ "FROM Concentration c "
-		+ "WHERE c.user.id = :userId "
-		+ "AND FUNCTION('YEAR', c.date) = :#{#yearMonth.getYear()} "
-		+ "AND FUNCTION('MONTH', c.date) = :#{#yearMonth.getMonthValue()}")
-	Integer getAverageConcentrationPercentageByMonth(Long userId, YearMonth yearMonth);
 }

--- a/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepository.java
+++ b/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepository.java
@@ -1,10 +1,12 @@
 package im.toduck.domain.concentration.persistence.repository;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import im.toduck.domain.concentration.persistence.entity.Concentration;
@@ -15,4 +17,11 @@ public interface ConcentrationRepository extends JpaRepository<Concentration, Lo
 	Optional<Concentration> findByUserAndDate(User user, LocalDate date);
 
 	List<Concentration> findByUserAndDateBetween(User user, LocalDate startDate, LocalDate endDate);
+
+	@Query("SELECT AVG(c.targetCount * 100 / c.settingCount) "
+		+ "FROM Concentration c "
+		+ "WHERE c.user.id = :userId "
+		+ "AND FUNCTION('YEAR', c.date) = :#{#yearMonth.getYear()} "
+		+ "AND FUNCTION('MONTH', c.date) = :#{#yearMonth.getMonthValue()}")
+	Integer getAverageConcentrationPercentageByMonth(Long userId, YearMonth yearMonth);
 }

--- a/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepositoryCustom.java
@@ -1,0 +1,7 @@
+package im.toduck.domain.concentration.persistence.repository;
+
+import java.time.YearMonth;
+
+public interface ConcentrationRepositoryCustom {
+	Integer getAverageConcentrationPercentageByMonth(Long userId, YearMonth yearMonth);
+}

--- a/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepositoryCustomImpl.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class ConcentrationRepositoryImpl implements ConcentrationRepositoryCustom {
+public class ConcentrationRepositoryCustomImpl implements ConcentrationRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepositoryImpl.java
+++ b/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepositoryImpl.java
@@ -1,0 +1,34 @@
+package im.toduck.domain.concentration.persistence.repository;
+
+import java.time.YearMonth;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import im.toduck.domain.concentration.persistence.entity.QConcentration;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ConcentrationRepositoryImpl implements ConcentrationRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Integer getAverageConcentrationPercentageByMonth(Long userId, YearMonth yearMonth) {
+		QConcentration concentration = QConcentration.concentration;
+
+		Double avgPercentage = queryFactory
+			.select(concentration.targetCount.multiply(100).divide(concentration.settingCount).avg())
+			.from(concentration)
+			.where(
+				concentration.user.id.eq(userId),
+				concentration.date.year().eq(yearMonth.getYear()),
+				concentration.date.month().eq(yearMonth.getMonthValue())
+			)
+			.fetchOne();
+
+		return avgPercentage != null ? avgPercentage.intValue() : null;
+	}
+}

--- a/src/main/java/im/toduck/domain/concentration/presentation/api/ConcentrationApi.java
+++ b/src/main/java/im/toduck/domain/concentration/presentation/api/ConcentrationApi.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import im.toduck.domain.concentration.presentation.dto.request.ConcentrationRequest;
 import im.toduck.domain.concentration.presentation.dto.response.ConcentrationListResponse;
+import im.toduck.domain.concentration.presentation.dto.response.ConcentrationPercentResponse;
 import im.toduck.domain.concentration.presentation.dto.response.ConcentrationSaveResponse;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -63,6 +64,25 @@ public interface ConcentrationApi {
 		)
 	)
 	ResponseEntity<ApiResponse<ConcentrationListResponse>> getMonthlyConcentration(
+		@RequestParam YearMonth yearMonth,
+		@AuthenticationPrincipal CustomUserDetails user
+	);
+
+	@Operation(
+		summary = "특정 연월 집중도 평균 조회",
+		description = """
+			특정 연월의 집중도 평균 값을 조회합니다.
+			- 평균 값을 계산하여 반환합니다.
+			- 조회를 원하는 연월을(yyyy-MM) /v1/concentration/percent 엔드포인트에 yearMonth 파라미터로 요청합니다.
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = ConcentrationPercentResponse.class,
+			description = "조회 성공, 해당 연월의 집중도 평균 값을 반환합니다."
+		)
+	)
+	ResponseEntity<ApiResponse<ConcentrationPercentResponse>> getMonthConcentrationPercent(
 		@RequestParam YearMonth yearMonth,
 		@AuthenticationPrincipal CustomUserDetails user
 	);

--- a/src/main/java/im/toduck/domain/concentration/presentation/api/ConcentrationApi.java
+++ b/src/main/java/im/toduck/domain/concentration/presentation/api/ConcentrationApi.java
@@ -1,5 +1,7 @@
 package im.toduck.domain.concentration.presentation.api;
 
+import java.time.YearMonth;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,7 +17,6 @@ import im.toduck.global.security.authentication.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
 
 @Tag(name = "Concentration")
 public interface ConcentrationApi {
@@ -62,9 +63,7 @@ public interface ConcentrationApi {
 		)
 	)
 	ResponseEntity<ApiResponse<ConcentrationListResponse>> getMonthlyConcentration(
-		@RequestParam("yearMonth")
-		@Pattern(regexp = "\\d{4}-\\d{2}", message = "yyyy-MM 형식으로 입력해야 합니다.")
-		String yearMonth,
+		@RequestParam YearMonth yearMonth,
 		@AuthenticationPrincipal CustomUserDetails user
 	);
 }

--- a/src/main/java/im/toduck/domain/concentration/presentation/controller/ConcentrationController.java
+++ b/src/main/java/im/toduck/domain/concentration/presentation/controller/ConcentrationController.java
@@ -1,5 +1,7 @@
 package im.toduck.domain.concentration.presentation.controller;
 
+import java.time.YearMonth;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,7 +20,6 @@ import im.toduck.domain.concentration.presentation.dto.response.ConcentrationSav
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -42,9 +43,7 @@ public class ConcentrationController implements ConcentrationApi {
 	@GetMapping("/monthly")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponse<ConcentrationListResponse>> getMonthlyConcentration(
-		@RequestParam("yearMonth")
-		@Pattern(regexp = "\\d{4}-\\d{2}", message = "yyyy-MM 형식으로 입력해야 합니다.")
-		String yearMonth,
+		@RequestParam YearMonth yearMonth,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
 		ConcentrationListResponse response = concentrationUseCase.getMonthlyConcentration(user.getUserId(), yearMonth);

--- a/src/main/java/im/toduck/domain/concentration/presentation/controller/ConcentrationController.java
+++ b/src/main/java/im/toduck/domain/concentration/presentation/controller/ConcentrationController.java
@@ -16,6 +16,7 @@ import im.toduck.domain.concentration.domain.usecase.ConcentrationUseCase;
 import im.toduck.domain.concentration.presentation.api.ConcentrationApi;
 import im.toduck.domain.concentration.presentation.dto.request.ConcentrationRequest;
 import im.toduck.domain.concentration.presentation.dto.response.ConcentrationListResponse;
+import im.toduck.domain.concentration.presentation.dto.response.ConcentrationPercentResponse;
 import im.toduck.domain.concentration.presentation.dto.response.ConcentrationSaveResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
@@ -47,6 +48,18 @@ public class ConcentrationController implements ConcentrationApi {
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
 		ConcentrationListResponse response = concentrationUseCase.getMonthlyConcentration(user.getUserId(), yearMonth);
+		return ResponseEntity.ok(ApiResponse.createSuccess(response));
+	}
+
+	@Override
+	@GetMapping("/percent")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<ConcentrationPercentResponse>> getMonthConcentrationPercent(
+		@RequestParam YearMonth yearMonth,
+		@AuthenticationPrincipal CustomUserDetails user
+	) {
+		ConcentrationPercentResponse response = concentrationUseCase.getMonthConcentrationPercent(user.getUserId(),
+			yearMonth);
 		return ResponseEntity.ok(ApiResponse.createSuccess(response));
 	}
 }

--- a/src/main/java/im/toduck/domain/concentration/presentation/dto/response/ConcentrationPercentResponse.java
+++ b/src/main/java/im/toduck/domain/concentration/presentation/dto/response/ConcentrationPercentResponse.java
@@ -1,0 +1,12 @@
+package im.toduck.domain.concentration.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "특정 연월의 집중도 평균")
+@Builder
+public record ConcentrationPercentResponse(
+	@Schema(description = "집중도 평균")
+	Integer percent
+) {
+}

--- a/src/main/java/im/toduck/domain/concentration/presentation/dto/response/ConcentrationResponse.java
+++ b/src/main/java/im/toduck/domain/concentration/presentation/dto/response/ConcentrationResponse.java
@@ -2,6 +2,7 @@ package im.toduck.domain.concentration.presentation.dto.response;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 
@@ -15,6 +16,7 @@ public record ConcentrationResponse(
 	Long id,
 
 	@JsonSerialize(using = LocalDateSerializer.class)
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 	@Schema(description = "집중 날짜", example = "2025-03-12")
 	LocalDate date,
 

--- a/src/main/java/im/toduck/global/config/web/WebConfig.java
+++ b/src/main/java/im/toduck/global/config/web/WebConfig.java
@@ -1,0 +1,15 @@
+package im.toduck.global.config.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import im.toduck.global.config.web.converter.YearMonthConverter;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addConverter(new YearMonthConverter());
+	}
+}

--- a/src/main/java/im/toduck/global/config/web/converter/YearMonthConverter.java
+++ b/src/main/java/im/toduck/global/config/web/converter/YearMonthConverter.java
@@ -1,0 +1,17 @@
+package im.toduck.global.config.web.converter;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class YearMonthConverter implements Converter<String, YearMonth> {
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
+
+	@Override
+	public YearMonth convert(String source) {
+		return YearMonth.parse(source, FORMATTER);
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용

> 특정 연월의 집중도 평균을 계산하여 반환하는 API를 추가했습니다.
> 집중 조회 시 날짜를 "yyyy-MM"으로 반환하도록 수정했습니다.
> yearMonth 파라미터 입력 시 타입을 String 말고 YearMonth(Converter)로 받도록 수정했습니다.

**1️⃣ 작업내용1**

- 설명1
  <br/>

## ✅ 리뷰 요구사항(선택)

> 해당 안내는 지워주세요.
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.  
> 작성하지 않는다면 항목을 지워주세요.  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
