### PR TITLE
프로필 사진 변경 API 개발

### DIFF
--- a/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
@@ -23,4 +23,9 @@ public class MyPageService {
 			throw CommonException.from(ExceptionCode.EXISTS_USER_NICKNAME);
 		}
 	}
+
+	@Transactional
+	public void updateProfileImage(User user, String imageUrl) {
+		userRepository.updateProfileImageUrl(user, imageUrl);
+	}
 }

--- a/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
@@ -4,6 +4,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.domain.mypage.domain.service.MyPageService;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
@@ -33,5 +34,13 @@ public class MyPageUseCase {
 		return NickNameResponse.builder()
 			.nickname(user.getNickname())
 			.build();
+	}
+
+	@Transactional
+	public void updateProfileImage(Long userId, ProfileImageUpdateRequest request) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		myPageService.updateProfileImage(user, request.imageUrl());
 	}
 }

--- a/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
@@ -48,6 +49,20 @@ public interface MyPageApi {
 		)
 	)
 	ResponseEntity<ApiResponse<NickNameResponse>> getMyNickname(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+
+	@Operation(
+		summary = "프로필 사진 변경",
+		description = "사용자 프로필 사진을 변경합니다. null을 보낼 경우 프로필 사진 삭제를 의미합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "프로필 사진 변경 성공, 빈 content 객체를 반환합니다."
+		)
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> updateProfileImage(
+		@RequestBody @Valid ProfileImageUpdateRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	);
 }

--- a/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import im.toduck.domain.mypage.domain.usecase.MyPageUseCase;
 import im.toduck.domain.mypage.presentation.api.MyPageApi;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
@@ -45,6 +46,17 @@ public class MyPageController implements MyPageApi {
 	) {
 		NickNameResponse response = myPageUseCase.getMyNickname(userDetails.getUserId());
 		return ResponseEntity.ok(ApiResponse.createSuccess(response));
+	}
+
+	@Override
+	@PatchMapping("/profile-image")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> updateProfileImage(
+		@RequestBody @Valid ProfileImageUpdateRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		myPageUseCase.updateProfileImage(userDetails.getUserId(), request);
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
 	}
 
 }

--- a/src/main/java/im/toduck/domain/mypage/presentation/dto/request/ProfileImageUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/dto/request/ProfileImageUpdateRequest.java
@@ -1,0 +1,12 @@
+package im.toduck.domain.mypage.presentation.dto.request;
+
+import org.springframework.lang.Nullable;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ProfileImageUpdateRequest(
+	@Nullable
+	@Schema(description = "이미지 URL", nullable = true, example = "https://cdn.toduck.app/example.jpg")
+	String imageUrl
+) {
+}

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
@@ -4,4 +4,6 @@ import im.toduck.domain.user.persistence.entity.User;
 
 public interface UserRepositoryCustom {
 	void updateNickname(User user, String nickname);
+
+	void updateProfileImageUrl(User user, String imageUrl);
 }

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
@@ -21,4 +21,12 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 			.where(qUser.id.eq(user.getId()))
 			.execute();
 	}
+
+	@Override
+	public void updateProfileImageUrl(User user, String imageUrl) {
+		queryFactory.update(qUser)
+			.set(qUser.imageUrl, imageUrl)
+			.where(qUser.id.eq(user.getId()))
+			.execute();
+	}
 }

--- a/src/test/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCaseTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import im.toduck.ServiceTest;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.domain.user.persistence.repository.UserRepository;
 import im.toduck.fixtures.user.UserFixtures;
@@ -54,6 +55,24 @@ public class MyPageUseCaseTest extends ServiceTest {
 			assertThatThrownBy(() -> myPageUseCase.updateNickname(updatingUser.getId(), request))
 				.isInstanceOf(CommonException.class)
 				.hasMessageContaining(ExceptionCode.EXISTS_USER_NICKNAME.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("프로필 이미지 변경 시")
+	class UpdateProfileImage {
+		@Test
+		public void 프로필_사진을_변경할_수_있다() {
+			// given
+			User user = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+			String imageUrl = "https://cdn.toduck.app/example.jpg";
+
+			// when
+			ProfileImageUpdateRequest request = new ProfileImageUpdateRequest(imageUrl);
+			myPageUseCase.updateProfileImage(user.getId(), request);
+
+			// then
+			assertThat(userRepository.findById(user.getId()).get().getImageUrl()).isEqualTo(imageUrl);
 		}
 	}
 }


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 프로필 사진 변경**

- 프로필 사진 변경 api입니다. `CUD`를 해당 api로 한번에 쓸 수 있습니다.

## ✅ 리뷰 요구사항(선택)

> 다른 도메인의 S3 사진 수정과 삭제를 확인하였을 때, 사진을 삭제할 때 데이터베이스 상에서 url을 삭제하는 로직까지는 확인했지만, S3 자체의 사진을 삭제하는 로직은 찾지 못하였습니다. 데이터베이스 상에서만 삭제하고 S3에 올라간 사진은 따로 삭제해주지 않는 것인지, 혹은 제가 해당 로직을 발견하지 못한 것인지 궁금합니다!
