### PR TITLE
소셜 프로필 - 공개 루틴 조회 api문서 수정

### DIFF
--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -137,6 +137,7 @@ public class RoutineMapper {
 		return UserProfileRoutineListResponse.UserProfileRoutineResponse.builder()
 			.routineId(routine.getId())
 			.category(routine.getCategory())
+			.color(routine.getColorValue())
 			.title(routine.getTitle())
 			.memo(routine.getMemoValue())
 			.time(routine.getTime())

--- a/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
+++ b/src/main/java/im/toduck/domain/social/presentation/api/SocialProfileApi.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
-import im.toduck.domain.routine.presentation.dto.response.MyRoutineAvailableListResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialProfileResponse;
 import im.toduck.domain.social.presentation.dto.response.SocialResponse;
@@ -78,7 +77,7 @@ public interface SocialProfileApi {
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
-			responseClass = MyRoutineAvailableListResponse.class,
+			responseClass = UserProfileRoutineListResponse.class,
 			description = "루틴 목록 조회 성공. 루틴 시간(time) 기준으로 오름차순 정렬됩니다."
 		),
 		errors = {

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
@@ -26,6 +26,9 @@ public record UserProfileRoutineListResponse(
 		@Schema(description = "루틴 카테고리", example = "MEDICINE")
 		PlanCategory category,
 
+		@Schema(description = "루틴 색상(null 이면 없는 색상)", example = "#FCDCDF")
+		String color,
+
 		@Schema(description = "루틴 제목", example = "하루 물 1L 이상 마시기")
 		String title,
 


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ [소셜 프로필 - 공개 루틴 조회] API 문서 수정**

**[수정전]**
```JAVA
@ApiResponseExplanations(
success = @ApiSuccessResponseExplanation(
	responseClass = MyRoutineAvailableListResponse.class, <-------
	description = "루틴 목록 조회 성공, 루틴의 고유 Id, 루틴 Color, 완료 여부를 반환합니다."
)

```
**[수정후]**
```JAVA
@ApiResponseExplanations(
success = @ApiSuccessResponseExplanation(
	responseClass = UserProfileRoutineListResponse.class, <------
	description = "루틴 목록 조회 성공, 루틴의 고유 Id, 루틴 Color, 완료 여부를 반환합니다."
)

```


  <br/>

**2️⃣ [소셜 프로필 - 공개 루틴 조회] 응답시 카테고리 색상 필드 추가**
```JAVA
public record UserProfileRoutineResponse(
    ...
    @Schema(description = "루틴 색상(null 이면 없는 색상)", example = "#FCDCDF")
    String color,
    ...
) {
}
```
  <br/>



## ✅ 리뷰 요구사항
- 궁금한 점 있으시면 댓글 남겨주세요!