### PR TITLE
일정 및 oidc 에러 수정

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -162,7 +162,7 @@ CREATE TABLE schedule
     is_all_day   BOOLEAN      NOT NULL,
     time         TIME                                                                                                                                       DEFAULT NULL,
     days_of_week TINYINT                                                                                                                                    DEFAULT NULL,
-    alarm        ENUM ('TEN_MINUTE', 'ONE_HOUR', 'ONE_DAY')                                                                                                 DEFAULT NULL,
+    alarm        ENUM ('TEN_MINUTE', 'ONE_HOUR', 'THIRTY_MINUTE')                                                                                                 DEFAULT NULL,
     location     VARCHAR(255)                                                                                                                               DEFAULT NULL,
     memo         VARCHAR(255)                                                                                                                               DEFAULT NULL,
     user_id      BIGINT       NOT NULL,

--- a/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleMapper.java
+++ b/src/main/java/im/toduck/domain/schedule/common/mapper/ScheduleMapper.java
@@ -73,6 +73,7 @@ public class ScheduleMapper {
 			.daysOfWeek(convertDaysOfWeekBitmaskToDayOfWeekList(schedule.getDaysOfWeekBitmask()))
 			.time(schedule.getScheduleTime().getTime())
 			.location(schedule.getLocation())
+			.memo(schedule.getMemo())
 			.build();
 	}
 

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleCompleteRequest.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/request/ScheduleCompleteRequest.java
@@ -2,6 +2,9 @@ package im.toduck.domain.schedule.presentation.dto.request;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -12,6 +15,7 @@ public record ScheduleCompleteRequest(
 	@Schema(description = "일정 완료 여부", example = "false")
 	Boolean isComplete,
 	@Schema(description = "일정 조회 날짜", example = "2024-08-31")
+	@JsonDeserialize(using = LocalDateDeserializer.class)
 	LocalDate queryDate
 ) {
 }

--- a/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleHeadResponse.java
+++ b/src/main/java/im/toduck/domain/schedule/presentation/dto/response/ScheduleHeadResponse.java
@@ -73,7 +73,10 @@ public record ScheduleHeadResponse(
 		LocalTime time,
 
 		@Schema(description = "장소", example = "일정 장소")
-		String location
+		String location,
+
+		@Schema(description = "메모", example = "일정 메모")
+		String memo
 	) {
 		@Schema(description = "일정 기록 DTO")
 		public record ScheduleRecordDto(

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,3 +6,17 @@ decorator:
   datasource:
     p6spy:
       enable-logging: false
+
+oauth2:
+  client:
+    provider:
+      apple:
+        jwks-uri: ${OIDC_APPLE_JWKS_URI}
+        secret: ${OIDC_APPLE_SECRET_KEY}
+      google:
+        jwks-uri: https://www.googleapis.com
+        secret: googleSecret
+        issuer: https://accounts.google.com
+      kakao:
+        jwks-uri: ${OIDC_KAKAO_JWKS_URI}
+        secret: ${OIDC_KAKAO_SECRET_KEY}


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 일정 Api 에서 역직렬화 에러 및 init.sql enum 누락 에러 해결**

- request dto 에서 LocalDate 역직렬화를 안해서 생기는 에러 해결
- init sql 에서 enum 누락에서 생기는 에러 해결

  <br/>

**2️⃣ 일정 기간 조회 API 에 memo 필드 추가**

- memo 필드 추가해달라는 프론트 요청으로 추가했습니다
  <br/>

**3️⃣ OIDC prod profile 환경 설정**

- prod 프로필에서 OIDC 설정이 누락되어 있어서 수정했습니다
  <br/>

## ✅ 리뷰 요구사항(선택)

> 해당 안내는 지워주세요.
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.  
> 작성하지 않는다면 항목을 지워주세요.  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
