### PR TITLE
소셜 관련 응답 필드 추가 및 수정

### DIFF
--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -94,6 +94,7 @@ public class RoutineMapper {
 			.category(routine.getCategory())
 			.color(routine.getColorValue())
 			.title(routine.getTitle())
+			.memo(routine.getMemoValue())
 			.time(routine.getTime())
 			.isPublic(routine.getIsPublic())
 			.isInDeletedState(routine.isInDeletedState())

--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -136,6 +136,11 @@ public class RoutineMapper {
 	private static UserProfileRoutineListResponse.UserProfileRoutineResponse toUserProfileRoutineRecordReadResponse(
 		final Routine routine
 	) {
+		DaysOfWeekBitmask daysOfWeekBitmask = routine.getDaysOfWeekBitmask();
+		List<DayOfWeek> daysOfWeek = daysOfWeekBitmask.getDaysOfWeek().stream()
+			.sorted()
+			.toList();
+
 		return UserProfileRoutineListResponse.UserProfileRoutineResponse.builder()
 			.routineId(routine.getId())
 			.category(routine.getCategory())
@@ -144,6 +149,7 @@ public class RoutineMapper {
 			.memo(routine.getMemoValue())
 			.time(routine.getTime())
 			.sharedCount(routine.getSharedCount())
+			.daysOfWeek(daysOfWeek)
 			.build();
 	}
 }

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
@@ -1,5 +1,6 @@
 package im.toduck.domain.social.presentation.dto.response;
 
+import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -8,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 
 import im.toduck.domain.person.persistence.entity.PlanCategory;
+import im.toduck.global.serializer.DayOfWeekListSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -37,6 +39,10 @@ public record UserProfileRoutineListResponse(
 
 		@Schema(description = "루틴 공유 수", example = "455")
 		int sharedCount,
+
+		@JsonSerialize(using = DayOfWeekListSerializer.class)
+		@Schema(description = "반복 요일", example = "[\"MONDAY\",\"TUESDAY\"]")
+		List<DayOfWeek> daysOfWeek,
 
 		@JsonSerialize(using = LocalTimeSerializer.class)
 		@JsonFormat(pattern = "HH:mm")


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 소셜 프로필 - 공개 루틴 목록 조회 시  반복 날짜 응답 추가**
```JAVA
public record UserProfileRoutineListResponse(
    List<UserProfileRoutineResponse> routines
  ) {
  public record UserProfileRoutineResponse(
        ...
        @JsonSerialize(using = DayOfWeekListSerializer.class)
        @Schema(description = "반복 요일", example = "[\"MONDAY\",\"TUESDAY\"]")
        List<DayOfWeek> daysOfWeek,
        ...
  ) {
  }
}

```
  <br/>

**2️⃣ 루틴 Detail - memo 값 응답**
``` JAVA
public static RoutineDetailResponse toRoutineDetailResponse(final Routine routine) {
    ...
    return RoutineDetailResponse.builder()
        ...
	.memo(routine.getMemoValue())       <----- Mapper에서 응답 하지 않던 것 수정
        ...
}
```
  <br/>