### PR TITLE
루틴 생성 및 수정 시 당일 기록이 누락되는 문제 해결

### DIFF
--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -1,8 +1,6 @@
 package im.toduck.domain.routine.domain.service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,15 +38,7 @@ public class RoutineService {
 		final LocalDate date,
 		final List<RoutineRecord> routineRecords
 	) {
-		List<Routine> routines = routineRepository.findUnrecordedRoutinesForDate(user, date, routineRecords);
-
-		return routines.stream().filter(routine -> {
-			LocalDateTime compareTime = routine.isAllDay()
-				? date.minusDays(1).atTime(LocalTime.MAX)
-				: date.atTime(routine.getTime());
-
-			return !routine.getScheduleModifiedAt().isAfter(compareTime);
-		}).toList();
+		return routineRepository.findUnrecordedRoutinesForDate(user, date, routineRecords);
 	}
 
 	public Optional<Routine> getUserRoutine(final User user, final Long id) {
@@ -60,15 +50,7 @@ public class RoutineService {
 	}
 
 	public boolean canCreateRecordForDate(final Routine routine, final LocalDate date) {
-		if (routineRepository.isActiveForDate(routine, date)) {
-			LocalDateTime compareTime = routine.isAllDay()
-				? date.minusDays(1).atTime(LocalTime.MAX)
-				: date.atTime(routine.getTime());
-
-			return !routine.getScheduleModifiedAt().isAfter(compareTime);
-		}
-
-		return false;
+		return routineRepository.isActiveForDate(routine, date);
 	}
 
 	public List<Routine> getAvailableRoutine(final User user) {

--- a/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
+++ b/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
@@ -2,8 +2,6 @@ package im.toduck.domain.routine.domain.usecase;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -174,27 +172,15 @@ public class RoutineUseCase {
 		final LocalDateTime endTime
 	) {
 		Set<LocalDate> existingDates = routineRecordService.getExistingRecordDates(routine, startTime, endTime);
-		List<RoutineRecord> newRecords = new ArrayList<>();
 
 		LocalDate startDate = startTime.toLocalDate();
 		LocalDate endDate = endTime.toLocalDate();
 
-		routine.getDaysOfWeekBitmask().streamMatchingDatesInRange(startDate, endDate)
+		List<RoutineRecord> newRecords = routine.getDaysOfWeekBitmask()
+			.streamMatchingDatesInRange(startDate, endDate)
 			.filter(date -> !existingDates.contains(date))
-			.filter(date -> {
-				if (date.equals(startDate)) {
-					LocalTime timeToCompare = routine.isAllDay() ? LocalTime.MIN : routine.getTime();
-					return !date.atTime(timeToCompare).isBefore(startTime);
-				}
-				if (date.equals(endDate)) {
-					LocalTime timeToCompare = routine.isAllDay() ? LocalTime.MAX : routine.getTime();
-					return !date.atTime(timeToCompare).isAfter(endTime);
-				}
-
-				return true;
-			})
 			.map(date -> RoutineRecordMapper.toRoutineRecord(routine, date, false))
-			.forEach(newRecords::add);
+			.toList();
 
 		if (!newRecords.isEmpty()) {
 			routineRecordService.saveAll(newRecords);

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
@@ -88,11 +88,6 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 		);
 	}
 
-	private BooleanExpression routineCreatedOnOrBeforeDate(final LocalDate date) {
-		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
-		return qRoutine.createdAt.loe(endOfDay);
-	}
-
 	private BooleanExpression scheduleModifiedOnOrBeforeDate(final LocalDate date) {
 		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 		return qRoutine.scheduleModifiedAt.loe(endOfDay);

--- a/src/test/java/im/toduck/domain/routine/domain/service/RoutineServiceTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/service/RoutineServiceTest.java
@@ -83,7 +83,7 @@ class RoutineServiceTest extends ServiceTest {
 	@DisplayName("기록되지 않은 루틴 목록 조회 시")
 	class GetUnrecordedRoutinesForDateTest {
 		@Test
-		void 종일_루틴의_경우_수정_시각과_관계없이_당일_수정된_루틴은_조회되지_않는다() {
+		void 종일_루틴의_경우_수정_시각과_관계없이_당일_수정된_루틴은_조회_대상에_포함된다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
 				PUBLIC_MONDAY_ALLDAY_ROUTINE(USER)
@@ -97,11 +97,11 @@ class RoutineServiceTest extends ServiceTest {
 			List<Routine> unrecordedRoutines = routineService.getUnrecordedRoutinesForDate(USER, monday, List.of());
 
 			// then
-			assertThat(unrecordedRoutines).doesNotContain(ROUTINE);
+			assertThat(unrecordedRoutines).contains(ROUTINE);
 		}
 
 		@Test
-		void 특정_시간_루틴의_경우_해당_시간_이후_수정된_루틴은_조회되지_않는다() {
+		void 특정_시간_루틴의_경우_수정_시간과_관계없이_당일_수정된_루틴은_조회_대상에_포함된다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
 				PUBLIC_MONDAY_ALLDAY_ROUTINE(USER) //아침 7시 루틴
@@ -115,7 +115,7 @@ class RoutineServiceTest extends ServiceTest {
 			List<Routine> unrecordedRoutines = routineService.getUnrecordedRoutinesForDate(USER, monday, List.of());
 
 			// then
-			assertThat(unrecordedRoutines).doesNotContain(ROUTINE);
+			assertThat(unrecordedRoutines).contains(ROUTINE);
 		}
 	}
 }


### PR DESCRIPTION
## ✨ 작업 내용
**1️⃣ 루틴 생성 및 수정 시 당일 기록이 누락되는 문제 해결**

- RoutineService에서 불필요한 필터링 로직을 제거하여 당일 생성/수정된 루틴도 정상적으로 조회되도록 수정
- 루틴 시간과 스케줄 수정 시간을 비교하는 복잡한 로직을 제거하여 시간대 문제 해결
<br/>

**2️⃣ saveMissingIncompleteRecordsInBulk 메서드 간소화**

- 복잡한 시간 비교 로직 제거 및 코드 간소화
- 불필요한 날짜 필터링 로직 제거
<br/>

**3️⃣ 미사용 코드 및 불필요한 임포트 제거**

- LocalTime 및 ArrayList 등 불필요한 임포트 제거
- 미사용 메서드 routineCreatedOnOrBeforeDate 제거

