### PR TITLE
개별 루틴 삭제 기능 구현

### DIFF
--- a/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/Routine.java
@@ -41,11 +41,9 @@ public class Routine extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	// TODO: 변경 필요
 	@Enumerated(EnumType.STRING)
 	private PlanCategory category;
 
-	// TODO: 변경 필요
 	@Embedded
 	private PlanCategoryColor color;
 

--- a/src/main/java/im/toduck/domain/routine/persistence/entity/RoutineRecord.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/entity/RoutineRecord.java
@@ -50,4 +50,12 @@ public class RoutineRecord extends BaseEntity {
 	public void changeCompletion(Boolean isCompleted) {
 		this.isCompleted = isCompleted;
 	}
+
+	public void delete() {
+		this.deletedAt = LocalDateTime.now();
+	}
+
+	public Boolean isInDeletedState() {
+		return deletedAt != null;
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
@@ -67,7 +67,8 @@ public class RoutineRecordRepositoryCustomImpl implements RoutineRecordRepositor
 			.where(
 				qRecord.routine.eq(routine),
 				qRecord.recordAt.after(targetDateTime),
-				qRecord.isCompleted.isFalse()
+				qRecord.isCompleted.isFalse(),
+				qRecord.deletedAt.isNull()
 			)
 			.execute();
 	}

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.TimePath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import im.toduck.domain.routine.persistence.entity.QRoutine;
@@ -72,20 +71,6 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 
 	private BooleanExpression routineNotDeleted() {
 		return qRoutine.deletedAt.isNull();
-	}
-
-	private BooleanExpression routineNotDeletedOrDeletedAfterDate(
-		final TimePath<LocalTime> timePath,
-		final LocalDate date
-	) {
-		return qRoutine.deletedAt.isNull().or(
-			Expressions.booleanTemplate(
-				"cast(concat({0}, ' ', cast({1} as time)) as timestamp) < {2}",
-				date,
-				timePath,
-				qRoutine.deletedAt
-			)
-		);
 	}
 
 	private BooleanExpression scheduleModifiedOnOrBeforeDate(final LocalDate date) {

--- a/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
@@ -138,6 +138,27 @@ public interface RoutineApi {
 	);
 
 	@Operation(
+		summary = "개별 루틴 삭제",
+		description = "개별 루틴 기록을 삭제합니다. "
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "개별 루틴 삭제 성공"
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_ROUTINE),
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.ROUTINE_INVALID_DATE)
+		}
+	)
+	ResponseEntity<ApiResponse<?>> deleteIndividualRoutine(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@Parameter(description = "삭제할 루틴의 Id", required = true, example = "1")
+		@PathVariable final Long routineId,
+		@Parameter(description = "삭제할 개별 루틴이 포함되는 날짜 (형식: YYYY-MM-DD)", required = true, example = "2024-09-02")
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+	);
+
+	@Operation(
 		summary = "루틴 삭제",
 		description = "루틴을 삭제합니다. keepRecords 파라미터를 통해 이전 기록 유지 여부를 결정할 수 있습니다."
 	)

--- a/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
@@ -115,6 +115,21 @@ public class RoutineController implements RoutineApi {
 	}
 
 	@Override
+	@DeleteMapping("/{routineId}/individual")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> deleteIndividualRoutine(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long routineId,
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate date
+	) {
+		routineUseCase.deleteIndividualRoutine(userDetails.getUserId(), routineId, date);
+
+		return ResponseEntity.ok(
+			ApiResponse.createSuccessWithNoContent()
+		);
+	}
+
+	@Override
 	@DeleteMapping("/{routineId}")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponse<?>> deleteRoutine(


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 개별 루틴 삭제 기능 구현**

- 특정 날짜의 개별 루틴만 삭제할 수 있는 기능 구현
- 실제 삭제가 아닌 soft delete 방식 적용 (deletedAt 필드 사용)
<br/>

**2️⃣ 기존 루틴 조회 기능 개선**

- 삭제된 루틴을 포함/제외하는 기능 구분 구현
- getRecords → getRecordsIncludingDeleted 메서드명 변경
- 루틴 조회 시 삭제되지 않은 루틴만 반환하도록 필터링 로직 추가
<br/>

**3️⃣ API 엔드포인트 추가**

- 개별 루틴 삭제를 위한 DELETE `/routines/{routineId}/individual?date=YYYY-MM-DD` 엔드포인트 구현
- 삭제 요청 시 이미 기록이 있으면 삭제 상태로 변경, 없으면 삭제 상태로 생성하는 로직 구현 (동시성 문제 해결 필요)