### PR TITLE
회원 탈퇴 API 개발

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -309,3 +309,13 @@ CREATE TABLE concentration
     deleted_at          DATETIME                            NULL,
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
+
+CREATE TABLE account_deletion_log
+(
+    id          BIGINT PRIMARY KEY auto_increment,
+    user_id     BIGINT                                                                                      NOT NULL,
+    reason_code ENUM ('HARD_TO_USE', 'NO_FEATURES', 'MANY_ERRORS', 'BETTER_APP', 'SWITCH_ACCOUNT', 'OTHER') NOT NULL,
+    reason_text VARCHAR(130)                                                                                NOT NULL,
+    created_at  DATETIME                                                                                    NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
+);

--- a/src/main/java/im/toduck/domain/concentration/domain/service/ConcentrationService.java
+++ b/src/main/java/im/toduck/domain/concentration/domain/service/ConcentrationService.java
@@ -50,4 +50,9 @@ public class ConcentrationService {
 
 		return totalPercentage;
 	}
+
+	@Transactional
+	public void deleteAllConcentrationsByUser(User user) {
+		concentrationRepository.deleteAllByUser(user);
+	}
 }

--- a/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepository.java
+++ b/src/main/java/im/toduck/domain/concentration/persistence/repository/ConcentrationRepository.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import im.toduck.domain.concentration.persistence.entity.Concentration;
@@ -15,4 +18,8 @@ public interface ConcentrationRepository extends JpaRepository<Concentration, Lo
 	Optional<Concentration> findByUserAndDate(User user, LocalDate date);
 
 	List<Concentration> findByUserAndDateBetween(User user, LocalDate startDate, LocalDate endDate);
+
+	@Modifying(clearAutomatically = true)
+	@Query("UPDATE Concentration c SET c.deletedAt = NOW() WHERE c.user = :user")
+	void deleteAllByUser(@Param("user") User user);
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -62,6 +62,13 @@ public class DiaryService {
 	}
 
 	@Transactional
+	public void deleteAllDiariesByUser(final User user) {
+		List<Diary> diaries = diaryRepository.findAllByUser(user);
+
+		diaries.forEach(this::deleteDiary);
+	}
+
+	@Transactional
 	public void updateDiary(
 		User user,
 		Diary diary,

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.user.persistence.entity.User;
 import jakarta.validation.constraints.NotNull;
 
 @Repository
@@ -16,4 +17,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	Diary findByUserIdAndDate(Long userId, @NotNull(message = "날짜는 비어있을 수 없습니다.") LocalDate date);
 
 	int countByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+
+	List<Diary> findAllByUser(User user);
 }

--- a/src/main/java/im/toduck/domain/mypage/common/mapper/AccountDeletionLogMapper.java
+++ b/src/main/java/im/toduck/domain/mypage/common/mapper/AccountDeletionLogMapper.java
@@ -1,0 +1,18 @@
+package im.toduck.domain.mypage.common.mapper;
+
+import im.toduck.domain.mypage.persistence.entity.AccountDeletionLog;
+import im.toduck.domain.mypage.presentation.dto.request.UserDeleteRequest;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AccountDeletionLogMapper {
+	public static AccountDeletionLog toAccountDeletionLog(User user, UserDeleteRequest request) {
+		return AccountDeletionLog.builder()
+			.user(user)
+			.reasonCode(request.reasonCode())
+			.reasonText(request.reasonText())
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
@@ -4,6 +4,10 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import im.toduck.domain.mypage.common.mapper.AccountDeletionLogMapper;
+import im.toduck.domain.mypage.persistence.entity.AccountDeletionLog;
+import im.toduck.domain.mypage.persistence.repository.AccountDeletionLogRepository;
+import im.toduck.domain.mypage.presentation.dto.request.UserDeleteRequest;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.domain.user.persistence.repository.UserRepository;
 import im.toduck.global.exception.CommonException;
@@ -14,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MyPageService {
 	private final UserRepository userRepository;
+	private final AccountDeletionLogRepository accountDeletionLogRepository;
 
 	@Transactional
 	public void updateUniqueNickname(User user, String nickname) {
@@ -27,5 +32,11 @@ public class MyPageService {
 	@Transactional
 	public void updateProfileImage(User user, String imageUrl) {
 		userRepository.updateProfileImageUrl(user, imageUrl);
+	}
+
+	@Transactional
+	public void recordUserDeletionLog(User user, UserDeleteRequest request) {
+		AccountDeletionLog accountDeletionLog = AccountDeletionLogMapper.toAccountDeletionLog(user, request);
+		accountDeletionLogRepository.save(accountDeletionLog);
 	}
 }

--- a/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
@@ -40,7 +40,7 @@ public class MyPageService {
 	public void recordUserDeletionLog(User user, UserDeleteRequest request) {
 		AccountDeletionLog accountDeletionLog = AccountDeletionLogMapper.toAccountDeletionLog(user, request);
 		accountDeletionLogRepository.save(accountDeletionLog);
-  }
+	}
 
 	@Transactional(readOnly = true)
 	public List<User> getBlockedUsers(final User user) {

--- a/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
@@ -80,7 +80,7 @@ public class MyPageUseCase {
 		// TODO. schedule 관련 삭제 추가
 
 		userService.softDelete(user);
-  }
+	}
 
 	@Transactional(readOnly = true)
 	public BlockedUsersResponse getBlockedUsers(final Long userId) {

--- a/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
@@ -1,19 +1,12 @@
 package im.toduck.domain.mypage.domain.usecase;
 
-import java.util.List;
-
 import org.springframework.transaction.annotation.Transactional;
 
-import im.toduck.domain.concentration.domain.service.ConcentrationService;
-import im.toduck.domain.diary.domain.service.DiaryService;
 import im.toduck.domain.mypage.domain.service.MyPageService;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.UserDeleteRequest;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
-import im.toduck.domain.routine.domain.service.RoutineRecordService;
-import im.toduck.domain.routine.domain.service.RoutineService;
-import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.social.domain.service.SocialBoardService;
 import im.toduck.domain.user.domain.service.FollowService;
 import im.toduck.domain.user.domain.service.UserService;
@@ -29,11 +22,7 @@ public class MyPageUseCase {
 	private final UserService userService;
 	private final MyPageService myPageService;
 	private final FollowService followService;
-	private final DiaryService diaryService;
 	private final SocialBoardService socialBoardService;
-	private final ConcentrationService concentrationService;
-	private final RoutineService routineService;
-	private final RoutineRecordService routineRecordService;
 
 	@Transactional
 	public void updateNickname(Long userId, NickNameUpdateRequest request) {
@@ -75,14 +64,14 @@ public class MyPageUseCase {
 
 		socialBoardService.deleteAllSocialBoardsByUser(user);
 
-		// TODO. 즉각 반영되지 않아도 되는 데이터 배치 처리
-		diaryService.deleteAllDiariesByUser(user);
-
-		List<Routine> routines = routineService.findAllUnsharedRoutineByUser(user);
-		routines.forEach(routineRecordService::removeAllByRoutine);
-		routineService.deleteAllUnsharedRoutinesByUser(user);
-
-		concentrationService.deleteAllConcentrationsByUser(user);
+		// TODO. 즉각 반영되지 않아도 되는 데이터(diary, 공유되지 않은 routine, concentration) 배치 처리
+		// diaryService.deleteAllDiariesByUser(user);
+		//
+		// List<Routine> routines = routineService.findAllUnsharedRoutineByUser(user);
+		// routines.forEach(routineRecordService::removeAllByRoutine);
+		// routineService.deleteAllUnsharedRoutinesByUser(user);
+		//
+		// concentrationService.deleteAllConcentrationsByUser(user);
 
 		// TODO. schedule 관련 삭제 추가
 

--- a/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
@@ -1,12 +1,21 @@
 package im.toduck.domain.mypage.domain.usecase;
 
+import java.util.List;
+
 import org.springframework.transaction.annotation.Transactional;
 
+import im.toduck.domain.concentration.domain.service.ConcentrationService;
+import im.toduck.domain.diary.domain.service.DiaryService;
 import im.toduck.domain.mypage.domain.service.MyPageService;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.UserDeleteRequest;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
+import im.toduck.domain.routine.domain.service.RoutineRecordService;
+import im.toduck.domain.routine.domain.service.RoutineService;
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.social.domain.service.SocialBoardService;
+import im.toduck.domain.user.domain.service.FollowService;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.annotation.UseCase;
@@ -19,6 +28,12 @@ import lombok.RequiredArgsConstructor;
 public class MyPageUseCase {
 	private final UserService userService;
 	private final MyPageService myPageService;
+	private final FollowService followService;
+	private final DiaryService diaryService;
+	private final SocialBoardService socialBoardService;
+	private final ConcentrationService concentrationService;
+	private final RoutineService routineService;
+	private final RoutineRecordService routineRecordService;
 
 	@Transactional
 	public void updateNickname(Long userId, NickNameUpdateRequest request) {
@@ -51,5 +66,26 @@ public class MyPageUseCase {
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
 		myPageService.recordUserDeletionLog(user, request);
+		this.deleteUserData(user);
+	}
+
+	private void deleteUserData(User user) {
+		followService.deleteAllFollowsByUser(user);
+		userService.deleteAllBlocksByUser(user);
+
+		socialBoardService.deleteAllSocialBoardsByUser(user);
+
+		// TODO. 즉각 반영되지 않아도 되는 데이터 배치 처리
+		diaryService.deleteAllDiariesByUser(user);
+
+		List<Routine> routines = routineService.findAllUnsharedRoutineByUser(user);
+		routines.forEach(routineRecordService::removeAllByRoutine);
+		routineService.deleteAllUnsharedRoutinesByUser(user);
+
+		concentrationService.deleteAllConcentrationsByUser(user);
+
+		// TODO. schedule 관련 삭제 추가
+
+		userService.softDelete(user);
 	}
 }

--- a/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 import im.toduck.domain.mypage.domain.service.MyPageService;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.request.UserDeleteRequest;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
@@ -42,5 +43,13 @@ public class MyPageUseCase {
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
 		myPageService.updateProfileImage(user, request.imageUrl());
+	}
+
+	@Transactional
+	public void deleteAccount(Long userId, UserDeleteRequest request) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		myPageService.recordUserDeletionLog(user, request);
 	}
 }

--- a/src/main/java/im/toduck/domain/mypage/persistence/entity/AccountDeletionLog.java
+++ b/src/main/java/im/toduck/domain/mypage/persistence/entity/AccountDeletionLog.java
@@ -1,0 +1,57 @@
+package im.toduck.domain.mypage.persistence.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import im.toduck.domain.user.persistence.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "account_deletion_log")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class AccountDeletionLog {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", unique = true)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	private AccountDeletionReason reasonCode;
+
+	@Column(length = 130)
+	private String reasonText;
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@Builder
+	public AccountDeletionLog(User user, AccountDeletionReason reasonCode, String reasonText) {
+		this.user = user;
+		this.reasonCode = reasonCode;
+		this.reasonText = reasonText;
+	}
+}

--- a/src/main/java/im/toduck/domain/mypage/persistence/entity/AccountDeletionReason.java
+++ b/src/main/java/im/toduck/domain/mypage/persistence/entity/AccountDeletionReason.java
@@ -1,0 +1,20 @@
+package im.toduck.domain.mypage.persistence.entity;
+
+public enum AccountDeletionReason {
+	HARD_TO_USE("사용 방법이 어려워요"),
+	NO_FEATURES("원하는 기능이 없어요"),
+	MANY_ERRORS("오류가 자주 발생해요"),
+	BETTER_APP("더 좋은 어플이 있어요"),
+	SWITCH_ACCOUNT("다른 계정으로 다시 가입하고 싶어요"),
+	OTHER("기타");
+
+	private final String description;
+
+	AccountDeletionReason(String description) {
+		this.description = description;
+	}
+
+	public String description() {
+		return description;
+	}
+}

--- a/src/main/java/im/toduck/domain/mypage/persistence/repository/AccountDeletionLogRepository.java
+++ b/src/main/java/im/toduck/domain/mypage/persistence/repository/AccountDeletionLogRepository.java
@@ -1,0 +1,12 @@
+package im.toduck.domain.mypage.persistence.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import im.toduck.domain.mypage.persistence.entity.AccountDeletionLog;
+import im.toduck.domain.user.persistence.entity.User;
+
+public interface AccountDeletionLogRepository extends JpaRepository<AccountDeletionLog, Long> {
+	Optional<AccountDeletionLog> findByUser(User user);
+}

--- a/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.request.UserDeleteRequest;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
@@ -63,6 +64,29 @@ public interface MyPageApi {
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> updateProfileImage(
 		@RequestBody @Valid ProfileImageUpdateRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+
+	@Operation(
+		summary = "회원 탈퇴",
+		description = """
+			회원 탈퇴합니다. 회원 탈퇴 코드와 회원 탈퇴 텍스트를 담아 보냅니다. \n
+			회원 코드는 다음과 같습니다. \n
+			- **HARD_TO_USE**: 사용 방법이 어려워요 \n
+			- **NO_FEATURES**: 원하는 기능이 없어요 \n
+			- **MANY_ERRORS**: 오류가 자주 발생해요 \n
+			- **BETTER_APP**: 더 좋은 어플이 있어요 \n
+			- **SWITCH_ACCOUNT**: 다른 계정으로 다시 가입하고 싶어요 \n
+			- **OTHER**: 기타
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "회원 탈퇴 성공, 빈 content 객체를 반환합니다."
+		)
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> deleteAccount(
+		@RequestBody @Valid UserDeleteRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	);
 }

--- a/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
@@ -91,7 +91,7 @@ public interface MyPageApi {
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	);
 
-  @Operation(
+	@Operation(
 		summary = "차단한 유저 목록 조회",
 		description = "자신이 차단한 유저들의 목록을 조회합니다."
 	)

--- a/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
@@ -71,9 +71,9 @@ public class MyPageController implements MyPageApi {
 	) {
 		myPageUseCase.deleteAccount(userDetails.getUserId(), request);
 		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
-  }
+	}
 
-  @Override
+	@Override
 	@GetMapping("/blocked-users")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponse<BlockedUsersResponse>> getBlockedUsers(

--- a/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import im.toduck.domain.mypage.domain.usecase.MyPageUseCase;
 import im.toduck.domain.mypage.presentation.api.MyPageApi;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.request.UserDeleteRequest;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
@@ -59,4 +61,13 @@ public class MyPageController implements MyPageApi {
 		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
 	}
 
+	@Override
+	@DeleteMapping("/account")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteAccount(
+		@RequestBody @Valid UserDeleteRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		myPageUseCase.deleteAccount(userDetails.getUserId(), request);
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
+	}
 }

--- a/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
@@ -63,6 +63,7 @@ public class MyPageController implements MyPageApi {
 
 	@Override
 	@DeleteMapping("/account")
+	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteAccount(
 		@RequestBody @Valid UserDeleteRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/im/toduck/domain/mypage/presentation/dto/request/UserDeleteRequest.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/dto/request/UserDeleteRequest.java
@@ -1,0 +1,18 @@
+package im.toduck.domain.mypage.presentation.dto.request;
+
+import im.toduck.domain.mypage.persistence.entity.AccountDeletionReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UserDeleteRequest(
+	@Schema(description = "탈퇴 사유 코드", example = "OTHER")
+	@NotNull(message = "탈퇴 사유 코드는 필수입니다.")
+	AccountDeletionReason reasonCode,
+
+	@Schema(description = "탈퇴 사유 입력값", example = "파이팅")
+	@NotNull(message = "탈퇴 사유는 필수입니다.")
+	@Size(max = 130, message = "탈퇴 사유는 최대 130자까지 입력 가능합니다.")
+	String reasonText
+) {
+}

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -87,4 +87,13 @@ public class RoutineService {
 	public int getTotalRoutineShareCount(final User user) {
 		return routineRepository.sumRoutineSharedCountByUser(user);
 	}
+
+	@Transactional
+	public void deleteAllUnsharedRoutinesByUser(final User user) {
+		routineRepository.deleteAllUnsharedRoutinesByUser(user);
+	}
+
+	public List<Routine> findAllUnsharedRoutineByUser(User user) {
+		return routineRepository.findAllUnsharedRoutinesByUser(user);
+	}
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
@@ -37,4 +37,7 @@ public interface RoutineRepository extends JpaRepository<Routine, Long>, Routine
 			+ "AND r.deletedAt IS NULL"
 	)
 	int sumRoutineSharedCountByUser(@Param("user") User user);
+
+	@Query("SELECT r FROM Routine r WHERE r.user = :user AND r.sharedCount = 0")
+	List<Routine> findAllUnsharedRoutinesByUser(@Param("user") User user);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/RoutineRepository.java
@@ -38,6 +38,6 @@ public interface RoutineRepository extends JpaRepository<Routine, Long>, Routine
 	)
 	int sumRoutineSharedCountByUser(@Param("user") User user);
 
-	@Query("SELECT r FROM Routine r WHERE r.user = :user AND r.sharedCount = 0")
+	@Query("SELECT r FROM Routine r WHERE r.user = :user AND r.sharedCount = 0 AND r.deletedAt IS null")
 	List<Routine> findAllUnsharedRoutinesByUser(@Param("user") User user);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
@@ -16,4 +16,5 @@ public interface RoutineRepositoryCustom {
 
 	boolean isActiveForDate(final Routine routine, final LocalDate date);
 
+	void deleteAllUnsharedRoutinesByUser(User user);
 }

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
@@ -69,6 +69,17 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 		return fetchOne != null;
 	}
 
+	@Override
+	public void deleteAllUnsharedRoutinesByUser(User user) {
+		queryFactory.update(qRoutine)
+			.set(qRoutine.deletedAt, LocalDateTime.now())
+			.where(
+				qRoutine.user.eq(user)
+					.and(qRoutine.sharedCount.eq(0))
+			)
+			.execute();
+	}
+
 	private BooleanExpression routineNotDeleted() {
 		return qRoutine.deletedAt.isNull();
 	}

--- a/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
+++ b/src/main/java/im/toduck/domain/social/domain/service/SocialBoardService.java
@@ -92,6 +92,12 @@ public class SocialBoardService {
 	}
 
 	@Transactional
+	public void deleteAllSocialBoardsByUser(User user) {
+		List<Social> socials = socialRepository.findAllByUser(user);
+		socials.forEach(this::deleteSocialBoard);
+	}
+
+	@Transactional
 	public void updateSocialBoard(
 		final User user,
 		final Social socialBoard,

--- a/src/main/java/im/toduck/domain/social/persistence/repository/SocialRepository.java
+++ b/src/main/java/im/toduck/domain/social/persistence/repository/SocialRepository.java
@@ -1,13 +1,18 @@
 package im.toduck.domain.social.persistence.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import im.toduck.domain.social.persistence.entity.Social;
 import im.toduck.domain.social.persistence.repository.querydsl.SocialRepositoryCustom;
+import im.toduck.domain.user.persistence.entity.User;
 
 public interface SocialRepository extends JpaRepository<Social, Long>, SocialRepositoryCustom {
 	@Query("select count(s) from Social s where s.user.id = :userId and s.deletedAt is null")
 	long countByUserId(@Param("userId") Long userId);
+
+	List<Social> findAllByUser(User user);
 }

--- a/src/main/java/im/toduck/domain/user/domain/service/FollowService.java
+++ b/src/main/java/im/toduck/domain/user/domain/service/FollowService.java
@@ -30,6 +30,11 @@ public class FollowService {
 		followRepository.delete(follow);
 	}
 
+	@Transactional
+	public void deleteAllFollowsByUser(final User user) {
+		followRepository.deleteAllByUser(user);
+	}
+
 	@Transactional(readOnly = true)
 	public boolean isFollowing(final User follower, final User followed) {
 		return followRepository.existsByFollowerAndFollowed(follower, followed);

--- a/src/main/java/im/toduck/domain/user/domain/service/UserService.java
+++ b/src/main/java/im/toduck/domain/user/domain/service/UserService.java
@@ -87,4 +87,14 @@ public class UserService {
 	public boolean isBlockedUser(User blocker, User blockedUser) {
 		return blockRepository.existsByBlockerAndBlocked(blocker, blockedUser);
 	}
+
+	@Transactional
+	public void deleteAllBlocksByUser(User user) {
+		blockRepository.deleteAllByUser(user);
+	}
+
+	@Transactional
+	public void softDelete(User user) {
+		userRepository.softDelete(user);
+	}
 }

--- a/src/main/java/im/toduck/domain/user/persistence/repository/BlockRepository.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/BlockRepository.java
@@ -3,6 +3,9 @@ package im.toduck.domain.user.persistence.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import im.toduck.domain.user.persistence.entity.Block;
 import im.toduck.domain.user.persistence.entity.User;
@@ -12,4 +15,8 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 	boolean existsByBlockerAndBlocked(User blocker, User blocked);
 
 	Optional<Block> findByBlockerAndBlocked(User blocker, User blocked);
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM Block b WHERE b.blocked = :user OR b.blocker = :user")
+	void deleteAllByUser(@Param("user") User user);
 }

--- a/src/main/java/im/toduck/domain/user/persistence/repository/FollowRepository.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/FollowRepository.java
@@ -3,6 +3,9 @@ package im.toduck.domain.user.persistence.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import im.toduck.domain.user.persistence.entity.Follow;
 import im.toduck.domain.user.persistence.entity.User;
@@ -15,4 +18,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 	long countByFollower_Id(Long followerId);
 
 	long countByFollowed_Id(Long followedId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM Follow f WHERE f.follower = :user OR f.followed = :user")
+	void deleteAllByUser(@Param("user") User user);
 }

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
@@ -6,4 +6,6 @@ public interface UserRepositoryCustom {
 	void updateNickname(User user, String nickname);
 
 	void updateProfileImageUrl(User user, String imageUrl);
+
+	void softDelete(User user);
 }

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
@@ -1,5 +1,7 @@
 package im.toduck.domain.user.persistence.repository.querydsl;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -26,6 +28,16 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 	public void updateProfileImageUrl(User user, String imageUrl) {
 		queryFactory.update(qUser)
 			.set(qUser.imageUrl, imageUrl)
+			.where(qUser.id.eq(user.getId()))
+			.execute();
+	}
+
+	@Override
+	public void softDelete(User user) {
+		queryFactory.update(qUser)
+			.set(qUser.nickname, (String)null)
+			.set(qUser.imageUrl, (String)null)
+			.set(qUser.deletedAt, LocalDateTime.now())
 			.where(qUser.id.eq(user.getId()))
 			.execute();
 	}

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
@@ -43,9 +43,9 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 			.set(qUser.deletedAt, LocalDateTime.now())
 			.where(qUser.id.eq(user.getId()))
 			.execute();
-  }
+	}
 
-  @Override
+	@Override
 	public List<User> findBlockedUsersByUser(User user) {
 		return queryFactory.select(qBlock.blocked)
 			.from(qBlock)

--- a/src/test/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCaseTest.java
@@ -1,17 +1,31 @@
 package im.toduck.domain.mypage.domain.usecase;
 
+import static im.toduck.fixtures.user.BlockFixtures.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import im.toduck.ServiceTest;
+import im.toduck.domain.mypage.persistence.entity.AccountDeletionLog;
+import im.toduck.domain.mypage.persistence.entity.AccountDeletionReason;
+import im.toduck.domain.mypage.persistence.repository.AccountDeletionLogRepository;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.request.UserDeleteRequest;
+import im.toduck.domain.social.persistence.entity.Social;
+import im.toduck.domain.social.persistence.repository.SocialRepository;
+import im.toduck.domain.user.persistence.entity.Block;
+import im.toduck.domain.user.persistence.entity.Follow;
 import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.domain.user.persistence.repository.BlockRepository;
+import im.toduck.domain.user.persistence.repository.FollowRepository;
 import im.toduck.domain.user.persistence.repository.UserRepository;
+import im.toduck.fixtures.social.SocialFixtures;
 import im.toduck.fixtures.user.UserFixtures;
 import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
@@ -23,6 +37,18 @@ public class MyPageUseCaseTest extends ServiceTest {
 
 	@Autowired
 	private UserRepository userRepository;
+
+	@Autowired
+	private AccountDeletionLogRepository accountDeletionLogRepository;
+
+	@Autowired
+	private FollowRepository followRepository;
+
+	@Autowired
+	private BlockRepository blockRepository;
+
+	@Autowired
+	private SocialRepository socialRepository;
 
 	@Nested
 	@DisplayName("닉네임 변경 시")
@@ -73,6 +99,67 @@ public class MyPageUseCaseTest extends ServiceTest {
 
 			// then
 			assertThat(userRepository.findById(user.getId()).get().getImageUrl()).isEqualTo(imageUrl);
+		}
+	}
+
+	@Nested
+	@DisplayName("회원 탈퇴 시")
+	class DeleteAccount {
+		private User user;
+		private UserDeleteRequest request;
+
+		@BeforeEach
+		void setUp() {
+			user = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+
+			AccountDeletionReason reasonCode = AccountDeletionReason.OTHER;
+			String reasonText = "파이팅";
+			request = new UserDeleteRequest(reasonCode, reasonText);
+		}
+
+		@Test
+		public void 회원_탈퇴를_할_수_있다() {
+			// when
+			myPageUseCase.deleteAccount(user.getId(), request);
+
+			// then
+			assertSoftly(softly -> {
+				User deletedUser = userRepository.findById(user.getId()).get();
+				assertThat(deletedUser.getNickname()).isEqualTo(User.DELETED_MEMBER_NICKNAME);
+				assertThat(deletedUser.getImageUrl()).isNull();
+				assertThat(deletedUser.getDeletedAt()).isNotNull();
+
+				AccountDeletionLog log = accountDeletionLogRepository.findByUser(deletedUser).get();
+				assertThat(log.getReasonCode()).isEqualTo(request.reasonCode());
+				assertThat(log.getReasonText()).isEqualTo(request.reasonText());
+			});
+		}
+
+		@Test
+		public void 회원_탈퇴_시_공개된_관련_데이터가_삭제된다() {
+			// given
+			User followingUser = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+			Follow following = testFixtureBuilder.buildFollow(user, followingUser);
+
+			User blockedUser = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+			Block block = testFixtureBuilder.buildBlock(BLOCK_USER(user, blockedUser));
+
+			Social social = testFixtureBuilder.buildSocial(SocialFixtures.SINGLE_SOCIAL(user, false));
+
+			// when
+			myPageUseCase.deleteAccount(user.getId(), request);
+
+			// then
+			assertSoftly(softly -> {
+				assertThat(followRepository.findById(following.getId())).isEmpty();
+				assertThat(blockRepository.findById(block.getId())).isEmpty();
+				assertThat(socialRepository.findById(social.getId())).isEmpty();
+			});
+		}
+
+		@Test
+		public void 회원_탈퇴_시_비공개된_관련_데이터가_삭제된다() {
+			// TODO. diary, routine, concentration, schedule 관련 테스트
 		}
 	}
 }


### PR DESCRIPTION
## ✨ 작업 내용


**1️⃣ 회원 탈퇴 사유 저장**

- 회원 탈퇴 사유에 대해 추후 활용 가능성이 높지 않을까 생각하여, 데이터베이스 상에서도 남길 수 있도록 하였습니다.
- 테이블의 생성 SQL문은 다음과 같습니다.
```MySQL
CREATE TABLE account_deletion_log
(
    id          BIGINT PRIMARY KEY auto_increment,
    user_id     BIGINT                                                                                      NOT NULL,
    reason_code ENUM ('HARD_TO_USE', 'NO_FEATURES', 'MANY_ERRORS', 'BETTER_APP', 'SWITCH_ACCOUNT', 'OTHER') NOT NULL,
    reason_text VARCHAR(130)                                                                                NOT NULL,
    created_at  DATETIME                                                                                    NOT NULL,
    FOREIGN KEY (user_id) REFERENCES users (id)
);
```
<br/>

**2️⃣ 회원 연관 데이터 삭제**

- `Follow`와 `Block`의 경우 `hard delete`, 나머지 경우는 `soft delete`를 적용했습니다. (기존 각 도메인의 삭제 요청 시 삭제 전략과 동일)
- 다른 사람에게 공개되기 때문에 즉각 반영되어야 하는 데이터(`Follow`, `Block`, `Social`)에 대한 테스트만 작성하였고, 나머지 내용의 경우 추후 성능 최적화를 위해 배치 처리 등의 방식으로 리팩토링 할 예정입니다.
- `Schedule`의 경우 기존 삭제 로직이 복잡하여 조금 더 고민이 필요할 것 같아 추후 리팩토링 할 때 추가할 예정입니다.
<br/>

## 🚨 이슈
- `Routine`의 벌크 연산과 관련하여(추정) `Social`이 업데이트 되지 않는 현상으로 테스트가 실패하였습니다. 
- `flush`를 Routine의 벌크 연산을 수행하는 함수에서 수행할 때만  테스트가 성공하고, `User`를 soft delete할 때나 테스트 코드 내에서 `flush`를 발생시킬 때도 반영되지 않았습니다.
- `Routine` 로직은 추후 따로 성능 최적화를 위해 따로 처리할 예정이었기 때문에 우선 주석 처리로 해당 로직이 실행되지 않도록 해두었으나, 이와 관련하여 혹시 원인이나 해결 방법을 아시는 분은 알려주시면 감사하겠습니다!
