### PR TITLE
여러 날짜에 대한 루틴 기록 조회 기능 추가

### DIFF
--- a/src/main/java/im/toduck/domain/routine/common/dto/DailyRoutineData.java
+++ b/src/main/java/im/toduck/domain/routine/common/dto/DailyRoutineData.java
@@ -1,0 +1,17 @@
+package im.toduck.domain.routine.common.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+
+public record DailyRoutineData(
+	LocalDate date,
+	List<Routine> routines,
+	List<RoutineRecord> routineRecords
+) {
+	public static DailyRoutineData of(LocalDate date, List<Routine> routines, List<RoutineRecord> routineRecords) {
+		return new DailyRoutineData(date, routines, routineRecords);
+	}
+}

--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -5,13 +5,14 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Stream;
 
+import im.toduck.domain.routine.common.dto.DailyRoutineData;
 import im.toduck.domain.routine.persistence.entity.Routine;
-import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.routine.persistence.vo.PlanCategoryColor;
 import im.toduck.domain.routine.persistence.vo.RoutineMemo;
 import im.toduck.domain.routine.presentation.dto.request.RoutineCreateRequest;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineAvailableListResponse;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadListResponse;
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadMultipleDatesResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
 import im.toduck.domain.social.presentation.dto.response.UserProfileRoutineListResponse;
@@ -47,16 +48,32 @@ public class RoutineMapper {
 			.build();
 	}
 
-	public static MyRoutineRecordReadListResponse toMyRoutineRecordReadListResponse(
-		final LocalDate queryDate,
-		final List<Routine> routines,
-		final List<RoutineRecord> routineRecords
+	public static MyRoutineRecordReadMultipleDatesResponse toMyRoutineRecordReadMultipleDatesResponse(
+		final LocalDate startDate,
+		final LocalDate endDate,
+		final List<DailyRoutineData> dailyRoutineDatas
 	) {
-		List<MyRoutineRecordReadListResponse.MyRoutineReadResponse> routineResponses = routines.stream()
+		List<MyRoutineRecordReadListResponse> dateRoutines = dailyRoutineDatas.stream()
+			.map(RoutineMapper::toMyRoutineRecordReadListResponse)
+			.toList();
+
+		return MyRoutineRecordReadMultipleDatesResponse.builder()
+			.startDate(startDate)
+			.endDate(endDate)
+			.dateRoutines(dateRoutines)
+			.build();
+	}
+
+	public static MyRoutineRecordReadListResponse toMyRoutineRecordReadListResponse(
+		final DailyRoutineData dailyRoutineData
+	) {
+		List<MyRoutineRecordReadListResponse.MyRoutineReadResponse> routineResponses = dailyRoutineData.routines()
+			.stream()
 			.map(routine -> toMyRoutineRecordReadResponse(routine, INCOMPLETE_STATUS))
 			.toList();
 
-		List<MyRoutineRecordReadListResponse.MyRoutineReadResponse> recordResponses = routineRecords.stream()
+		List<MyRoutineRecordReadListResponse.MyRoutineReadResponse> recordResponses = dailyRoutineData.routineRecords()
+			.stream()
 			.map(record -> toMyRoutineRecordReadResponse(record.getRoutine(), record.getIsCompleted()))
 			.toList();
 
@@ -64,7 +81,7 @@ public class RoutineMapper {
 			Stream.concat(routineResponses.stream(), recordResponses.stream()).toList();
 
 		return MyRoutineRecordReadListResponse.builder()
-			.queryDate(queryDate)
+			.queryDate(dailyRoutineData.date())
 			.routines(combinedResponses)
 			.build();
 	}

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineRecordService.java
@@ -23,8 +23,18 @@ import lombok.extern.slf4j.Slf4j;
 public class RoutineRecordService {
 	private final RoutineRecordRepository routineRecordRepository;
 
+	@Transactional(readOnly = true)
 	public List<RoutineRecord> getRecordsIncludingDeleted(final User user, final LocalDate date) {
-		return routineRecordRepository.findRoutineRecordsForUserAndDate(user, date);
+		return routineRecordRepository.findAllByUserAndRecordAtDate(user, date);
+	}
+
+	@Transactional(readOnly = true)
+	public List<RoutineRecord> getRecordsBetweenDates(
+		final User user,
+		final LocalDate startDate,
+		final LocalDate endDate
+	) {
+		return routineRecordRepository.findAllByUserAndRecordAtBetween(user, startDate, endDate);
 	}
 
 	@Transactional

--- a/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
+++ b/src/main/java/im/toduck/domain/routine/domain/service/RoutineService.java
@@ -1,12 +1,19 @@
 package im.toduck.domain.routine.domain.service;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import im.toduck.domain.routine.common.dto.DailyRoutineData;
 import im.toduck.domain.routine.common.mapper.RoutineMapper;
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
@@ -33,12 +40,56 @@ public class RoutineService {
 		);
 	}
 
+	@Transactional(readOnly = true)
 	public List<Routine> getUnrecordedRoutinesForDate(
 		final User user,
 		final LocalDate date,
 		final List<RoutineRecord> routineRecords
 	) {
-		return routineRepository.findUnrecordedRoutinesForDate(user, date, routineRecords);
+		return routineRepository.findUnrecordedRoutinesByDateMatchingDayOfWeek(user, date, routineRecords);
+	}
+
+	@Transactional(readOnly = true)
+	public List<DailyRoutineData> getRoutineDataByDateRange(
+		final User user,
+		final LocalDate startDate,
+		final LocalDate endDate,
+		final List<RoutineRecord> routineRecords
+	) {
+		List<Routine> periodRoutines = routineRepository.findRoutinesByDateBetween(
+			user, startDate, endDate
+		);
+
+		Map<LocalDate, List<RoutineRecord>> recordsByDate = routineRecords.stream()
+			.collect(Collectors.groupingBy(record -> record.getRecordAt().toLocalDate()));
+
+		List<DailyRoutineData> result = new ArrayList<>();
+		LocalDate currentDate = startDate;
+
+		while (!currentDate.isAfter(endDate)) {
+			final LocalDate date = currentDate;
+
+			List<RoutineRecord> dateRoutineRecords = recordsByDate.getOrDefault(date, Collections.emptyList());
+
+			Set<Long> recordedRoutineIds = dateRoutineRecords.stream()
+				.map(record -> record.getRoutine().getId())
+				.collect(Collectors.toSet());
+
+			List<Routine> dateUnrecordedRoutines = periodRoutines.stream()
+				.filter(routine -> !recordedRoutineIds.contains(routine.getId()))
+				.filter(routine -> routine.getDaysOfWeekBitmask().includesDayOf(date))
+				.filter(routine -> !routine.getScheduleModifiedAt().isAfter(date.atTime(LocalTime.MAX)))
+				.toList();
+
+			List<RoutineRecord> activeDateRoutineRecords = dateRoutineRecords.stream()
+				.filter(record -> !record.isInDeletedState())
+				.toList();
+
+			result.add(DailyRoutineData.of(date, dateUnrecordedRoutines, activeDateRoutineRecords));
+			currentDate = currentDate.plusDays(1);
+		}
+
+		return result;
 	}
 
 	public Optional<Routine> getUserRoutine(final User user, final Long id) {

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustom.java
@@ -10,7 +10,11 @@ import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.user.persistence.entity.User;
 
 public interface RoutineRecordRepositoryCustom {
-	List<RoutineRecord> findRoutineRecordsForUserAndDate(final User user, final LocalDate date);
+	List<RoutineRecord> findAllByUserAndRecordAtDate(final User user, final LocalDate date);
+
+	List<RoutineRecord> findAllByUserAndRecordAtBetween(
+		final User user, final LocalDate startDate, final LocalDate endDate
+	);
 
 	Optional<RoutineRecord> findByRoutineAndRecordDate(
 		final Routine routine,

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRecordRepositoryCustomImpl.java
@@ -26,13 +26,25 @@ public class RoutineRecordRepositoryCustomImpl implements RoutineRecordRepositor
 	private final QRoutineRecord qRecord = QRoutineRecord.routineRecord;
 
 	@Override
-	public List<RoutineRecord> findRoutineRecordsForUserAndDate(User user, LocalDate date) {
+	public List<RoutineRecord> findAllByUserAndRecordAtDate(User user, LocalDate date) {
 		return queryFactory
 			.selectFrom(qRecord)
 			.join(qRecord.routine, qRoutine).fetchJoin()
 			.where(
 				qRoutine.user.eq(user),
 				recordAtBetween(date)
+			)
+			.fetch();
+	}
+
+	@Override
+	public List<RoutineRecord> findAllByUserAndRecordAtBetween(User user, LocalDate startDate, LocalDate endDate) {
+		return queryFactory
+			.selectFrom(qRecord)
+			.join(qRecord.routine, qRoutine).fetchJoin()
+			.where(
+				qRoutine.user.eq(user),
+				recordAtBetweenDates(startDate, endDate)
 			)
 			.fetch();
 	}
@@ -57,6 +69,13 @@ public class RoutineRecordRepositoryCustomImpl implements RoutineRecordRepositor
 		return qRecord.recordAt.between(
 			date.atStartOfDay(),
 			date.plusDays(1).atStartOfDay().minusNanos(1)
+		);
+	}
+
+	private BooleanExpression recordAtBetweenDates(LocalDate startDate, LocalDate endDate) {
+		return qRecord.recordAt.between(
+			startDate.atStartOfDay(),
+			endDate.plusDays(1).atStartOfDay().minusNanos(1)
 		);
 	}
 

--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustom.java
@@ -8,10 +8,16 @@ import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.user.persistence.entity.User;
 
 public interface RoutineRepositoryCustom {
-	List<Routine> findUnrecordedRoutinesForDate(
+	List<Routine> findUnrecordedRoutinesByDateMatchingDayOfWeek(
 		final User user,
 		final LocalDate date,
 		final List<RoutineRecord> routineRecords
+	);
+
+	List<Routine> findRoutinesByDateBetween(
+		final User user,
+		final LocalDate startDate,
+		final LocalDate endDate
 	);
 
 	boolean isActiveForDate(final Routine routine, final LocalDate date);

--- a/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/api/RoutineApi.java
@@ -14,6 +14,7 @@ import im.toduck.domain.routine.presentation.dto.request.RoutinePutCompletionReq
 import im.toduck.domain.routine.presentation.dto.request.RoutineUpdateRequest;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineAvailableListResponse;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadListResponse;
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadMultipleDatesResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
@@ -58,6 +59,24 @@ public interface RoutineApi {
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
 		@Parameter(description = "조회할 루틴의 날짜 (형식: YYYY-MM-DD)", required = true, example = "2024-09-02")
 		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+	);
+
+	@Operation(
+		summary = "여러 날짜에 대한 본인 루틴 기록 목록 조회",
+		description = "지정된 기간 내 자신의 루틴 기록 목록을 날짜별로 조회합니다. 최대 조회 가능 기간은 31일입니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = MyRoutineRecordReadMultipleDatesResponse.class,
+			description = "여러 날짜에 대한 루틴 목록 조회 성공, 각 날짜별로 루틴 정보를 포함하는 목록을 반환합니다."
+		)
+	)
+	ResponseEntity<ApiResponse<MyRoutineRecordReadMultipleDatesResponse>> getMyRoutineListMultipleDates(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@Parameter(description = "조회 시작 날짜 (형식: YYYY-MM-DD)", required = true, example = "2024-09-01")
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+		@Parameter(description = "조회 종료 날짜 (형식: YYYY-MM-DD)", required = true, example = "2024-09-07")
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
 	);
 
 	@Operation(

--- a/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/controller/RoutineController.java
@@ -23,6 +23,7 @@ import im.toduck.domain.routine.presentation.dto.request.RoutinePutCompletionReq
 import im.toduck.domain.routine.presentation.dto.request.RoutineUpdateRequest;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineAvailableListResponse;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadListResponse;
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadMultipleDatesResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
 import im.toduck.global.presentation.ApiResponse;
@@ -58,6 +59,21 @@ public class RoutineController implements RoutineApi {
 	) {
 		return ResponseEntity.ok(
 			ApiResponse.createSuccess(routineUseCase.readMyRoutineRecordList(userDetails.getUserId(), date))
+		);
+	}
+
+	@Override
+	@GetMapping("/me/dates")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<MyRoutineRecordReadMultipleDatesResponse>> getMyRoutineListMultipleDates(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.createSuccess(
+				routineUseCase.readMyRoutineRecordListMultipleDates(userDetails.getUserId(), startDate, endDate)
+			)
 		);
 	}
 

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineRecordReadMultipleDatesResponse.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineRecordReadMultipleDatesResponse.java
@@ -1,0 +1,29 @@
+package im.toduck.domain.routine.presentation.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "여러 날짜에 대한 본인 루틴기록 목록 응답 DTO")
+@Builder
+public record MyRoutineRecordReadMultipleDatesResponse(
+	@JsonSerialize(using = LocalDateSerializer.class)
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	@Schema(description = "조회 시작 날짜", example = "2024-08-31")
+	LocalDate startDate,
+
+	@JsonSerialize(using = LocalDateSerializer.class)
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	@Schema(description = "조회 종료 날짜", example = "2024-09-06")
+	LocalDate endDate,
+
+	@Schema(description = "날짜별 루틴 목록")
+	List<MyRoutineRecordReadListResponse> dateRoutines
+) {
+}

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -117,6 +117,8 @@ public enum ExceptionCode {
 		"요청된 날짜에 대한 루틴 변경이 불가능합니다. 루틴의 반복 요일과 현재 날짜를 확인하고 올바른 날짜로 다시 요청해 주세요."),
 	PRIVATE_ROUTINE(HttpStatus.FORBIDDEN, 43203, "비공개된 루틴입니다.",
 		"요청하신 루틴은 비공개 상태입니다. 접근 권한이 없는 경우 접근할 수 없습니다."),
+	EXCEED_ROUTINE_DATE_RANGE(HttpStatus.BAD_REQUEST, 40304, "기간 범위가 유효하지 않거나, 최대 조회 범위를 초과했습니다.",
+		"루틴 범위 조회는 14일로 제한됩니다."),
 
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),

--- a/src/main/java/im/toduck/global/helper/DaysOfWeekBitmask.java
+++ b/src/main/java/im/toduck/global/helper/DaysOfWeekBitmask.java
@@ -92,6 +92,43 @@ public class DaysOfWeekBitmask {
 			.filter(this::includesDayOf);
 	}
 
+	/**
+	 * 시작일부터 종료일까지의 기간에 포함된 모든 요일에 대한 비트마스크를 생성합니다.
+	 * 예: 월요일부터 수요일까지의 기간은 0000111 (0x07) 반환
+	 * 일주일 이상의 기간은 항상 0111111 (0x7F) 반환
+	 *
+	 * @param startDate 시작일 (포함)
+	 * @param endDate 종료일 (포함)
+	 * @return 기간에 포함된 모든 요일에 대한 비트마스크
+	 */
+	public static DaysOfWeekBitmask createFromDateRange(LocalDate startDate, LocalDate endDate) {
+		if (startDate.plusDays(6).isBefore(endDate) || startDate.plusDays(6).isEqual(endDate)) {
+			return new DaysOfWeekBitmask(DayBitmasks.ALL_DAYS);
+		}
+
+		byte bitmask = 0;
+		LocalDate current = startDate;
+
+		while (!current.isAfter(endDate)) {
+			bitmask |= getDayBitmask(current.getDayOfWeek());
+			current = current.plusDays(1);
+		}
+
+		return new DaysOfWeekBitmask(bitmask);
+	}
+
+	/**
+	 * 시작일부터 종료일까지의 기간에 포함된 모든 요일에 대한 비트마스크 값을 반환합니다.
+	 * 내부 구현을 숨기고 바이트 값만 필요한 경우 사용합니다.
+	 *
+	 * @param startDate 시작일 (포함)
+	 * @param endDate 종료일 (포함)
+	 * @return 기간에 포함된 모든 요일에 대한 비트마스크 값
+	 */
+	public static byte getDaysOfWeekBitmaskValueInRange(LocalDate startDate, LocalDate endDate) {
+		return createFromDateRange(startDate, endDate).getValue();
+	}
+
 	public byte getValue() {
 		return bitmask;
 	}

--- a/src/test/java/im/toduck/architecture/main/domain/LayeredArchitectureTest.java
+++ b/src/test/java/im/toduck/architecture/main/domain/LayeredArchitectureTest.java
@@ -34,10 +34,14 @@ public class LayeredArchitectureTest {
 		)
 		.whereLayer(MAPPER.name()).mayOnlyBeAccessedByLayers(SERVICE.name(), USECASE.name())
 
+		// QueryDSL 제외
 		.ignoreDependency(JavaClass.Predicates.simpleNameStartingWith("Q"),
 			JavaClass.Predicates.resideInAnyPackage(".."))
-		.ignoreDependency(JavaClass.Predicates.resideInAPackage("..global.."),
-			JavaClass.Predicates.resideInAnyPackage(".."));
+		.ignoreDependency(
+			JavaClass.Predicates.resideInAPackage("..global..")
+				.or(JavaClass.Predicates.resideInAPackage("..common.dto..")),
+			JavaClass.Predicates.resideInAnyPackage("..")
+		);
 
 	@ArchTest
 	static final ArchRule 오직_Entity_레이어의_enum_만_DTO_에서_사용될_수_있다 =

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
@@ -14,8 +14,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +42,7 @@ import im.toduck.domain.routine.persistence.repository.RoutineRepository;
 import im.toduck.domain.routine.presentation.dto.request.RoutinePutCompletionRequest;
 import im.toduck.domain.routine.presentation.dto.request.RoutineUpdateRequest;
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadListResponse;
+import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadMultipleDatesResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.exception.CommonException;
@@ -186,6 +192,285 @@ class RoutineUseCaseTest extends ServiceTest {
 				softly.assertThat(response.isCompleted()).isEqualTo(ROUTINE_RECORD.getIsCompleted());
 				softly.assertThat(response.time()).isEqualTo(ROUTINE_RECORD.getRecordAt().toLocalTime());
 			});
+		}
+	}
+
+	@Nested
+	@DisplayName("특정 기간 내 루틴 목록 조회시")
+	class ReadMyRoutineRecordListMultipleDatesTest {
+
+		@BeforeEach
+		void setUp() {
+			// given
+			given(userService.getUserById(any(Long.class))).willReturn(Optional.ofNullable(USER));
+		}
+
+		@Test
+		void 여러_날짜에_대한_루틴_기록_조회_시_기간_내_모든_루틴과_상태가_정확히_조회된다() {
+			// given
+			// 1. 평일 루틴(월-금) - 기록이 있는 루틴
+			Routine weekdayRoutine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.scheduleModifiedAt("2024-12-01 01:00:00")
+					.build()
+			);
+
+			// 2. 주말 루틴(토-일) - 기록이 없는 루틴
+			Routine weekendRoutine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKEND_NOON_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.scheduleModifiedAt("2024-12-01 01:00:00")
+					.build()
+			);
+
+			// 3. 매일 루틴 - 일부만 기록이 있는 루틴
+			Routine dailyRoutine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_DAILY_EVENING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.scheduleModifiedAt("2024-12-01 01:00:00")
+					.build()
+			);
+
+			// 4. 삭제된 루틴 - 기록이 있는 루틴
+			Routine deletedRoutine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_MONDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.scheduleModifiedAt("2024-12-01 01:00:00")
+					.deletedAt("2024-12-03 01:00:00")
+					.build()
+			);
+
+			// 테스트 기간 설정 - 월요일부터 일요일까지 일주일
+			LocalDate startDate = LocalDate.parse("2024-12-02"); // 월요일
+			LocalDate endDate = LocalDate.parse("2024-12-08");   // 일요일
+
+			// 루틴 기록 생성
+			// 월요일 - 평일 루틴 완료, 매일 루틴 완료, 삭제된 루틴 완료
+			testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(weekdayRoutine).recordAt("2024-12-02 07:00:00").build()
+			);
+			testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(dailyRoutine).recordAt("2024-12-02 19:00:00").build()
+			);
+			testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(deletedRoutine).recordAt("2024-12-02 07:00:00").build()
+			);
+
+			// 화요일 - 평일 루틴 미완료
+			testFixtureBuilder.buildRoutineRecord(
+				INCOMPLETED_RECORD(weekdayRoutine).recordAt("2024-12-03 07:00:00").build()
+			);
+
+			// 수요일 - 매일 루틴 완료
+			testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(dailyRoutine).recordAt("2024-12-04 19:00:00").build()
+			);
+
+			// 금요일 - 매일 루틴 완료
+			testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(dailyRoutine).recordAt("2024-12-06 19:00:00").build()
+			);
+
+			// when
+			MyRoutineRecordReadMultipleDatesResponse response =
+				routineUseCase.readMyRoutineRecordListMultipleDates(USER.getId(), startDate, endDate);
+
+			// then
+			// 기대되는 루틴 목록 정의: 날짜 -> (루틴ID, 완료 여부)
+			Map<LocalDate, Map<Long, Boolean>> expectedRoutinesByDate = Map.of(
+				LocalDate.parse("2024-12-02"), Map.of(
+					weekdayRoutine.getId(), true,
+					dailyRoutine.getId(), true,
+					deletedRoutine.getId(), true
+				),
+				LocalDate.parse("2024-12-03"), Map.of(
+					weekdayRoutine.getId(), false,
+					dailyRoutine.getId(), false
+				),
+				LocalDate.parse("2024-12-04"), Map.of(
+					weekdayRoutine.getId(), false,
+					dailyRoutine.getId(), true
+				),
+				LocalDate.parse("2024-12-05"), Map.of(
+					weekdayRoutine.getId(), false,
+					dailyRoutine.getId(), false
+				),
+				LocalDate.parse("2024-12-06"), Map.of(
+					weekdayRoutine.getId(), false,
+					dailyRoutine.getId(), true
+				),
+				LocalDate.parse("2024-12-07"), Map.of(
+					weekendRoutine.getId(), false,
+					dailyRoutine.getId(), false
+				),
+				LocalDate.parse("2024-12-08"), Map.of(
+					weekendRoutine.getId(), false,
+					dailyRoutine.getId(), false
+				)
+			);
+
+			// 검증
+			assertSoftly(softly -> {
+				Map<LocalDate, List<MyRoutineRecordReadListResponse.MyRoutineReadResponse>> routinesByDate =
+					response.dateRoutines().stream()
+						.collect(Collectors.toMap(
+							MyRoutineRecordReadListResponse::queryDate,
+							MyRoutineRecordReadListResponse::routines
+						));
+
+				expectedRoutinesByDate.forEach((date, expectedRoutines) -> {
+					List<MyRoutineRecordReadListResponse.MyRoutineReadResponse> routines = routinesByDate.get(date);
+					Set<Long> actualIds = routines.stream()
+						.map(MyRoutineRecordReadListResponse.MyRoutineReadResponse::routineId)
+						.collect(Collectors.toSet());
+
+					expectedRoutines.forEach((expectedId, expectedCompleted) -> {
+						Optional<MyRoutineRecordReadListResponse.MyRoutineReadResponse> found =
+							routines.stream().filter(r -> r.routineId().equals(expectedId)).findFirst();
+
+						softly.assertThat(found)
+							.as("%s - 루틴(ID: %d)이 존재해야 함", date, expectedId)
+							.isPresent();
+
+						found.ifPresent(r ->
+							softly.assertThat(r.isCompleted())
+								.as("%s - 루틴(ID: %d)의 완료 여부", date, expectedId)
+								.isEqualTo(expectedCompleted)
+						);
+					});
+
+					// 응답에 존재하지 않아야 하는 루틴 체크
+					Set<Long> expectedIds = expectedRoutines.keySet();
+					Set<Long> unexpectedIds = new HashSet<>(Set.of(
+						weekdayRoutine.getId(),
+						dailyRoutine.getId(),
+						deletedRoutine.getId(),
+						weekendRoutine.getId()
+					));
+					unexpectedIds.removeAll(expectedIds);
+
+					unexpectedIds.forEach(unexpectedId ->
+						softly.assertThat(actualIds)
+							.as("%s - 루틴(ID: %d)는 존재하지 않아야 함", date, unexpectedId)
+							.doesNotContain(unexpectedId)
+					);
+				});
+			});
+
+		}
+
+		@Test
+		void 다중_날짜_조회_결과는_각_날짜별_단일_조회_결과와_동일해야_한다() {
+			// given
+			// 1. 평일 루틴(월-금)
+			Routine weekdayRoutine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKDAY_MORNING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.scheduleModifiedAt("2024-12-01 01:00:00")
+					.build()
+			);
+
+			// 2. 주말 루틴(토-일)
+			Routine weekendRoutine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_WEEKEND_NOON_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.scheduleModifiedAt("2024-12-01 01:00:00")
+					.build()
+			);
+
+			// 3. 매일 루틴
+			Routine dailyRoutine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+				PUBLIC_DAILY_EVENING_ROUTINE(USER)
+					.createdAt("2024-11-29 01:00:00")
+					.scheduleModifiedAt("2024-12-01 01:00:00")
+					.build()
+			);
+
+			// 루틴 기록 생성
+			testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(weekdayRoutine).recordAt("2024-12-02 07:00:00").build()  // 월요일 완료
+			);
+			testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(dailyRoutine).recordAt("2024-12-03 19:00:00").build()    // 화요일 완료
+			);
+			testFixtureBuilder.buildRoutineRecord(
+				COMPLETED_RECORD(weekendRoutine).recordAt("2024-12-07 12:00:00").build()  // 토요일 완료
+			);
+
+			// 테스트 기간 설정 - 월요일부터 일요일까지 일주일
+			LocalDate startDate = LocalDate.parse("2024-12-02"); // 월요일
+			LocalDate endDate = LocalDate.parse("2024-12-08");   // 일요일
+
+			// when
+			// 1. 다중 날짜 조회 결과 가져오기
+			MyRoutineRecordReadMultipleDatesResponse multipleResponse =
+				routineUseCase.readMyRoutineRecordListMultipleDates(USER.getId(), startDate, endDate);
+
+			// 2. 각 날짜별 단일 조회 결과 가져오기
+			Map<LocalDate, Map<Long, Boolean>> singleResponsesMap = new HashMap<>();
+			LocalDate currentDate = startDate;
+			while (!currentDate.isAfter(endDate)) {
+				MyRoutineRecordReadListResponse singleResponse =
+					routineUseCase.readMyRoutineRecordList(USER.getId(), currentDate);
+
+				// 루틴 ID -> 완료 상태 맵핑
+				Map<Long, Boolean> routineStatusMap = singleResponse.routines().stream()
+					.collect(Collectors.toMap(
+						MyRoutineRecordReadListResponse.MyRoutineReadResponse::routineId,
+						MyRoutineRecordReadListResponse.MyRoutineReadResponse::isCompleted
+					));
+
+				singleResponsesMap.put(currentDate, routineStatusMap);
+				currentDate = currentDate.plusDays(1);
+			}
+
+			// then
+			// 단순화된 검증: 각 날짜의 루틴 존재 여부와 완료 상태만 검증
+			assertSoftly(softly -> {
+				for (MyRoutineRecordReadListResponse dateResponse : multipleResponse.dateRoutines()) {
+					LocalDate date = dateResponse.queryDate();
+					Map<Long, Boolean> expectedRoutines = singleResponsesMap.get(date);
+
+					// 1. 루틴 개수 검증
+					softly.assertThat(dateResponse.routines()).hasSize(expectedRoutines.size());
+
+					// 2. 각 루틴의 존재 여부와 완료 상태 검증
+					for (MyRoutineRecordReadListResponse.MyRoutineReadResponse routine : dateResponse.routines()) {
+						Long routineId = routine.routineId();
+						Boolean isCompleted = routine.isCompleted();
+
+						softly.assertThat(expectedRoutines).containsKey(routineId);
+						softly.assertThat(isCompleted).isEqualTo(expectedRoutines.get(routineId));
+					}
+				}
+			});
+		}
+
+		@Test
+		void 기간이_최대_일수를_초과하면_예외가_발생한다() {
+			// given
+			LocalDate startDate = LocalDate.of(2024, 12, 1);
+			LocalDate endDate = startDate.plusDays(14); // 14일 (최대 13일까지만 허용)
+
+			// when & then
+			assertThatThrownBy(
+				() -> routineUseCase.readMyRoutineRecordListMultipleDates(USER.getId(), startDate, endDate))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(EXCEED_ROUTINE_DATE_RANGE.getMessage());
+		}
+
+		@Test
+		void 시작일이_종료일보다_이후면_예외가_발생한다() {
+			// given
+			LocalDate startDate = LocalDate.of(2024, 12, 10);
+			LocalDate endDate = LocalDate.of(2024, 12, 5); // 시작일보다 이전
+
+			// when & then
+			assertThatThrownBy(
+				() -> routineUseCase.readMyRoutineRecordListMultipleDates(USER.getId(), startDate, endDate))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(EXCEED_ROUTINE_DATE_RANGE.getMessage());
 		}
 	}
 

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRecordRepositoryTest.java
@@ -52,7 +52,7 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 			);
 
 			// when
-			List<RoutineRecord> records = routineRecordRepository.findRoutineRecordsForUserAndDate(
+			List<RoutineRecord> records = routineRecordRepository.findAllByUserAndRecordAtDate(
 				USER,
 				LocalDate.from(RECORD.getRecordAt())
 			);
@@ -93,7 +93,7 @@ class RoutineRecordRepositoryTest extends RepositoryTest {
 			);
 
 			// when
-			List<RoutineRecord> records = routineRecordRepository.findRoutineRecordsForUserAndDate(
+			List<RoutineRecord> records = routineRecordRepository.findAllByUserAndRecordAtDate(
 				USER,
 				LocalDate.from(RECORD_WEEKLY1_1.getRecordAt())
 			);

--- a/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
+++ b/src/test/java/im/toduck/domain/routine/persistence/repository/RoutineRepositoryTest.java
@@ -46,7 +46,8 @@ class RoutineRepositoryTest extends RepositoryTest {
 			LocalDate monday = LocalDate.parse("2024-12-02");
 
 			// when
-			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, monday, List.of());
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesByDateMatchingDayOfWeek(USER,
+				monday, List.of());
 
 			// then
 			assertThat(unrecordedRoutines).contains(ROUTINE);
@@ -64,7 +65,8 @@ class RoutineRepositoryTest extends RepositoryTest {
 			LocalDate monday = LocalDate.parse("2024-12-02");
 
 			// when
-			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, monday, List.of());
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesByDateMatchingDayOfWeek(USER,
+				monday, List.of());
 
 			// then
 			assertThat(unrecordedRoutines).doesNotContain(ROUTINE);
@@ -88,7 +90,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 			LocalDate monday = LocalDate.parse("2024-12-02");
 
 			// when
-			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesByDateMatchingDayOfWeek(
 				USER, monday, List.of(ROUTINE_RECORD1, ROUTINE_RECORD2)
 			);
 
@@ -121,7 +123,7 @@ class RoutineRepositoryTest extends RepositoryTest {
 			// when & then
 			assertSoftly(softly -> {
 				dates.forEach(date -> {
-					List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(
+					List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesByDateMatchingDayOfWeek(
 						USER, LocalDate.parse(date), List.of()
 					);
 
@@ -148,7 +150,8 @@ class RoutineRepositoryTest extends RepositoryTest {
 			LocalDate weekday = LocalDate.parse("2024-12-02");
 
 			// when
-			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, weekday,
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesByDateMatchingDayOfWeek(USER,
+				weekday,
 				List.of());
 
 			// then
@@ -168,7 +171,8 @@ class RoutineRepositoryTest extends RepositoryTest {
 			LocalDate monday = LocalDate.parse("2024-12-02");
 
 			// when
-			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, monday, List.of());
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesByDateMatchingDayOfWeek(USER,
+				monday, List.of());
 
 			// then
 			assertThat(unrecordedRoutines).doesNotContain(ROUTINE);
@@ -192,7 +196,8 @@ class RoutineRepositoryTest extends RepositoryTest {
 			LocalDate monday = LocalDate.parse("2024-12-09");
 
 			// when
-			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesForDate(USER, monday, List.of());
+			List<Routine> unrecordedRoutines = routineRepository.findUnrecordedRoutinesByDateMatchingDayOfWeek(USER,
+				monday, List.of());
 
 			// then
 			assertThat(unrecordedRoutines).contains(ALLDAY_ROUTINE, ROUTINE);


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 여러 날짜에 대한 루틴 기록 조회 API 추가**
- `/routines/me/dates?startDate=2024-12-02&endDate=2024-12-08` 엔드포인트 추가
- 단일 날짜가 아닌 기간으로 루틴과 루틴 기록을 조회할 수 있는 기능 구현
- 최대 조회 기간을 13일(`MAX_ROUTINE_DATE_RANGE_DAYS`)로 제한하여 성능과 리소스 사용량 최적화
- 시작일과 종료일이 유효한지 검증하는 로직 추가 (`ExceptionCode.EXCEED_ROUTINE_DATE_RANGE`)
  <br/>

**2️⃣ 날짜별 루틴 데이터 추상화를 위한 DailyRoutineData 추가**
- 특정 날짜의 모든 루틴 데이터를 담는 레코드 클래스 구현
- 날짜(`date`), 미완료 루틴 목록(`routines`), 루틴 기록 목록(`routineRecords`)을 캡슐화하여 코드 가독성 향상
- 기존 단일 날짜 조회 로직(`readMyRoutineRecordList`)도 DailyRoutineData를 활용하도록 리팩토링하여 코드 일관성 확보
- 서비스와 프레젠테이션 계층 간 데이터 전달 구조 개선
  <br/>

**3️⃣ 루틴 조회 로직 최적화**
- 날짜 범위 기반 쿼리 성능 최적화 
  - 특정 기간의 루틴을 한 번에 조회하는 메소드 추가 (`findRoutinesByDateBetween`)
  - 날짜 범위에 맞는 요일 비트마스크 필터링을 통한 쿼리 효율성 향상 (`routineMatchesDateRange`)
  - 요일 비트마스크 유틸리티에 날짜 범위 기능 확장 (`getDaysOfWeekBitmaskValueInRange`)
- 서비스 레이어에서 복잡한 필터링 로직 구현
  - 날짜별 루틴 기록 맵핑 및 중복 제거 처리
  - 특정 날짜에 해당하는 루틴만 필터링하는 로직 (`includesDayOf`, `scheduleModifiedAt` 검증)
  - 기간 내 삭제된 루틴 처리 및 삭제된 루틴 기록 필터링
  <br/>

**4️⃣ 테스트 작성**
- 여러 날짜 루틴 조회 기능에 대한 단위 테스트 추가
  - 다양한 상황에서의 루틴 목록 정확성 검증 (평일/주말/매일 루틴, 완료/미완료 상태 등)
  - **날짜별 단일 조회 결과와 다중 날짜 조회 결과의 일관성 테스트**
	- 두 기능이 서로 다른 DB 조회 및 필터링 로직을 사용하므로 결과 일치 여부 확인 필요
  - 날짜 범위 유효성 검증 테스트 (최대 기간 초과, 시작일>종료일 케이스)
  <br/>

## 📊 조회 API 처리 흐름도

```mermaid
graph LR
    A["RoutineUseCase<br>(기간 검증)"] --> B["RoutineRecordService<br>(기간 내 모든 루틴 기록 조회)"]
    B --> C["RoutineService<br>(활성화된 모든 루틴 조회 - 요일필터 없음)"]
    C --> D["RoutineService<br>(날짜별 처리 로직)"]
    D --> E["날짜별 필터링<br>① 요일 비트마스크 검사<br>② 이미 기록된 루틴 제외<br>③ 삭제된 루틴/기록 제외<br>④ 일정 변경일자 확인"]
    E --> F["DailyRoutineData 생성"]
```

1. 단일 날짜 조회는 해당 날짜에 맞는 요일 비트마스크로 직접 필터링된 쿼리를 실행
2. 다중 날짜 조회는 더 넓은 범위의 쿼리를 수행한 후 애플리케이션에서 날짜별로 필터링