### PR TITLE
마이페이지 - 차단한 유저 조회 API 개발

### DIFF
--- a/src/main/java/im/toduck/domain/mypage/common/mapper/MyPageMapper.java
+++ b/src/main/java/im/toduck/domain/mypage/common/mapper/MyPageMapper.java
@@ -1,0 +1,32 @@
+package im.toduck.domain.mypage.common.mapper;
+
+import java.util.List;
+
+import im.toduck.domain.mypage.presentation.dto.response.BlockedUsersResponse;
+import im.toduck.domain.mypage.presentation.dto.response.BlockedUsersResponse.BlockedUser;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MyPageMapper {
+
+	public static BlockedUsersResponse toBlockedUsersResponse(final List<User> blockedUsers) {
+		List<BlockedUser> blockedUserDtos = blockedUsers.stream()
+			.map(MyPageMapper::toBlockedUser)
+			.toList();
+
+		return BlockedUsersResponse.builder()
+			.blockedUsers(blockedUserDtos)
+			.build();
+	}
+
+	public static BlockedUser toBlockedUser(final User user) {
+		return BlockedUser.builder()
+			.userId(user.getId())
+			.nickname(user.getNickname())
+			.profileImageUrl(user.getImageUrl())
+			.build();
+
+	}
+}

--- a/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/service/MyPageService.java
@@ -1,5 +1,7 @@
 package im.toduck.domain.mypage.domain.service;
 
+import java.util.List;
+
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,5 +29,10 @@ public class MyPageService {
 	@Transactional
 	public void updateProfileImage(User user, String imageUrl) {
 		userRepository.updateProfileImageUrl(user, imageUrl);
+	}
+
+	@Transactional(readOnly = true)
+	public List<User> getBlockedUsers(final User user) {
+		return userRepository.findBlockedUsersByUser(user);
 	}
 }

--- a/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
+++ b/src/main/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCase.java
@@ -1,10 +1,14 @@
 package im.toduck.domain.mypage.domain.usecase;
 
+import java.util.List;
+
 import org.springframework.transaction.annotation.Transactional;
 
+import im.toduck.domain.mypage.common.mapper.MyPageMapper;
 import im.toduck.domain.mypage.domain.service.MyPageService;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.response.BlockedUsersResponse;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
@@ -42,5 +46,14 @@ public class MyPageUseCase {
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 
 		myPageService.updateProfileImage(user, request.imageUrl());
+	}
+
+	@Transactional(readOnly = true)
+	public BlockedUsersResponse getBlockedUsers(final Long userId) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+		List<User> blockedUsers = myPageService.getBlockedUsers(user);
+
+		return MyPageMapper.toBlockedUsersResponse(blockedUsers);
 	}
 }

--- a/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/api/MyPageApi.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.response.BlockedUsersResponse;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
@@ -65,4 +66,18 @@ public interface MyPageApi {
 		@RequestBody @Valid ProfileImageUpdateRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	);
+
+	@Operation(
+		summary = "차단한 유저 목록 조회",
+		description = "자신이 차단한 유저들의 목록을 조회합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "차단한 유저 목록 조회 성공, 차단한 유저들의 정보를 반환합니다."
+		)
+	)
+	ResponseEntity<ApiResponse<BlockedUsersResponse>> getBlockedUsers(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	);
+
 }

--- a/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/controller/MyPageController.java
@@ -15,6 +15,7 @@ import im.toduck.domain.mypage.domain.usecase.MyPageUseCase;
 import im.toduck.domain.mypage.presentation.api.MyPageApi;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.response.BlockedUsersResponse;
 import im.toduck.domain.mypage.presentation.dto.response.NickNameResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
@@ -59,4 +60,13 @@ public class MyPageController implements MyPageApi {
 		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
 	}
 
+	@Override
+	@GetMapping("/blocked-users")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<BlockedUsersResponse>> getBlockedUsers(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		BlockedUsersResponse response = myPageUseCase.getBlockedUsers(userDetails.getUserId());
+		return ResponseEntity.ok(ApiResponse.createSuccess(response));
+	}
 }

--- a/src/main/java/im/toduck/domain/mypage/presentation/dto/response/BlockedUsersResponse.java
+++ b/src/main/java/im/toduck/domain/mypage/presentation/dto/response/BlockedUsersResponse.java
@@ -1,0 +1,27 @@
+package im.toduck.domain.mypage.presentation.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "차단한 유저 목록 응답")
+@Builder
+public record BlockedUsersResponse(
+	@Schema(description = "차단한 유저 목록")
+	List<BlockedUser> blockedUsers
+) {
+	@Schema(description = "차단한 유저 정보")
+	@Builder
+	public record BlockedUser(
+		@Schema(description = "차단한 유저 ID", example = "1")
+		Long userId,
+
+		@Schema(description = "차단한 유저 닉네임", example = "뽀덕잉")
+		String nickname,
+
+		@Schema(description = "차단한 유저 프로필 이미지 URL", example = "https://cdn.toduck.app/profile.jpg")
+		String profileImageUrl
+	) {
+	}
+}

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
@@ -1,9 +1,13 @@
 package im.toduck.domain.user.persistence.repository.querydsl;
 
+import java.util.List;
+
 import im.toduck.domain.user.persistence.entity.User;
 
 public interface UserRepositoryCustom {
 	void updateNickname(User user, String nickname);
 
 	void updateProfileImageUrl(User user, String imageUrl);
+
+	List<User> findBlockedUsersByUser(User user);
 }

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
@@ -1,9 +1,12 @@
 package im.toduck.domain.user.persistence.repository.querydsl;
 
+import java.util.List;
+
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import im.toduck.domain.user.persistence.entity.QBlock;
 import im.toduck.domain.user.persistence.entity.QUser;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 	private final QUser qUser = QUser.user;
+	private final QBlock qBlock = QBlock.block;
 
 	@Override
 	public void updateNickname(User user, String nickname) {
@@ -28,5 +32,16 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 			.set(qUser.imageUrl, imageUrl)
 			.where(qUser.id.eq(user.getId()))
 			.execute();
+	}
+
+	@Override
+	public List<User> findBlockedUsersByUser(User user) {
+		return queryFactory.select(qBlock.blocked)
+			.from(qBlock)
+			.where(
+				qBlock.blocker.eq(user),
+				qBlock.blocked.deletedAt.isNull()
+			)
+			.fetch();
 	}
 }

--- a/src/test/java/im/toduck/builder/TestFixtureBuilder.java
+++ b/src/test/java/im/toduck/builder/TestFixtureBuilder.java
@@ -1,5 +1,6 @@
 package im.toduck.builder;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +32,12 @@ public class TestFixtureBuilder {
 
 	public User buildUser(final User user) {
 		return bs.userRepository().save(user);
+	}
+
+	public User buildDeletedUser(final User user, final LocalDateTime deletedAt) {
+		User saved = bs.userRepository().save(user);
+		ReflectionTestUtils.setField(saved, "deletedAt", deletedAt);
+		return bs.userRepository().save(saved);
 	}
 
 	public PhoneNumber buildPhoneNumber(final PhoneNumber phoneNumber) {

--- a/src/test/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/mypage/domain/usecase/MyPageUseCaseTest.java
@@ -2,6 +2,9 @@ package im.toduck.domain.mypage.domain.usecase;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -10,8 +13,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import im.toduck.ServiceTest;
 import im.toduck.domain.mypage.presentation.dto.request.NickNameUpdateRequest;
 import im.toduck.domain.mypage.presentation.dto.request.ProfileImageUpdateRequest;
+import im.toduck.domain.mypage.presentation.dto.response.BlockedUsersResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.domain.user.persistence.repository.UserRepository;
+import im.toduck.fixtures.user.BlockFixtures;
 import im.toduck.fixtures.user.UserFixtures;
 import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
@@ -75,4 +80,52 @@ public class MyPageUseCaseTest extends ServiceTest {
 			assertThat(userRepository.findById(user.getId()).get().getImageUrl()).isEqualTo(imageUrl);
 		}
 	}
+
+	@Nested
+	@DisplayName("차단한 유저 조회 시")
+	class GetBlockedUsers {
+
+		private User BLOCKER;
+		private User BLOCKED_1;
+		private User BLOCKED_2;
+		private User BLOCKED_DELETED;
+
+		@BeforeEach
+		void setUp() {
+			BLOCKER = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+			BLOCKED_1 = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+			BLOCKED_2 = testFixtureBuilder.buildUser(UserFixtures.GENERAL_USER());
+			BLOCKED_DELETED = testFixtureBuilder.buildDeletedUser(
+				UserFixtures.GENERAL_USER(),
+				LocalDateTime.now()
+			);
+		}
+
+		@Test
+		void 차단한_유저를_조회할_수_있다() {
+			// given
+			testFixtureBuilder.buildBlock(BlockFixtures.BLOCK_USER(BLOCKER, BLOCKED_1));
+			testFixtureBuilder.buildBlock(BlockFixtures.BLOCK_USER(BLOCKER, BLOCKED_2));
+			testFixtureBuilder.buildBlock(BlockFixtures.BLOCK_USER(BLOCKER, BLOCKED_DELETED));
+
+			// when
+			BlockedUsersResponse response = myPageUseCase.getBlockedUsers(BLOCKER.getId());
+
+			// then
+			assertThat(response.blockedUsers()).hasSize(2);
+			assertThat(response.blockedUsers())
+				.extracting("userId")
+				.containsExactlyInAnyOrder(BLOCKED_1.getId(), BLOCKED_2.getId());
+		}
+
+		@Test
+		void 차단한_유저가_없으면_빈_리스트를_반환한다() {
+			// when
+			BlockedUsersResponse response = myPageUseCase.getBlockedUsers(BLOCKER.getId());
+
+			// then
+			assertThat(response.blockedUsers()).isEmpty();
+		}
+	}
+
 }


### PR DESCRIPTION
## ✨ 작업 내용


**1️⃣ 마이페이지 - 차단한 유저 조회 API 개발**
- 차단 했지만 탈퇴한 회원은 조회시 제외

## ✅ 리뷰 요구사항
- 궁금한 점 있으면 댓글 남겨주세요!

