### PR TITLE
특정 케이스에서 범위 조회가 제대로 동작하지 않는 문제 해결

### DIFF
--- a/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/routine/persistence/repository/querydsl/RoutineRepositoryCustomImpl.java
@@ -53,7 +53,7 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 			.where(
 				qRoutine.user.eq(user),
 				routineNotDeleted(),
-				scheduleModifiedOnOrBeforeDate(startDate),
+				scheduleModifiedOnOrBeforeDate(endDate),
 				routineMatchesDateRange(startDate, endDate)
 			)
 			.fetch();
@@ -97,6 +97,7 @@ public class RoutineRepositoryCustomImpl implements RoutineRepositoryCustom {
 
 	private BooleanExpression routineMatchesDate(final LocalDate date) {
 		byte dayBitmask = DaysOfWeekBitmask.getDayBitmask(date.getDayOfWeek());
+
 		return Expressions.numberTemplate(
 			Byte.class, "function('bitand', {0}, CAST({1} as byte))", qRoutine.daysOfWeekBitmask, dayBitmask
 		).gt((byte)0);

--- a/src/test/java/im/toduck/fixtures/routine/RoutineFixtures.java
+++ b/src/test/java/im/toduck/fixtures/routine/RoutineFixtures.java
@@ -78,8 +78,25 @@ public class RoutineFixtures {
 			.user(user)
 			.title("평일 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
-				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+				List.of(DayOfWeek.MONDAY, java.time.DayOfWeek.TUESDAY, java.time.DayOfWeek.WEDNESDAY,
+					java.time.DayOfWeek.THURSDAY,
 					DayOfWeek.FRIDAY)))
+			.time(MORNING_TIME)
+			.color(PlanCategoryColor.from("#0000FF"))
+			.isPublic(true) // 수정: false -> true
+			.build();
+
+		return RoutineWithAuditInfo.builder()
+			.routine(routine);
+	}
+
+	public static RoutineWithAuditInfo.RoutineWithAuditInfoBuilder PUBLIC_TUESDAY_WEDNESDAY_THURSDAY_MORNING_ROUTINE(
+		User user) {
+		Routine routine = Routine.builder()
+			.user(user)
+			.title("평일 루틴")
+			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
+				List.of(DayOfWeek.TUESDAY, java.time.DayOfWeek.WEDNESDAY, java.time.DayOfWeek.THURSDAY)))
 			.time(MORNING_TIME)
 			.color(PlanCategoryColor.from("#0000FF"))
 			.isPublic(true) // 수정: false -> true
@@ -108,7 +125,8 @@ public class RoutineFixtures {
 			.user(user)
 			.title("평일 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
-				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+				List.of(DayOfWeek.MONDAY, java.time.DayOfWeek.TUESDAY, java.time.DayOfWeek.WEDNESDAY,
+					java.time.DayOfWeek.THURSDAY,
 					DayOfWeek.FRIDAY)))
 			.time(MORNING_TIME)
 			.color(PlanCategoryColor.from("#0000FF"))
@@ -123,7 +141,8 @@ public class RoutineFixtures {
 		Routine routine = Routine.builder()
 			.user(user)
 			.title("주말 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)))
+			.daysOfWeekBitmask(
+				DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SATURDAY, java.time.DayOfWeek.SUNDAY)))
 			.time(NOON_TIME)
 			.color(PlanCategoryColor.from("#00FF00"))
 			.isPublic(true)
@@ -137,7 +156,8 @@ public class RoutineFixtures {
 		Routine routine = Routine.builder()
 			.user(user)
 			.title("주말 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)))
+			.daysOfWeekBitmask(
+				DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.SATURDAY, java.time.DayOfWeek.SUNDAY)))
 			.time(NOON_TIME)
 			.color(PlanCategoryColor.from("#00FF00"))
 			.isPublic(false)
@@ -152,7 +172,8 @@ public class RoutineFixtures {
 			.user(user)
 			.title("화목토 루틴")
 			.daysOfWeekBitmask(
-				DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY)))
+				DaysOfWeekBitmask.createByDayOfWeek(
+					List.of(DayOfWeek.TUESDAY, java.time.DayOfWeek.THURSDAY, java.time.DayOfWeek.SATURDAY)))
 			.time(NIGHT_TIME)
 			.color(PlanCategoryColor.from("#800080"))
 			.isPublic(true)
@@ -167,7 +188,8 @@ public class RoutineFixtures {
 			.user(user)
 			.title("화목토 루틴")
 			.daysOfWeekBitmask(
-				DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY)))
+				DaysOfWeekBitmask.createByDayOfWeek(
+					List.of(DayOfWeek.TUESDAY, java.time.DayOfWeek.THURSDAY, java.time.DayOfWeek.SATURDAY)))
 			.time(NIGHT_TIME)
 			.color(PlanCategoryColor.from("#800080"))
 			.isPublic(false)
@@ -181,7 +203,8 @@ public class RoutineFixtures {
 		Routine routine = Routine.builder()
 			.user(user)
 			.title("수금 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)))
+			.daysOfWeekBitmask(
+				DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.WEDNESDAY, java.time.DayOfWeek.FRIDAY)))
 			.time(MORNING_TIME)
 			.color(PlanCategoryColor.from("#FFA500"))
 			.isPublic(true)
@@ -195,7 +218,8 @@ public class RoutineFixtures {
 		Routine routine = Routine.builder()
 			.user(user)
 			.title("수금 루틴")
-			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)))
+			.daysOfWeekBitmask(
+				DaysOfWeekBitmask.createByDayOfWeek(List.of(DayOfWeek.WEDNESDAY, java.time.DayOfWeek.FRIDAY)))
 			.time(MORNING_TIME)
 			.color(PlanCategoryColor.from("#FFA500"))
 			.isPublic(false)
@@ -210,7 +234,8 @@ public class RoutineFixtures {
 			.user(user)
 			.title("일요일 제외 매일 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
-				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY,
+				List.of(DayOfWeek.MONDAY, java.time.DayOfWeek.TUESDAY, java.time.DayOfWeek.WEDNESDAY,
+					java.time.DayOfWeek.THURSDAY, java.time.DayOfWeek.FRIDAY,
 					DayOfWeek.SATURDAY)))
 			.time(NOON_TIME)
 			.color(PlanCategoryColor.from("#008080"))
@@ -226,7 +251,8 @@ public class RoutineFixtures {
 			.user(user)
 			.title("일요일 제외 매일 루틴")
 			.daysOfWeekBitmask(DaysOfWeekBitmask.createByDayOfWeek(
-				List.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY,
+				List.of(DayOfWeek.MONDAY, java.time.DayOfWeek.TUESDAY, java.time.DayOfWeek.WEDNESDAY,
+					java.time.DayOfWeek.THURSDAY, java.time.DayOfWeek.FRIDAY,
 					DayOfWeek.SATURDAY)))
 			.time(NOON_TIME)
 			.color(PlanCategoryColor.from("#008080"))


### PR DESCRIPTION
## ✨ 작업 내용
클라이언트측에서 루틴 범위 조회 시 루틴이 다음 주부터 보인다는 오류 제보를 받았습니다.
범위 조회가 아닌 단건 조회에서는 정상적으로 동작하는 것을 확인했고, 문제 재현을 위해 테스트 코드를 작성했습니다.
범위 조회 시 `scheduleModifiedOnOrBeforeDate` 조건이 startDate로 설정되어 있어 일부 루틴이 정상적으로 조회되지 않는 현상을 확인하고 수정했습니다.

| 루틴 상세 | 루틴이 보이지 않음 |
|---------|---------|
| ![루틴이 보이지 않음](https://github.com/user-attachments/assets/fab26e91-b664-4298-b221-0326e278155a) | ![루틴 상세 정보](https://github.com/user-attachments/assets/ff10992f-5f3a-4db2-917d-6f3e43d27ea2) |


**1️⃣ 루틴 범위 조회 기능 오류 수정**
- `RoutineRepositoryCustomImpl` 클래스의 `findAllByUserAndDateRange` 메서드에서 `scheduleModifiedOnOrBeforeDate` 조건을 startDate에서 endDate로 변경
- 이 변경으로 지정된 날짜 범위 내의 루틴을 모두 올바르게 조회할 수 있게 됨
  <br/>

**2️⃣ 테스트 케이스 추가**
- 다중 날짜 조회 결과가 각 날짜별 단일 조회 결과와 동일한지 검증하는 테스트 케이스를 하나 더 추가
