### PR TITLE
 루틴 동시성 문제 해결

### DIFF
--- a/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
+++ b/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineUseCase.java
@@ -1,6 +1,5 @@
 package im.toduck.domain.routine.domain.usecase;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -112,24 +111,23 @@ public class RoutineUseCase {
 		boolean isCompleted = request.isCompleted();
 
 		String lockKey = "routine:" + routineId + ":date:" + date;
-		distributedLock.executeWithLock(lockKey, Duration.ofSeconds(3), 10, () -> {
+		distributedLock.executeWithLock(lockKey, () -> {
 			if (routineRecordService.updateIfPresent(routine, date, isCompleted)) {
-				log.info(
-					"루틴 상태 변경 성공(기록 수정) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}, 완료상태: {}",
+				log.info("루틴 상태 변경 성공(기록 수정) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}, 완료상태: {}",
 					userId, routineId, date, isCompleted
 				);
-			} else {
-				if (!routineService.canCreateRecordForDate(routine, date)) {
-					log.info("루틴 상태 변경 실패 - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}", userId, routineId, date);
-					throw CommonException.from(ExceptionCode.ROUTINE_INVALID_DATE);
-				}
-
-				routineRecordService.create(routine, date, isCompleted);
-				log.info(
-					"루틴 상태 변경 성공(기록 생성) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}, 완료상태: {}",
-					userId, routineId, date, isCompleted
-				);
+				return;
 			}
+
+			if (!routineService.canCreateRecordForDate(routine, date)) {
+				log.info("루틴 상태 변경 실패 - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}", userId, routineId, date);
+				throw CommonException.from(ExceptionCode.ROUTINE_INVALID_DATE);
+			}
+
+			routineRecordService.create(routine, date, isCompleted);
+			log.info(
+				"루틴 상태 변경 성공(기록 생성) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}, 완료상태: {}", userId, routineId, date, isCompleted
+			);
 		});
 	}
 
@@ -204,24 +202,19 @@ public class RoutineUseCase {
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_ROUTINE));
 
 		String lockKey = "routine:" + routineId + ":date:" + date;
-		distributedLock.executeWithLock(lockKey, Duration.ofSeconds(3), 10, () -> {
+		distributedLock.executeWithLock(lockKey, () -> {
 			if (routineRecordService.removeIfPresent(routine, date)) {
-				log.info(
-					"개별 루틴 삭제 성공(기존 기록 삭제) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}",
-					userId, routineId, date
-				);
-			} else {
-				if (!routineService.canCreateRecordForDate(routine, date)) {
-					log.info("개별 루틴 삭제 실패(유효하지 않은 날짜) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}", userId, routineId, date);
-					throw CommonException.from(ExceptionCode.ROUTINE_INVALID_DATE);
-				}
-
-				routineRecordService.createAsDeleted(routine, date);
-				log.info(
-					"개별 루틴 삭제 성공(삭제 기록 생성) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}",
-					userId, routineId, date
-				);
+				log.info("개별 루틴 삭제 성공(기존 기록 삭제) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}", userId, routineId, date);
+				return;
 			}
+
+			if (!routineService.canCreateRecordForDate(routine, date)) {
+				log.info("개별 루틴 삭제 실패(유효하지 않은 날짜) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}", userId, routineId, date);
+				throw CommonException.from(ExceptionCode.ROUTINE_INVALID_DATE);
+			}
+
+			routineRecordService.createAsDeleted(routine, date);
+			log.info("개별 루틴 삭제 성공(삭제 기록 생성) - 사용자 Id: {}, 루틴 Id: {}, 루틴 날짜: {}", userId, routineId, date);
 		});
 	}
 

--- a/src/main/java/im/toduck/global/lock/DistributedLock.java
+++ b/src/main/java/im/toduck/global/lock/DistributedLock.java
@@ -1,0 +1,159 @@
+package im.toduck.global.lock;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DistributedLock {
+
+	private final RedisLockManager lockManager;
+
+	public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(3);
+	public static final int DEFAULT_MAX_RETRIES = 5;
+	public static final Duration DEFAULT_RETRY_DELAY = Duration.ofMillis(100);
+
+	/**
+	 * 분산 락을 획득하고 작업을 실행합니다.
+	 *
+	 * @param key 락 식별자
+	 * @param task 실행할 작업
+	 * @return 작업 실행 결과
+	 * @throws LockAcquisitionException 락 획득 실패 시
+	 * @see #executeWithLock(String, Duration, int, Duration, Supplier)
+	 */
+	public <T> T executeWithLock(String key, Supplier<T> task) {
+		return executeWithLock(key, DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY, task);
+	}
+
+	/**
+	 * @see #executeWithLock(String, Duration, int, Duration, Supplier)
+	 */
+	public <T> T executeWithLock(String key, Duration timeout, Supplier<T> task) {
+		return executeWithLock(key, timeout, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY, task);
+	}
+
+	/**
+	 * @see #executeWithLock(String, Duration, int, Duration, Supplier)
+	 */
+	public <T> T executeWithLock(String key, Duration timeout, int maxRetries, Supplier<T> task) {
+		return executeWithLock(key, timeout, maxRetries, DEFAULT_RETRY_DELAY, task);
+	}
+
+	/**
+	 * 분산 락을 획득하고 작업을 실행합니다.
+	 *
+	 * @param key 락 식별자
+	 * @param timeout 락 타임아웃
+	 * @param maxRetries 최대 재시도 횟수
+	 * @param retryDelay 재시도 대기 시간
+	 * @param task 실행할 작업
+	 * @return 작업 실행 결과
+	 * @throws IllegalArgumentException 키가 null이거나 빈 문자열인 경우
+	 * @throws LockAcquisitionException 락 획득 실패 시
+	 */
+	public <T> T executeWithLock(String key, Duration timeout, int maxRetries, Duration retryDelay, Supplier<T> task) {
+		if (key == null || key.isBlank()) {
+			throw new IllegalArgumentException("락 키는 필수값입니다.");
+		}
+
+		String lockValue = UUID.randomUUID().toString();
+
+		for (int attempt = 1; attempt <= maxRetries; attempt++) {
+			if (acquireLock(key, lockValue, timeout)) {
+				try {
+					log.debug("[DistributedLock] 락 획득 성공 - 키: {}, 시도: {}", key, attempt);
+					return task.get();
+				} finally {
+					releaseLock(key, lockValue);
+				}
+			}
+
+			if (attempt < maxRetries) {
+				log.debug("[DistributedLock] 락 획득 실패, 재시도 - 키: {}, 시도: {}/{}", key, attempt, maxRetries);
+				waitBeforeRetry(retryDelay);
+			}
+		}
+
+		log.warn("[DistributedLock] 최대 재시도 횟수 초과 - 키: {}, 최대시도: {}", key, maxRetries);
+		throw new LockAcquisitionException(key, maxRetries);
+	}
+
+	/**
+	 * 반환값이 없는 작업을 위한 메서드
+	 *
+	 * @param key 락 식별자
+	 * @param task 실행할 작업
+	 * @throws LockAcquisitionException 락 획득 실패 시
+	 * @see #executeWithLock(String, Duration, int, Duration, Supplier)
+	 */
+	public void executeWithLock(String key, Runnable task) {
+		executeWithLock(key, DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY, () -> {
+			task.run();
+			return null;
+		});
+	}
+
+	/**
+	 * @see #executeWithLock(String, Duration, int, Duration, Supplier)
+	 */
+	public void executeWithLock(String key, Duration timeout, Runnable task) {
+		executeWithLock(key, timeout, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY, () -> {
+			task.run();
+			return null;
+		});
+	}
+
+	/**
+	 * @see #executeWithLock(String, Duration, int, Duration, Supplier)
+	 */
+	public void executeWithLock(String key, Duration timeout, int maxRetries, Runnable task) {
+		executeWithLock(key, timeout, maxRetries, DEFAULT_RETRY_DELAY, () -> {
+			task.run();
+			return null;
+		});
+	}
+
+	/**
+	 * @see #executeWithLock(String, Duration, int, Duration, Supplier)
+	 */
+	public void executeWithLock(String key, Duration timeout, int maxRetries, Duration retryDelay, Runnable task) {
+		executeWithLock(key, timeout, maxRetries, retryDelay, () -> {
+			task.run();
+			return null;
+		});
+	}
+
+	private boolean acquireLock(String key, String lockValue, Duration timeout) {
+		return lockManager.tryLock(key, lockValue, timeout);
+	}
+
+	private void releaseLock(String key, String lockValue) {
+		try {
+			boolean released = lockManager.unlock(key, lockValue);
+			if (released) {
+				log.debug("[DistributedLock] 락 해제 성공 - 키: {}", key);
+			} else {
+				log.warn("[DistributedLock] 락 해제 실패 - 키: {}", key);
+			}
+		} catch (Exception e) {
+			log.error("[DistributedLock] 락 해제 중 오류 발생 - 키: {}", key, e);
+		}
+	}
+
+	private void waitBeforeRetry(Duration retryDelay) {
+		try {
+			Thread.sleep(retryDelay.toMillis());
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("락 획득 대기 중 인터럽트 발생", e);
+		}
+	}
+}

--- a/src/main/java/im/toduck/global/lock/DistributedLock.java
+++ b/src/main/java/im/toduck/global/lock/DistributedLock.java
@@ -2,6 +2,7 @@ package im.toduck.global.lock;
 
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
 import org.springframework.stereotype.Component;
@@ -15,10 +16,70 @@ import lombok.extern.slf4j.Slf4j;
 public class DistributedLock {
 
 	private final RedisLockManager lockManager;
+	private final TransactionExecutor transactionExecutor;
 
 	public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(3);
 	public static final int DEFAULT_MAX_RETRIES = 5;
 	public static final Duration DEFAULT_RETRY_DELAY = Duration.ofMillis(100);
+
+	/**
+	 * 분산 락을 획득하고 작업을 실행합니다.
+	 * 내부적으로 REQUIRES_NEW 전파 옵션을 사용하여 새로운 트랜잭션을 생성하여 작업을 실행합니다.
+	 * 새 트랜잭션은 기존 트랜잭션과 독립적으로 실행되므로, 락 획득/해제 로직과 비즈니스 로직 간의
+	 * 트랜잭션 격리가 보장됩니다.
+	 *
+	 * <p><strong>사용 시 주의사항:</strong>
+	 * <ul>
+	 *   <li>호출하는 메서드에 이미 트랜잭션이 있는 경우, 이 메서드 내부의 작업은 독립적인 새 트랜잭션으로 실행됩니다.</li>
+	 *   <li>따라서 외부 트랜잭션이 롤백되어도 이 메서드 내부에서 실행된 작업은 롤백되지 않습니다.</li>
+	 *   <li>반대로 내부 작업 중 예외가 발생해도 외부 트랜잭션은 영향받지 않고 독립적으로 커밋될 수 있습니다.</li>
+	 *   <li>작업 실행 후 락이 자동으로 해제되므로 별도의 락 해제 로직을 구현할 필요가 없습니다.</li>
+	 * </ul>
+	 *
+	 * <p><strong>테스트 시 주의사항:</strong>
+	 * <ul>
+	 *   <li>테스트에서 외부 트랜잭션 내에서 엔티티를 저장한 후 분산 락을 사용하면,
+	 *       새 트랜잭션에서는 아직 커밋되지 않은 엔티티를 볼 수 없어 테스트가 실패할 수 있습니다.</li>
+	 *   <li>JUnit 테스트의 @Transactional 롤백도 내부 트랜잭션에 적용되지 않아 데이터가 남을 수 있습니다.</li>
+	 *   <li>해결책: @Transactional(propagation = Propagation.NEVER)로 테스트 트랜잭션을 비활성화하고,
+	 *       테스트에서 명시적으로 데이터를 저장(flush)한 후 분산 락을 사용하며, @AfterEach에서 데이터를 정리하세요.</li>
+	 * </ul>
+	 *
+	 * @param key 락 식별자
+	 * @param timeout 락 타임아웃
+	 * @param maxRetries 최대 재시도 횟수
+	 * @param retryDelay 재시도 대기 시간
+	 * @param task 실행할 작업
+	 * @return 작업 실행 결과
+	 * @throws IllegalArgumentException 키가 null이거나 빈 문자열인 경우
+	 * @throws LockAcquisitionException 락 획득 실패 시
+	 */
+	public <T> T executeWithLock(String key, Duration timeout, int maxRetries, Duration retryDelay, Supplier<T> task) {
+		if (key == null || key.isBlank()) {
+			throw new IllegalArgumentException("락 키는 필수값입니다.");
+		}
+
+		String lockValue = UUID.randomUUID().toString();
+
+		for (int attempt = 1; attempt <= maxRetries; attempt++) {
+			if (acquireLock(key, lockValue, timeout)) {
+				try {
+					log.debug("[DistributedLock] 락 획득 성공 - 키: {}, 시도: {}", key, attempt);
+					return transactionExecutor.executeInNewTransaction(task);
+				} finally {
+					releaseLock(key, lockValue);
+				}
+			}
+
+			if (attempt < maxRetries) {
+				log.debug("[DistributedLock] 락 획득 실패, 재시도 - 키: {}, 시도: {}/{}", key, attempt, maxRetries);
+				waitBeforeRetry(retryDelay, attempt);
+			}
+		}
+
+		log.warn("[DistributedLock] 최대 재시도 횟수 초과 - 키: {}, 최대시도: {}", key, maxRetries);
+		throw new LockAcquisitionException(key, maxRetries);
+	}
 
 	/**
 	 * 분산 락을 획득하고 작업을 실행합니다.
@@ -45,45 +106,6 @@ public class DistributedLock {
 	 */
 	public <T> T executeWithLock(String key, Duration timeout, int maxRetries, Supplier<T> task) {
 		return executeWithLock(key, timeout, maxRetries, DEFAULT_RETRY_DELAY, task);
-	}
-
-	/**
-	 * 분산 락을 획득하고 작업을 실행합니다.
-	 *
-	 * @param key 락 식별자
-	 * @param timeout 락 타임아웃
-	 * @param maxRetries 최대 재시도 횟수
-	 * @param retryDelay 재시도 대기 시간
-	 * @param task 실행할 작업
-	 * @return 작업 실행 결과
-	 * @throws IllegalArgumentException 키가 null이거나 빈 문자열인 경우
-	 * @throws LockAcquisitionException 락 획득 실패 시
-	 */
-	public <T> T executeWithLock(String key, Duration timeout, int maxRetries, Duration retryDelay, Supplier<T> task) {
-		if (key == null || key.isBlank()) {
-			throw new IllegalArgumentException("락 키는 필수값입니다.");
-		}
-
-		String lockValue = UUID.randomUUID().toString();
-
-		for (int attempt = 1; attempt <= maxRetries; attempt++) {
-			if (acquireLock(key, lockValue, timeout)) {
-				try {
-					log.debug("[DistributedLock] 락 획득 성공 - 키: {}, 시도: {}", key, attempt);
-					return task.get();
-				} finally {
-					releaseLock(key, lockValue);
-				}
-			}
-
-			if (attempt < maxRetries) {
-				log.debug("[DistributedLock] 락 획득 실패, 재시도 - 키: {}, 시도: {}/{}", key, attempt, maxRetries);
-				waitBeforeRetry(retryDelay);
-			}
-		}
-
-		log.warn("[DistributedLock] 최대 재시도 횟수 초과 - 키: {}, 최대시도: {}", key, maxRetries);
-		throw new LockAcquisitionException(key, maxRetries);
 	}
 
 	/**
@@ -132,12 +154,12 @@ public class DistributedLock {
 	}
 
 	private boolean acquireLock(String key, String lockValue, Duration timeout) {
-		return lockManager.tryLock(key, lockValue, timeout);
+		return lockManager.acquireLock(key, lockValue, timeout);
 	}
 
 	private void releaseLock(String key, String lockValue) {
 		try {
-			boolean released = lockManager.unlock(key, lockValue);
+			boolean released = lockManager.releaseLock(key, lockValue);
 			if (released) {
 				log.debug("[DistributedLock] 락 해제 성공 - 키: {}", key);
 			} else {
@@ -148,12 +170,15 @@ public class DistributedLock {
 		}
 	}
 
-	private void waitBeforeRetry(Duration retryDelay) {
+	private void waitBeforeRetry(Duration baseRetryDelay, int attempt) {
 		try {
-			Thread.sleep(retryDelay.toMillis());
+			long delayMillis = (long)(baseRetryDelay.toMillis() * Math.pow(1.5, attempt));
+			long jitter = ThreadLocalRandom.current().nextLong(delayMillis / 4);
+
+			Thread.sleep(delayMillis + jitter);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
-			throw new RuntimeException("락 획득 대기 중 인터럽트 발생", e);
+			throw new RuntimeException("락 획득 대기 중, 인터럽트 발생", e);
 		}
 	}
 }

--- a/src/main/java/im/toduck/global/lock/LockAcquisitionException.java
+++ b/src/main/java/im/toduck/global/lock/LockAcquisitionException.java
@@ -1,0 +1,8 @@
+package im.toduck.global.lock;
+
+public class LockAcquisitionException extends RuntimeException {
+
+	public LockAcquisitionException(String lockKey, int attempts) {
+		super(String.format("락 획득 실패 - 키: %s, 시도횟수: %d", lockKey, attempts));
+	}
+}

--- a/src/main/java/im/toduck/global/lock/RedisLockManager.java
+++ b/src/main/java/im/toduck/global/lock/RedisLockManager.java
@@ -1,0 +1,56 @@
+package im.toduck.global.lock;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisLockManager {
+	private final StringRedisTemplate redisTemplate;
+
+	private static final String LOCK_PREFIX = "lock:";
+	private static final String UNLOCK_SCRIPT =
+		"if redis.call('get', KEYS[1]) == ARGV[1] then "
+			+ "   return redis.call('del', KEYS[1]) "
+			+ "else "
+			+ "   return 0 "
+			+ "end";
+
+	private static final DefaultRedisScript<Long> UNLOCK_REDIS_SCRIPT =
+		new DefaultRedisScript<>(UNLOCK_SCRIPT, Long.class);
+
+	public boolean tryLock(String key, String value, Duration timeout) {
+		try {
+			String lockKey = LOCK_PREFIX + key;
+			return Boolean.TRUE.equals(
+				redisTemplate.opsForValue().setIfAbsent(lockKey, value, timeout)
+			);
+		} catch (Exception e) {
+			log.error("[RedisLockManager] 락 획득 중 오류 발생 - 키: {}", key, e);
+			return false;
+		}
+	}
+
+	public boolean unlock(String key, String value) {
+		try {
+			String lockKey = LOCK_PREFIX + key;
+			Long result = redisTemplate.execute(
+				UNLOCK_REDIS_SCRIPT,
+				Collections.singletonList(lockKey),
+				value
+			);
+			return Long.valueOf(1).equals(result);
+		} catch (Exception e) {
+			log.error("[RedisLockManager] 락 해제 중 오류 발생 - 키: {}", key, e);
+			return false;
+		}
+	}
+}

--- a/src/main/java/im/toduck/global/lock/TransactionExecutor.java
+++ b/src/main/java/im/toduck/global/lock/TransactionExecutor.java
@@ -1,0 +1,23 @@
+package im.toduck.global.lock;
+
+import java.util.function.Supplier;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TransactionExecutor {
+
+	/**
+	 * 새로운 트랜잭션 컨텍스트에서 주어진 작업을 실행합니다.
+	 *
+	 * @param supplier 실행할 작업
+	 * @return 작업 실행 결과
+	 * @param <T> 반환 타입
+	 */
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public <T> T executeInNewTransaction(Supplier<T> supplier) {
+		return supplier.get();
+	}
+}

--- a/src/test/java/im/toduck/architecture/main/domain/domain/UseCaseRulesTest.java
+++ b/src/test/java/im/toduck/architecture/main/domain/domain/UseCaseRulesTest.java
@@ -11,7 +11,10 @@ import com.tngtech.archunit.lang.ArchRule;
 import im.toduck.global.annotation.UseCase;
 import im.toduck.global.lock.DistributedLock;
 
-@AnalyzeClasses(packages = "im.toduck.domain", importOptions = ImportOption.DoNotIncludeTests.class)
+@AnalyzeClasses(
+	packages = {"im.toduck.domain", "im.toduck.global.lock"},
+	importOptions = ImportOption.DoNotIncludeTests.class
+)
 public class UseCaseRulesTest {
 	@ArchTest
 	static final ArchRule UseCase_클래스는_UseCase_어노테이션을_가진다 =
@@ -24,5 +27,6 @@ public class UseCaseRulesTest {
 		methods()
 			.that().areDeclaredIn(DistributedLock.class)
 			.should().onlyBeCalled().byClassesThat().resideInAPackage(USECASE.getFullPackageName())
+			.orShould().beDeclaredIn(DistributedLock.class)
 			.because("분산 락(DistributedLock) 메서드는 오직 UseCase 계층에서만 호출되어야 합니다.");
 }

--- a/src/test/java/im/toduck/architecture/main/domain/domain/UseCaseRulesTest.java
+++ b/src/test/java/im/toduck/architecture/main/domain/domain/UseCaseRulesTest.java
@@ -9,6 +9,7 @@ import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
 import im.toduck.global.annotation.UseCase;
+import im.toduck.global.lock.DistributedLock;
 
 @AnalyzeClasses(packages = "im.toduck.domain", importOptions = ImportOption.DoNotIncludeTests.class)
 public class UseCaseRulesTest {
@@ -17,4 +18,11 @@ public class UseCaseRulesTest {
 		classes()
 			.that().resideInAPackage(USECASE.getFullPackageName())
 			.should().beAnnotatedWith(UseCase.class);
+
+	@ArchTest
+	static final ArchRule DistributedLock_메서드는_UseCase_클래스에서만_호출된다 =
+		methods()
+			.that().areDeclaredIn(DistributedLock.class)
+			.should().onlyBeCalled().byClassesThat().resideInAPackage(USECASE.getFullPackageName())
+			.because("분산 락(DistributedLock) 메서드는 오직 UseCase 계층에서만 호출되어야 합니다.");
 }

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseConcurrencyTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseConcurrencyTest.java
@@ -1,0 +1,261 @@
+package im.toduck.domain.routine.domain.usecase;
+
+import static im.toduck.fixtures.routine.RoutineFixtures.*;
+import static im.toduck.fixtures.user.UserFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import im.toduck.ServiceTest;
+import im.toduck.domain.routine.persistence.entity.Routine;
+import im.toduck.domain.routine.persistence.entity.RoutineRecord;
+import im.toduck.domain.routine.persistence.repository.RoutineRecordRepository;
+import im.toduck.domain.routine.persistence.repository.RoutineRepository;
+import im.toduck.domain.routine.presentation.dto.request.RoutinePutCompletionRequest;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import jakarta.persistence.EntityManager;
+
+class RoutineUseCaseConcurrencyTest extends ServiceTest {
+
+	@Autowired
+	private RoutineUseCase routineUseCase;
+
+	@Autowired
+	private RoutineRepository routineRepository;
+
+	@Autowired
+	private RoutineRecordRepository routineRecordRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Autowired
+	private PlatformTransactionManager transactionManager;
+
+	@MockBean
+	private UserService userService;
+
+	private User USER;
+
+	@BeforeEach
+	void setUp() {
+		// given
+		USER = testFixtureBuilder.buildUser(GENERAL_USER());
+		given(userService.getUserById(any(Long.class))).willReturn(Optional.ofNullable(USER));
+	}
+
+	@Nested
+	@DisplayName("루틴 완료 상태 변경의 동시성 처리시")
+	class UpdateRoutineCompletionConcurrencyTest {
+		private Long routineId;
+
+		@BeforeEach
+		void setUp() {
+			TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
+			routineId = transactionTemplate.execute(status -> {
+				Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+					PUBLIC_MONDAY_MORNING_ROUTINE(USER)
+						.createdAt("2024-11-29 01:00:00")
+						.build()
+				);
+				entityManager.flush();
+				entityManager.clear();
+				return routine.getId();
+			});
+		}
+
+		@AfterEach
+		void tearDown() {
+			// 테스트 후 생성된 데이터 정리
+			TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+			transactionTemplate.execute(status -> {
+				routineRecordRepository.deleteAll();
+				if (routineId != null) {
+					routineRepository.deleteById(routineId);
+				}
+				entityManager.flush();
+				return null;
+			});
+		}
+
+		@Test
+		void 거의_동시에_여러_요청이_들어올때_루틴_기록이_중복_생성되지_않아야_한다() throws InterruptedException {
+			// given
+			int numberOfThreads = 5;
+			ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+			CountDownLatch startLatch = new CountDownLatch(1);
+			CountDownLatch endLatch = new CountDownLatch(numberOfThreads);
+			AtomicInteger successCount = new AtomicInteger(0);
+			List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+			Random random = new Random();
+
+			LocalDate TEST_MONDAY_DATE = LocalDate.parse("2025-04-14"); // 월요일
+			RoutinePutCompletionRequest request = new RoutinePutCompletionRequest(TEST_MONDAY_DATE, true);
+
+			// when - 여러 스레드에서 거의 동시에 같은 루틴에 대한 기록 생성 요청
+			for (int i = 0; i < numberOfThreads; i++) {
+				executorService.submit(() -> {
+					try {
+						startLatch.await(); // 모든 스레드가 준비될 때까지 대기
+
+						// 랜덤 지연 시간 (0-50ms)
+						Thread.sleep(random.nextInt(50));
+
+						routineUseCase.updateRoutineCompletion(USER.getId(), routineId, request);
+						successCount.incrementAndGet();
+					} catch (Exception e) {
+						exceptions.add(e);
+					} finally {
+						endLatch.countDown();
+					}
+				});
+			}
+
+			// 모든 스레드 동시 시작
+			startLatch.countDown();
+
+			// 모든 작업이 완료될 때까지 대기 (최대 5초)
+			boolean completed = endLatch.await(5, TimeUnit.SECONDS);
+			executorService.shutdown();
+
+			// then
+			assertThat(completed).isTrue();
+
+			TransactionTemplate readTemplate = new TransactionTemplate(transactionManager);
+			List<RoutineRecord> routineRecords = readTemplate.execute(status -> {
+				entityManager.clear(); // 영속성 컨텍스트 초기화
+				return routineRecordRepository.findAll();
+			});
+
+			assertSoftly(softly -> {
+				softly.assertThat(routineRecords).hasSize(1);
+				softly.assertThat(routineRecords.get(0).getRoutine().getId()).isEqualTo(routineId);
+				softly.assertThat(routineRecords.get(0).getRecordAt().toLocalDate()).isEqualTo(TEST_MONDAY_DATE);
+				softly.assertThat(routineRecords.get(0).getIsCompleted()).isTrue();
+
+				softly.assertThat(successCount.get()).isEqualTo(numberOfThreads);
+				softly.assertThat(exceptions).isEmpty();
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("개별 루틴 삭제의 동시성 처리시")
+	class DeleteIndividualRoutineConcurrencyTest {
+		private Long routineId;
+
+		@BeforeEach
+		void setUp() {
+			TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
+			routineId = transactionTemplate.execute(status -> {
+				Routine routine = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
+					PUBLIC_MONDAY_MORNING_ROUTINE(USER)
+						.createdAt("2024-11-29 01:00:00")
+						.build()
+				);
+				entityManager.flush();
+				entityManager.clear();
+				return routine.getId();
+			});
+		}
+
+		@AfterEach
+		void tearDown() {
+			// 테스트 후 생성된 데이터 정리
+			TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+			transactionTemplate.execute(status -> {
+				routineRecordRepository.deleteAll();
+				if (routineId != null) {
+					routineRepository.deleteById(routineId);
+				}
+				entityManager.flush();
+				return null;
+			});
+		}
+
+		@Test
+		void 거의_동시에_여러_요청이_들어올때_개별_루틴_삭제_기록이_중복_생성되지_않아야_한다() throws InterruptedException {
+			// given
+			int numberOfThreads = 5;
+			ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+			CountDownLatch startLatch = new CountDownLatch(1);
+			CountDownLatch endLatch = new CountDownLatch(numberOfThreads);
+			AtomicInteger successCount = new AtomicInteger(0);
+			List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+			Random random = new Random();
+
+			LocalDate TEST_MONDAY_DATE = LocalDate.parse("2025-04-14"); // 월요일
+
+			// when - 여러 스레드에서 거의 동시에 같은 날짜의 개별 루틴 삭제 요청
+			for (int i = 0; i < numberOfThreads; i++) {
+				executorService.submit(() -> {
+					try {
+						startLatch.await(); // 모든 스레드가 준비될 때까지 대기
+
+						// 랜덤 지연 시간 (0-50ms)
+						Thread.sleep(random.nextInt(50));
+
+						routineUseCase.deleteIndividualRoutine(USER.getId(), routineId, TEST_MONDAY_DATE);
+						successCount.incrementAndGet();
+					} catch (Exception e) {
+						exceptions.add(e);
+					} finally {
+						endLatch.countDown();
+					}
+				});
+			}
+
+			// 모든 스레드 동시 시작
+			startLatch.countDown();
+
+			// 모든 작업이 완료될 때까지 대기 (최대 5초)
+			boolean completed = endLatch.await(5, TimeUnit.SECONDS);
+			executorService.shutdown();
+
+			// then
+			assertThat(completed).isTrue();
+
+			TransactionTemplate readTemplate = new TransactionTemplate(transactionManager);
+			List<RoutineRecord> routineRecords = readTemplate.execute(status -> {
+				entityManager.clear(); // 영속성 컨텍스트 초기화
+				return routineRecordRepository.findAll();
+			});
+
+			assertSoftly(softly -> {
+				softly.assertThat(routineRecords).hasSize(1);
+				softly.assertThat(routineRecords.get(0).getRoutine().getId()).isEqualTo(routineId);
+				softly.assertThat(routineRecords.get(0).getRecordAt().toLocalDate()).isEqualTo(TEST_MONDAY_DATE);
+				softly.assertThat(routineRecords.get(0).isInDeletedState()).isTrue(); // 삭제 상태인지 확인
+
+				softly.assertThat(successCount.get()).isEqualTo(numberOfThreads);
+				softly.assertThat(exceptions).isEmpty();
+			});
+		}
+	}
+}

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseConcurrencyTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseConcurrencyTest.java
@@ -106,7 +106,7 @@ class RoutineUseCaseConcurrencyTest extends ServiceTest {
 		@Test
 		void 거의_동시에_여러_요청이_들어올때_루틴_기록이_중복_생성되지_않아야_한다() throws InterruptedException {
 			// given
-			int numberOfThreads = 5;
+			int numberOfThreads = 6;
 			ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
 			CountDownLatch startLatch = new CountDownLatch(1);
 			CountDownLatch endLatch = new CountDownLatch(numberOfThreads);
@@ -123,8 +123,8 @@ class RoutineUseCaseConcurrencyTest extends ServiceTest {
 					try {
 						startLatch.await(); // 모든 스레드가 준비될 때까지 대기
 
-						// 랜덤 지연 시간 (0-50ms)
-						Thread.sleep(random.nextInt(50));
+						// 랜덤 지연 시간 (0-10ms)
+						Thread.sleep(random.nextInt(10));
 
 						routineUseCase.updateRoutineCompletion(USER.getId(), routineId, request);
 						successCount.incrementAndGet();
@@ -202,7 +202,7 @@ class RoutineUseCaseConcurrencyTest extends ServiceTest {
 		@Test
 		void 거의_동시에_여러_요청이_들어올때_개별_루틴_삭제_기록이_중복_생성되지_않아야_한다() throws InterruptedException {
 			// given
-			int numberOfThreads = 5;
+			int numberOfThreads = 6;
 			ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
 			CountDownLatch startLatch = new CountDownLatch(1);
 			CountDownLatch endLatch = new CountDownLatch(numberOfThreads);
@@ -218,8 +218,8 @@ class RoutineUseCaseConcurrencyTest extends ServiceTest {
 					try {
 						startLatch.await(); // 모든 스레드가 준비될 때까지 대기
 
-						// 랜덤 지연 시간 (0-50ms)
-						Thread.sleep(random.nextInt(50));
+						// 랜덤 지연 시간 (0-10ms)
+						Thread.sleep(random.nextInt(10));
 
 						routineUseCase.deleteIndividualRoutine(USER.getId(), routineId, TEST_MONDAY_DATE);
 						successCount.incrementAndGet();

--- a/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/routine/domain/usecase/RoutineUseCaseTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import im.toduck.ServiceTest;
@@ -540,7 +541,16 @@ class RoutineUseCaseTest extends ServiceTest {
 			given(userService.getUserById(any(Long.class))).willReturn(Optional.ofNullable(USER));
 		}
 
+		@AfterEach
+		void cleanup() {
+			routineRecordRepository.deleteAll();
+			routineRepository.deleteAll();
+
+			reset(userService);
+		}
+
 		@Test
+		@Transactional(propagation = Propagation.NEVER)
 		void 기존_기록이_존재하는_경우에_완료_상태_변경이_성공한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
@@ -569,6 +579,7 @@ class RoutineUseCaseTest extends ServiceTest {
 		}
 
 		@Test
+		@Transactional(propagation = Propagation.NEVER)
 		void 기존_기록이_존재하는_경우에_모_루틴의_반복요일에_변경이_있더라도_변경이_성공한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(
@@ -599,6 +610,7 @@ class RoutineUseCaseTest extends ServiceTest {
 		}
 
 		@Test
+		@Transactional(propagation = Propagation.NEVER)
 		void 기존_기록이_존재하지_않는_경우에_완료_상태_변경이_성공한다() {
 			// given
 			Routine ROUTINE = testFixtureBuilder.buildRoutineAndUpdateAuditFields(

--- a/src/test/java/im/toduck/global/lock/DistributedLockTest.java
+++ b/src/test/java/im/toduck/global/lock/DistributedLockTest.java
@@ -34,9 +34,9 @@ class DistributedLockTest extends ServiceTest {
 			String lockKey = "test-lock";
 			String expectedResult = "success";
 
-			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+			given(redisLockManager.acquireLock(eq(lockKey), anyString(), any(Duration.class)))
 				.willReturn(true);
-			given(redisLockManager.unlock(eq(lockKey), anyString()))
+			given(redisLockManager.releaseLock(eq(lockKey), anyString()))
 				.willReturn(true);
 
 			// when
@@ -45,8 +45,8 @@ class DistributedLockTest extends ServiceTest {
 			// then
 			assertSoftly(softly -> {
 				softly.assertThat(result).isEqualTo(expectedResult);
-				verify(redisLockManager).tryLock(eq(lockKey), anyString(), any(Duration.class));
-				verify(redisLockManager).unlock(eq(lockKey), anyString());
+				verify(redisLockManager).acquireLock(eq(lockKey), anyString(), any(Duration.class));
+				verify(redisLockManager).releaseLock(eq(lockKey), anyString());
 			});
 		}
 
@@ -56,9 +56,9 @@ class DistributedLockTest extends ServiceTest {
 			String lockKey = "test-lock";
 			RuntimeException expectedException = new RuntimeException("작업 실패");
 
-			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+			given(redisLockManager.acquireLock(eq(lockKey), anyString(), any(Duration.class)))
 				.willReturn(true);
-			given(redisLockManager.unlock(eq(lockKey), anyString()))
+			given(redisLockManager.releaseLock(eq(lockKey), anyString()))
 				.willReturn(true);
 
 			// when & then
@@ -70,7 +70,7 @@ class DistributedLockTest extends ServiceTest {
 				.isInstanceOf(RuntimeException.class)
 				.hasMessage("작업 실패");
 
-			verify(redisLockManager).unlock(eq(lockKey), anyString());
+			verify(redisLockManager).releaseLock(eq(lockKey), anyString());
 		}
 
 		@Test
@@ -79,10 +79,10 @@ class DistributedLockTest extends ServiceTest {
 			String lockKey = "test-lock";
 			String expectedResult = "success";
 
-			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+			given(redisLockManager.acquireLock(eq(lockKey), anyString(), any(Duration.class)))
 				.willReturn(false)  // 첫 번째 시도 실패
 				.willReturn(true);  // 두 번째 시도 성공
-			given(redisLockManager.unlock(eq(lockKey), anyString()))
+			given(redisLockManager.releaseLock(eq(lockKey), anyString()))
 				.willReturn(true);
 
 			// when
@@ -91,8 +91,8 @@ class DistributedLockTest extends ServiceTest {
 			// then
 			assertSoftly(softly -> {
 				softly.assertThat(result).isEqualTo(expectedResult);
-				verify(redisLockManager, times(2)).tryLock(eq(lockKey), anyString(), any(Duration.class));
-				verify(redisLockManager).unlock(eq(lockKey), anyString());
+				verify(redisLockManager, times(2)).acquireLock(eq(lockKey), anyString(), any(Duration.class));
+				verify(redisLockManager).releaseLock(eq(lockKey), anyString());
 			});
 		}
 
@@ -102,7 +102,7 @@ class DistributedLockTest extends ServiceTest {
 			String lockKey = "test-lock";
 			int maxRetries = 3;
 
-			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+			given(redisLockManager.acquireLock(eq(lockKey), anyString(), any(Duration.class)))
 				.willReturn(false);
 
 			// when & then
@@ -111,7 +111,7 @@ class DistributedLockTest extends ServiceTest {
 			)
 				.isInstanceOf(LockAcquisitionException.class);
 
-			verify(redisLockManager, times(maxRetries)).tryLock(eq(lockKey), anyString(), any(Duration.class));
+			verify(redisLockManager, times(maxRetries)).acquireLock(eq(lockKey), anyString(), any(Duration.class));
 		}
 
 		@Test
@@ -149,9 +149,9 @@ class DistributedLockTest extends ServiceTest {
 			String lockKey = "test-lock";
 			AtomicInteger counter = new AtomicInteger(0);
 
-			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+			given(redisLockManager.acquireLock(eq(lockKey), anyString(), any(Duration.class)))
 				.willReturn(true);
-			given(redisLockManager.unlock(eq(lockKey), anyString()))
+			given(redisLockManager.releaseLock(eq(lockKey), anyString()))
 				.willReturn(true);
 
 			// when
@@ -160,8 +160,8 @@ class DistributedLockTest extends ServiceTest {
 			// then
 			assertSoftly(softly -> {
 				softly.assertThat(counter.get()).isEqualTo(1);
-				verify(redisLockManager).tryLock(eq(lockKey), anyString(), any(Duration.class));
-				verify(redisLockManager).unlock(eq(lockKey), anyString());
+				verify(redisLockManager).acquireLock(eq(lockKey), anyString(), any(Duration.class));
+				verify(redisLockManager).releaseLock(eq(lockKey), anyString());
 			});
 		}
 
@@ -172,9 +172,9 @@ class DistributedLockTest extends ServiceTest {
 			Duration timeout = Duration.ofSeconds(5);
 			AtomicInteger counter = new AtomicInteger(0);
 
-			given(redisLockManager.tryLock(eq(lockKey), anyString(), eq(timeout)))
+			given(redisLockManager.acquireLock(eq(lockKey), anyString(), eq(timeout)))
 				.willReturn(true);
-			given(redisLockManager.unlock(eq(lockKey), anyString()))
+			given(redisLockManager.releaseLock(eq(lockKey), anyString()))
 				.willReturn(true);
 
 			// when
@@ -183,8 +183,8 @@ class DistributedLockTest extends ServiceTest {
 			// then
 			assertSoftly(softly -> {
 				softly.assertThat(counter.get()).isEqualTo(1);
-				verify(redisLockManager).tryLock(eq(lockKey), anyString(), eq(timeout));
-				verify(redisLockManager).unlock(eq(lockKey), anyString());
+				verify(redisLockManager).acquireLock(eq(lockKey), anyString(), eq(timeout));
+				verify(redisLockManager).releaseLock(eq(lockKey), anyString());
 			});
 		}
 	}

--- a/src/test/java/im/toduck/global/lock/DistributedLockTest.java
+++ b/src/test/java/im/toduck/global/lock/DistributedLockTest.java
@@ -1,0 +1,191 @@
+package im.toduck.global.lock;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import im.toduck.ServiceTest;
+
+class DistributedLockTest extends ServiceTest {
+
+	@Autowired
+	private DistributedLock distributedLock;
+
+	@MockBean
+	private RedisLockManager redisLockManager;
+
+	@Nested
+	@DisplayName("분산 락 작업 실행시")
+	class ExecuteWithLockTest {
+
+		@Test
+		void 락_획득에_성공하면_작업이_실행된다() {
+			// given
+			String lockKey = "test-lock";
+			String expectedResult = "success";
+
+			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+				.willReturn(true);
+			given(redisLockManager.unlock(eq(lockKey), anyString()))
+				.willReturn(true);
+
+			// when
+			String result = distributedLock.executeWithLock(lockKey, () -> expectedResult);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result).isEqualTo(expectedResult);
+				verify(redisLockManager).tryLock(eq(lockKey), anyString(), any(Duration.class));
+				verify(redisLockManager).unlock(eq(lockKey), anyString());
+			});
+		}
+
+		@Test
+		void 작업_실행중_예외가_발생하면_락이_해제된다() {
+			// given
+			String lockKey = "test-lock";
+			RuntimeException expectedException = new RuntimeException("작업 실패");
+
+			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+				.willReturn(true);
+			given(redisLockManager.unlock(eq(lockKey), anyString()))
+				.willReturn(true);
+
+			// when & then
+			assertThatThrownBy(() ->
+				distributedLock.executeWithLock(lockKey, () -> {
+					throw expectedException;
+				})
+			)
+				.isInstanceOf(RuntimeException.class)
+				.hasMessage("작업 실패");
+
+			verify(redisLockManager).unlock(eq(lockKey), anyString());
+		}
+
+		@Test
+		void 락_획득에_실패하면_재시도한다() {
+			// given
+			String lockKey = "test-lock";
+			String expectedResult = "success";
+
+			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+				.willReturn(false)  // 첫 번째 시도 실패
+				.willReturn(true);  // 두 번째 시도 성공
+			given(redisLockManager.unlock(eq(lockKey), anyString()))
+				.willReturn(true);
+
+			// when
+			String result = distributedLock.executeWithLock(lockKey, () -> expectedResult);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result).isEqualTo(expectedResult);
+				verify(redisLockManager, times(2)).tryLock(eq(lockKey), anyString(), any(Duration.class));
+				verify(redisLockManager).unlock(eq(lockKey), anyString());
+			});
+		}
+
+		@Test
+		void 최대_재시도_횟수를_초과하면_예외가_발생한다() {
+			// given
+			String lockKey = "test-lock";
+			int maxRetries = 3;
+
+			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+				.willReturn(false);
+
+			// when & then
+			assertThatThrownBy(() ->
+				distributedLock.executeWithLock(lockKey, Duration.ofSeconds(1), maxRetries, () -> "result")
+			)
+				.isInstanceOf(LockAcquisitionException.class);
+
+			verify(redisLockManager, times(maxRetries)).tryLock(eq(lockKey), anyString(), any(Duration.class));
+		}
+
+		@Test
+		void null_또는_빈_키를_전달하면_예외가_발생한다() {
+			// when & then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() ->
+						distributedLock.executeWithLock(null, () -> "result")
+					)
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessage("락 키는 필수값입니다.");
+
+				softly.assertThatThrownBy(() ->
+						distributedLock.executeWithLock("", () -> "result")
+					)
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessage("락 키는 필수값입니다.");
+
+				softly.assertThatThrownBy(() ->
+						distributedLock.executeWithLock("   ", () -> "result")
+					)
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessage("락 키는 필수값입니다.");
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("void 반환 작업 실행시")
+	class ExecuteVoidTaskTest {
+
+		@Test
+		void Runnable_작업이_정상적으로_실행된다() {
+			// given
+			String lockKey = "test-lock";
+			AtomicInteger counter = new AtomicInteger(0);
+
+			given(redisLockManager.tryLock(eq(lockKey), anyString(), any(Duration.class)))
+				.willReturn(true);
+			given(redisLockManager.unlock(eq(lockKey), anyString()))
+				.willReturn(true);
+
+			// when
+			distributedLock.executeWithLock(lockKey, counter::incrementAndGet);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(counter.get()).isEqualTo(1);
+				verify(redisLockManager).tryLock(eq(lockKey), anyString(), any(Duration.class));
+				verify(redisLockManager).unlock(eq(lockKey), anyString());
+			});
+		}
+
+		@Test
+		void 타임아웃을_지정한_Runnable_작업이_정상적으로_실행된다() {
+			// given
+			String lockKey = "test-lock";
+			Duration timeout = Duration.ofSeconds(5);
+			AtomicInteger counter = new AtomicInteger(0);
+
+			given(redisLockManager.tryLock(eq(lockKey), anyString(), eq(timeout)))
+				.willReturn(true);
+			given(redisLockManager.unlock(eq(lockKey), anyString()))
+				.willReturn(true);
+
+			// when
+			distributedLock.executeWithLock(lockKey, timeout, counter::incrementAndGet);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(counter.get()).isEqualTo(1);
+				verify(redisLockManager).tryLock(eq(lockKey), anyString(), eq(timeout));
+				verify(redisLockManager).unlock(eq(lockKey), anyString());
+			});
+		}
+	}
+}

--- a/src/test/java/im/toduck/global/lock/RedisLockManagerTest.java
+++ b/src/test/java/im/toduck/global/lock/RedisLockManagerTest.java
@@ -1,0 +1,163 @@
+package im.toduck.global.lock;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import im.toduck.ServiceTest;
+
+class RedisLockManagerTest extends ServiceTest {
+
+	@Autowired
+	private RedisLockManager redisLockManager;
+
+	@Autowired
+	private StringRedisTemplate redisTemplate;
+
+	private static final String TEST_KEY = "test-key";
+	private static final String TEST_VALUE = UUID.randomUUID().toString();
+	private static final Duration TIMEOUT = Duration.ofSeconds(3);
+
+	@BeforeEach
+	void setUp() {
+		redisTemplate.getConnectionFactory().getConnection().flushAll();
+	}
+
+	@Nested
+	@DisplayName("락 획득시")
+	class TryLockTest {
+
+		@Test
+		void 처음_시도하면_락_획득에_성공한다() {
+			// when
+			boolean result = redisLockManager.tryLock(TEST_KEY, TEST_VALUE, TIMEOUT);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result).isTrue();
+				softly.assertThat(redisTemplate.opsForValue().get("lock:" + TEST_KEY))
+					.isEqualTo(TEST_VALUE);
+			});
+		}
+
+		@Test
+		void 이미_락이_존재하면_획득에_실패한다() {
+			// given
+			redisLockManager.tryLock(TEST_KEY, "other-value", TIMEOUT);
+
+			// when
+			boolean result = redisLockManager.tryLock(TEST_KEY, TEST_VALUE, TIMEOUT);
+
+			// then
+			assertThat(result).isFalse();
+		}
+
+		@Test
+		void 타임아웃_이후에는_다시_락을_획득할_수_있다() throws InterruptedException {
+			// given
+			Duration shortTimeout = Duration.ofMillis(100);
+			redisLockManager.tryLock(TEST_KEY, "other-value", shortTimeout);
+
+			// when
+			Thread.sleep(150);
+			boolean result = redisLockManager.tryLock(TEST_KEY, TEST_VALUE, TIMEOUT);
+
+			// then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Nested
+	@DisplayName("락 해제시")
+	class UnlockTest {
+
+		@Test
+		void 자신이_획득한_락은_해제할_수_있다() {
+			// given
+			redisLockManager.tryLock(TEST_KEY, TEST_VALUE, TIMEOUT);
+
+			// when
+			boolean result = redisLockManager.unlock(TEST_KEY, TEST_VALUE);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result).isTrue();
+				softly.assertThat(redisTemplate.opsForValue().get("lock:" + TEST_KEY))
+					.isNull();
+			});
+		}
+
+		@Test
+		void 다른_값으로_설정된_락은_해제할_수_없다() {
+			// given
+			redisLockManager.tryLock(TEST_KEY, "other-value", TIMEOUT);
+
+			// when
+			boolean result = redisLockManager.unlock(TEST_KEY, TEST_VALUE);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result).isFalse();
+				softly.assertThat(redisTemplate.opsForValue().get("lock:" + TEST_KEY))
+					.isEqualTo("other-value");
+			});
+		}
+
+		@Test
+		void 존재하지_않는_락을_해제하려하면_실패한다() {
+			// when
+			boolean result = redisLockManager.unlock(TEST_KEY, TEST_VALUE);
+
+			// then
+			assertThat(result).isFalse();
+		}
+	}
+
+	@Nested
+	@DisplayName("동시성 처리시")
+	class ConcurrencyTest {
+
+		@Test
+		void 여러_스레드가_동시에_락을_획득하려할_때_하나만_성공한다() throws InterruptedException {
+			// given
+			int threadCount = 10;
+			ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+			CountDownLatch latch = new CountDownLatch(threadCount);
+			AtomicInteger successCount = new AtomicInteger(0);
+
+			// when
+			for (int i = 0; i < threadCount; i++) {
+				String value = "value-" + i;
+				executorService.submit(() -> {
+					try {
+						if (redisLockManager.tryLock(TEST_KEY, value, TIMEOUT)) {
+							successCount.incrementAndGet();
+						}
+					} finally {
+						latch.countDown();
+					}
+				});
+			}
+
+			latch.await(5, TimeUnit.SECONDS);
+			executorService.shutdown();
+
+			// then
+			assertThat(successCount.get()).isEqualTo(1);
+		}
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용
### 배경 - 루틴 동시성 문제 발생

- 한 명의 사용자가 루틴 완료 상태를 변경할 때(또는 개별 삭제할 때) "없으면 생성, 있으면 수정" 방식으로 동작
- Upsert 패턴으로 인해 동일 루틴, 동일 날짜에 대해 중복 기록이 저장되는 문제 확인
- 현재 동시성 테스트를 통해 해당 문제가 재현됨

### 해결 방안 검토

- 클라이언트 측 디바운싱: 필수적이지만 완전한 해결책은 아님 (다중 클라이언트 접속 가능성, 네트워크 지연 등)
- 복합 유니크 제약조건: 예외 처리 복잡성, 벌크 연산 시 성능 저하 우려
- MySQL Upsert: JPA 표준이 아니며 벤더 종속성 발생(또한 기존 비즈니스 로직 가독성 해칠 우려, 유니크 제약 조건 필요)
- 낙관적/비관적 락: 레코드가 없을 때 생성하는 로직에는 적용 불가(비관적 락의 경우 테이블 락 우려)
- 분산 락 (선택): 기존 로직 수정 최소화, Redis 인프라 활용, 구현 비교적 간단

**1️⃣ 분산 락 시스템 구현**

- Redis 기반의 분산 락 시스템 구현 (`DistributedLock`, `RedisLockManager`, `LockAcquisitionException`)
- 락 획득 실패 시 재시도 메커니즘 포함 (최대 재시도 횟수, 재시도 대기 시간 설정 가능)
- 락 획득 실패 시 지수 백오프 및 지터 적용으로 효율적인 재시도 구현
- TransactionExecutor를 활용한 독립적 트랜잭션 컨텍스트 제공
- Lua 스크립트를 활용한 안전한 락 해제 구현 (락 소유자만 해제 가능)

**2️⃣ 루틴 완료 상태 변경 동시성 처리**

- `updateRoutineCompletion` 메서드에 분산 락 적용
- 락 키: routine:{routineId}:date:{date} 형식으로 구성
- 동일한 루틴의 동일한 날짜에 대해 동시에 여러 요청이 들어와도 중복 기록 방지

**3️⃣ 개별 루틴 삭제 동시성 처리**

- `deleteIndividualRoutine` 메서드에 분산 락 적용
- 동일한 락 키 전략 사용하여 동시 요청 처리
- 삭제 상태 기록의 중복 생성 방지

**4️⃣ 테스트 코드 작성**

- `RoutineUseCaseConcurrencyTest`: 실제 동시성 시나리오 테스트
  - 6개의 스레드가 거의 동시에 요청하는 상황 재현
  - 랜덤 지연을 통한 실제 운영 환경 시뮬레이션
- `DistributedLockTest`: 분산 락 단위 테스트
- `RedisLockManagerTest`: Redis 락 매니저 단위 테스트 및 동시성 테스트

## 🚨 사용상 주의사항

**1️⃣ 분산 락 사용 시 주의사항**

> 락 해제를 트랜잭션 커밋 이전에 하게 된다면, 락이 해제된 후 커밋 전에 다른 스레드가 접근할 수 있게 됩니다. 이 경우 첫 번째 트랜잭션의 변경사항이 아직 데이터베이스에 반영되지 않은 상태에서 두 번째 스레드가 동일 리소스에 접근하게 되어, 데이터 불일치 문제가 발생할 수 있습니다. 이처럼 트랜잭션과 락의 생명주기 불일치는 동시성 제어의 근본적인 목적을 훼손시킵니다. 이를 방지하기 위해 내부적으로 새 트랜잭션을 열어 락과 트랜잭션의 생명주기를 일치시키는 방식을 선택했습니다.

- 트랜잭션 독립성: 분산 락은 `REQUIRES_NEW` 전파 옵션을 사용하므로 기존 트랜잭션과 독립적으로 실행됩니다
- 롤백 미적용: 외부 트랜잭션이 롤백되어도 분산 락 내부 작업은 롤백되지 않습니다
- 예외 전파: 내부 작업 예외 발생 시 외부 트랜잭션은 영향받지 않고 독립적으로 커밋될 수 있습니다
- 자동 락 해제: 작업 실행 완료 후 락이 자동으로 해제되므로 별도 해제 로직이 불필요합니다

**2️⃣ 테스트 시 주의사항**

- 트랜잭션 격리: 외부 트랜잭션에서 저장한 엔티티는 분산 락의 새 트랜잭션에서 접근 불가능합니다
- 테스트 롤백 미적용: JUnit의 `@Transactional` 롤백은 내부 트랜잭션에 적용되지 않아 데이터가 남을 수 있습니다
- 해결 방법:
  - `@Transactional(propagation = Propagation.NEVER)`로 테스트 트랜잭션 비활성화
  - 테스트에서 명시적으로 데이터를 flush한 후 분산 락 사용
  - `@AfterEach`에서 테스트 데이터 정리 필요


