### PR TITLE
푸시 알림 시스템 구현 및 이벤트 기반 아키텍처 도입

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,7 +26,7 @@ reviews:
     ignore_title_keywords: [ ]
     labels: [ ]
     drafts: false
-    base_branches: [ ]
+    base_branches: [ "develop" ]
 
   tools:
     shellcheck:
@@ -85,7 +85,7 @@ knowledge_base:
   issues:
     scope: auto
   jira:
-    project_keys: [] # 필요한 경우 Jira 프로젝트 키 추가
+    project_keys: [ ] # 필요한 경우 Jira 프로젝트 키 추가
   docs:
     spring_references: # Spring 관련 문서 참조 추가
       enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ out/
 
 ### application*.properties ###
 src/main/resources/*.properties
+src/main/resources/*.json
 
 ### docker ###
 docker-infra/*

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
     /* CoolSMS */
     implementation 'net.nurigo:sdk:4.3.0'
 
+    /* FCM */
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
+
     /* Feign */
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
@@ -155,7 +158,7 @@ checkstyleMain.source = fileTree('src/main/java')
 // submodule 에서 민감정보 이동
 tasks.register('copyPrivate', Copy) {
     from 'toduck-backend-private'
-    include "*.properties"
+    include "*.properties", "*.json"
     into 'src/main/resources'
 }
 processResources.dependsOn('copyPrivate')

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -320,3 +320,52 @@ CREATE TABLE account_deletion_log
     created_at  DATETIME                                                                                    NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
+
+CREATE TABLE device_token (
+                              id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                              user_id BIGINT NOT NULL,
+                              token VARCHAR(512) NOT NULL,
+                              device_type ENUM('IOS') NOT NULL,
+                              created_at DATETIME NOT NULL,
+                              updated_at DATETIME NOT NULL,
+                              deleted_at DATETIME DEFAULT NULL,
+                              FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE notification_setting (
+                                      id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                                      user_id BIGINT NOT NULL,
+                                      all_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                                      notification_method ENUM('SOUND_ONLY', 'VIBRATION_ONLY') NOT NULL DEFAULT 'SOUND_ONLY',
+                                      notice_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                                      home_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                                      concentration_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                                      diary_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                                      social_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                                      created_at DATETIME NOT NULL,
+                                      updated_at DATETIME NOT NULL,
+                                      deleted_at DATETIME DEFAULT NULL,
+                                      FOREIGN KEY (user_id) REFERENCES users (id),
+                                      UNIQUE KEY notification_setting_user_id_unique (user_id)
+);
+
+CREATE TABLE notification (
+                              id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                              user_id BIGINT NOT NULL,
+                              type ENUM('COMMENT', 'REPLY', 'REPLY_ON_MY_POST', 'LIKE_POST', 'LIKE_COMMENT', 'FOLLOW',
+             'SCHEDULE_REMINDER', 'ROUTINE_REMINDER', 'DIARY_REMINDER', 'INACTIVITY_REMINDER',
+             'ROUTINE_SHARE_MILESTONE') NOT NULL,
+                              in_app_title VARCHAR(100) NOT NULL,
+                              in_app_body VARCHAR(500) NOT NULL,
+                              push_title VARCHAR(100) NOT NULL,
+                              push_body VARCHAR(500) NOT NULL,
+                              action_url VARCHAR(1024) DEFAULT NULL,
+                              data JSON DEFAULT NULL,
+                              is_read BOOLEAN NOT NULL DEFAULT FALSE,
+                              is_in_app_shown BOOLEAN NOT NULL DEFAULT FALSE,
+                              is_sent BOOLEAN NOT NULL DEFAULT FALSE,
+                              created_at DATETIME NOT NULL,
+                              updated_at DATETIME NOT NULL,
+                              deleted_at DATETIME DEFAULT NULL,
+                              FOREIGN KEY (user_id) REFERENCES users (id)
+);

--- a/src/main/java/im/toduck/ToduckBackendApplication.java
+++ b/src/main/java/im/toduck/ToduckBackendApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableAsync
 @ConfigurationPropertiesScan
 public class ToduckBackendApplication {
 	public static void main(String[] args) {

--- a/src/main/java/im/toduck/domain/notification/common/converter/NotificationDataConverter.java
+++ b/src/main/java/im/toduck/domain/notification/common/converter/NotificationDataConverter.java
@@ -1,0 +1,65 @@
+package im.toduck.domain.notification.common.converter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+
+import im.toduck.domain.notification.domain.data.NotificationData;
+import im.toduck.domain.notification.persistence.entity.NotificationType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Converter
+public class NotificationDataConverter implements AttributeConverter<NotificationData, String> {
+	private static final ObjectMapper objectMapper;
+
+	static {
+		objectMapper = new ObjectMapper();
+
+		Arrays.stream(NotificationType.values())
+			.filter(type -> type.getDataClass() != null)
+			.forEach(type -> objectMapper.registerSubtypes(
+				new NamedType(type.getDataClass(), type.name())
+			));
+
+		objectMapper.activateDefaultTyping(
+			objectMapper.getPolymorphicTypeValidator(),
+			ObjectMapper.DefaultTyping.NON_FINAL,
+			JsonTypeInfo.As.PROPERTY
+		);
+	}
+
+	@Override
+	public String convertToDatabaseColumn(NotificationData attribute) {
+		if (attribute == null) {
+			return null;
+		}
+
+		try {
+			return objectMapper.writeValueAsString(attribute);
+		} catch (JsonProcessingException e) {
+			log.error("NotificationData JSON 변환 실패: {}", e.getMessage());
+			throw new RuntimeException("NotificationData를 JSON으로 변환하는데 실패했습니다.", e);
+		}
+	}
+
+	@Override
+	public NotificationData convertToEntityAttribute(String dbData) {
+		if (dbData == null || dbData.isEmpty()) {
+			return null;
+		}
+
+		try {
+			return objectMapper.readValue(dbData, NotificationData.class);
+		} catch (IOException e) {
+			log.error("JSON NotificationData 변환 실패: {}", e.getMessage());
+			throw new RuntimeException("JSON을 NotificationData로 변환하는데 실패했습니다.", e);
+		}
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/common/mapper/NotificationMapper.java
+++ b/src/main/java/im/toduck/domain/notification/common/mapper/NotificationMapper.java
@@ -1,0 +1,74 @@
+package im.toduck.domain.notification.common.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import im.toduck.domain.notification.domain.data.NotificationData;
+import im.toduck.domain.notification.domain.event.NotificationEvent;
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.persistence.entity.NotificationSetting;
+import im.toduck.domain.notification.presentation.dto.response.NotificationDto;
+import im.toduck.domain.notification.presentation.dto.response.NotificationListResponse;
+import im.toduck.domain.notification.presentation.dto.response.NotificationSettingResponse;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class NotificationMapper {
+
+	public static NotificationDto toNotificationDto(final Notification notification) {
+		NotificationData data = notification.getTypedData();
+
+		return NotificationDto.builder()
+			.id(notification.getId())
+			.type(notification.getType())
+			.title(notification.getInAppTitle())
+			.body(notification.getInAppBody())
+			.actionUrl(notification.getActionUrl())
+			.data(data)
+			.isRead(notification.getIsRead())
+			.createdAt(notification.getCreatedAt())
+			.build();
+	}
+
+	public static NotificationListResponse toNotificationListResponse(final List<Notification> notifications) {
+		List<NotificationDto> notificationDtos = notifications.stream()
+			.map(NotificationMapper::toNotificationDto)
+			.collect(Collectors.toList());
+
+		return NotificationListResponse.builder()
+			.notifications(notificationDtos)
+			.build();
+	}
+
+	public static NotificationSettingResponse toNotificationSettingResponse(final NotificationSetting settings) {
+		return NotificationSettingResponse.builder()
+			.allEnabled(settings.isAllEnabled())
+			.notificationMethod(settings.getNotificationMethod())
+			.noticeEnabled(settings.isNoticeEnabled())
+			.homeEnabled(settings.isHomeEnabled())
+			.concentrationEnabled(settings.isConcentrationEnabled())
+			.diaryEnabled(settings.isDiaryEnabled())
+			.socialEnabled(settings.isSocialEnabled())
+			.build();
+	}
+
+	public static <T extends NotificationData> Notification toNotification(
+		final User user,
+		final NotificationEvent<T> event
+	) {
+		boolean isInAppShown = event.getType().isDefaultInAppShown();
+
+		return Notification.builder()
+			.user(user)
+			.type(event.getType())
+			.inAppTitle(event.getInAppTitle())
+			.inAppBody(event.getInAppBody())
+			.pushTitle(event.getPushTitle())
+			.pushBody(event.getPushBody())
+			.actionUrl(event.getActionUrl())
+			.isInAppShown(isInAppShown)
+			.notificationData(event.getData())
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/common/mapper/NotificationMapper.java
+++ b/src/main/java/im/toduck/domain/notification/common/mapper/NotificationMapper.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 public class NotificationMapper {
 
 	public static NotificationDto toNotificationDto(final Notification notification) {
-		NotificationData data = notification.getTypedData();
+		NotificationData data = notification.getData();
 
 		return NotificationDto.builder()
 			.id(notification.getId())

--- a/src/main/java/im/toduck/domain/notification/domain/data/AbstractNotificationData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/AbstractNotificationData.java
@@ -1,0 +1,13 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+
+/**
+ * 알림 데이터의 기본 추상 클래스
+ */
+@Getter
+public abstract class AbstractNotificationData implements NotificationData {
+	// 공통 속성을 추가할 수 있음
+	protected AbstractNotificationData() {
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/CommentNotificationData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/CommentNotificationData.java
@@ -1,0 +1,24 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 게시글에 댓글이 작성되었을 때 사용하는 알림 데이터
+ */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentNotificationData extends AbstractNotificationData {
+	private final String commenterName;
+	private final String commentContent;
+	private final Long postId;
+
+	public static CommentNotificationData of(
+		final String commenterName,
+		final String commentContent,
+		final Long postId
+	) {
+		return new CommentNotificationData(commenterName, commentContent, postId);
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/CommentNotificationData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/CommentNotificationData.java
@@ -1,18 +1,19 @@
 package im.toduck.domain.notification.domain.data;
 
-import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 /**
  * 게시글에 댓글이 작성되었을 때 사용하는 알림 데이터
  */
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@AllArgsConstructor
 public class CommentNotificationData extends AbstractNotificationData {
-	private final String commenterName;
-	private final String commentContent;
-	private final Long postId;
+	private String commenterName;
+	private String commentContent;
+	private Long postId;
 
 	public static CommentNotificationData of(
 		final String commenterName,

--- a/src/main/java/im/toduck/domain/notification/domain/data/DiaryReminderData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/DiaryReminderData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 일기 작성 유도 알림에 사용하는 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class DiaryReminderData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 유도 타입, 마지막 일기 작성 날짜 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/FollowNotificationData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/FollowNotificationData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자가 나를 팔로우했을 때 사용하는 알림 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class FollowNotificationData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 팔로우한 사용자 ID, 사용자 이름 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/InactivityReminderData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/InactivityReminderData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 미접속 알림에 사용하는 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class InactivityReminderData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 마지막 접속 날짜, 미접속 일수 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/LikeCommentNotificationData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/LikeCommentNotificationData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 내 댓글에 좋아요가 눌렸을 때 사용하는 알림 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class LikeCommentNotificationData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 좋아요 누른 사용자 ID, 사용자 이름, 댓글 ID, 게시글 ID 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/LikePostNotificationData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/LikePostNotificationData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 내 게시글에 좋아요가 눌렸을 때 사용하는 알림 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class LikePostNotificationData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 좋아요 누른 사용자 ID, 사용자 이름, 게시글 ID 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/NotificationData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/NotificationData.java
@@ -1,0 +1,15 @@
+package im.toduck.domain.notification.domain.data;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * 모든 알림 데이터 클래스가 구현해야 하는 기본 인터페이스
+ */
+@JsonTypeInfo(
+	use = JsonTypeInfo.Id.NAME,
+	property = "type"
+)
+public interface NotificationData extends Serializable {
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/ReplyNotificationData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/ReplyNotificationData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 내 댓글에 답글이 작성되었을 때 사용하는 알림 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class ReplyNotificationData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 답글 작성자 ID, 답글 작성자 이름, 답글 내용, 원 댓글 ID, 게시글 ID 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/ReplyOnMyPostNotificationData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/ReplyOnMyPostNotificationData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 내 게시글의 내 댓글에 답글이 작성되었을 때 사용하는 알림 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class ReplyOnMyPostNotificationData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 답글 작성자 ID, 답글 작성자 이름, 답글 내용, 원 댓글 ID, 게시글 ID 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/RoutineReminderData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/RoutineReminderData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 루틴 알림에 사용하는 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class RoutineReminderData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 루틴 ID, 루틴 제목, 루틴 시작 시간, 남은 시간 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/RoutineShareMilestoneData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/RoutineShareMilestoneData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 루틴 공유 마일스톤에 사용하는 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class RoutineShareMilestoneData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 루틴 ID, 루틴 제목, 공유 횟수 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/data/ScheduleReminderData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/ScheduleReminderData.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.domain.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 일정 알림에 사용하는 데이터
+ */
+@Getter
+@NoArgsConstructor
+public class ScheduleReminderData extends AbstractNotificationData {
+	// TODO: 필요한 필드 추가
+	// 예상 필드: 일정 ID, 일정 제목, 일정 시작 시간, 남은 시간 등
+}

--- a/src/main/java/im/toduck/domain/notification/domain/event/CommentNotificationEvent.java
+++ b/src/main/java/im/toduck/domain/notification/domain/event/CommentNotificationEvent.java
@@ -1,0 +1,45 @@
+package im.toduck.domain.notification.domain.event;
+
+import im.toduck.domain.notification.domain.data.CommentNotificationData;
+import im.toduck.domain.notification.persistence.entity.NotificationType;
+import lombok.Getter;
+
+@Getter
+public class CommentNotificationEvent extends NotificationEvent<CommentNotificationData> {
+
+	private CommentNotificationEvent(Long userId, CommentNotificationData data) {
+		super(userId, NotificationType.COMMENT, data);
+	}
+
+	public static CommentNotificationEvent of(Long userId, String commenterName, String commentContent, Long postId) {
+		return new CommentNotificationEvent(
+			userId,
+			CommentNotificationData.of(commenterName, commentContent, postId)
+		);
+	}
+
+	@Override
+	public String getInAppTitle() {
+		return getData().getCommenterName() + "님이 내 게시물에 댓글을 남겼어요.";
+	}
+
+	@Override
+	public String getInAppBody() {
+		return getData().getCommentContent();
+	}
+
+	@Override
+	public String getPushTitle() {
+		return getInAppTitle();
+	}
+
+	@Override
+	public String getPushBody() {
+		return getInAppBody();
+	}
+
+	@Override
+	public String getActionUrl() {
+		return "toduck://post?postId=" + getData().getPostId();
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/event/NotificationEvent.java
+++ b/src/main/java/im/toduck/domain/notification/domain/event/NotificationEvent.java
@@ -1,0 +1,77 @@
+package im.toduck.domain.notification.domain.event;
+
+import im.toduck.domain.notification.domain.data.NotificationData;
+import im.toduck.domain.notification.persistence.entity.NotificationType;
+import lombok.Getter;
+
+/**
+ * 알림 이벤트의 기본 추상 클래스.
+ * 모든 알림 이벤트는 이 클래스를 상속받아 구현합니다.
+ *
+ * @param <T> 알림에 필요한 추가 데이터 타입 (NotificationData 상속)
+ */
+@Getter
+public abstract class NotificationEvent<T extends NotificationData> {
+	/**
+	 * 알림을 받을 사용자의 ID
+	 */
+	private final Long userId;
+
+	/**
+	 * 알림의 유형
+	 */
+	private final NotificationType type;
+
+	/**
+	 * 알림 유형별 구체적인 데이터
+	 */
+	private final T data;
+
+	/**
+	 * 알림 이벤트 생성자
+	 *
+	 * @param userId 알림을 받을 사용자의 ID
+	 * @param type 알림 유형
+	 * @param data 알림 관련 추가 데이터
+	 */
+	protected NotificationEvent(final Long userId, final NotificationType type, final T data) {
+		this.userId = userId;
+		this.type = type;
+		this.data = data;
+	}
+
+	/**
+	 * 앱 내 알림창에 표시될 제목을 반환합니다.
+	 *
+	 * @return 앱 내 알림 제목
+	 */
+	public abstract String getInAppTitle();
+
+	/**
+	 * 앱 내 알림창에 표시될 내용을 반환합니다.
+	 *
+	 * @return 앱 내 알림 내용
+	 */
+	public abstract String getInAppBody();
+
+	/**
+	 * 푸시 알림으로 전송될 제목을 반환합니다.
+	 *
+	 * @return 푸시 알림 제목
+	 */
+	public abstract String getPushTitle();
+
+	/**
+	 * 푸시 알림으로 전송될 내용을 반환합니다.
+	 *
+	 * @return 푸시 알림 내용
+	 */
+	public abstract String getPushBody();
+
+	/**
+	 * 알림 클릭 시 이동할 앱 내 경로(URL)를 반환합니다.
+	 *
+	 * @return 액션 URL (앱 내 화면 이동 경로)
+	 */
+	public abstract String getActionUrl();
+}

--- a/src/main/java/im/toduck/domain/notification/domain/event/NotificationEventListener.java
+++ b/src/main/java/im/toduck/domain/notification/domain/event/NotificationEventListener.java
@@ -1,0 +1,41 @@
+package im.toduck.domain.notification.domain.event;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import im.toduck.domain.notification.domain.service.NotificationService;
+import im.toduck.domain.notification.domain.service.NotificationSettingService;
+import im.toduck.domain.notification.domain.service.PushNotificationService;
+import im.toduck.domain.notification.persistence.entity.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+	private final NotificationService notificationService;
+	private final PushNotificationService pushNotificationService;
+	private final NotificationSettingService notificationSettingService;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Async
+	@Transactional(propagation = Propagation.REQUIRES_NEW) // 항상 새로운 트랜잭션 시작
+	public void handleNotificationEvent(final NotificationEvent<?> event) {
+		log.info("알림 이벤트 처리 - 타입: {}, 사용자: {}", event.getType(), event.getUserId());
+
+		Notification notification = notificationService.createNotification(event);
+		log.info("알림 저장 완료 - ID: {}", notification.getId());
+
+		if (notificationSettingService.isTypeEnabled(event.getUserId(), event.getType())) {
+			pushNotificationService.sendPushNotification(notification);
+			return;
+		}
+
+		log.info("푸시 알림 비활성화 - 사용자: {}, 타입: {}", event.getUserId(), event.getType());
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/service/DeviceTokenService.java
+++ b/src/main/java/im/toduck/domain/notification/domain/service/DeviceTokenService.java
@@ -1,0 +1,81 @@
+package im.toduck.domain.notification.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.notification.persistence.entity.DeviceToken;
+import im.toduck.domain.notification.persistence.entity.DeviceType;
+import im.toduck.domain.notification.persistence.repository.DeviceTokenRepository;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeviceTokenService {
+	private final DeviceTokenRepository deviceTokenRepository;
+	private final UserService userService;
+
+	@Transactional
+	public void registerDeviceToken(final Long userId, final String token, final DeviceType deviceType) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		deviceTokenRepository.findByUserAndToken(user, token)
+			.ifPresentOrElse(
+				existingToken -> log.debug("디바이스 토큰 이미 등록됨 - 사용자: {}, 토큰: {}", userId, token),
+				() -> {
+					DeviceToken deviceToken = DeviceToken.builder()
+						.user(user)
+						.token(token)
+						.deviceType(deviceType)
+						.build();
+					deviceTokenRepository.save(deviceToken);
+					log.info("디바이스 토큰 등록 성공 - 사용자: {}, 디바이스: {}", userId, deviceType);
+				}
+			);
+	}
+
+	/**
+	 * 디바이스 토큰을 삭제합니다.
+	 * 사용자가 로그아웃하거나 앱을 제거할 때 호출됩니다.
+	 */
+	@Transactional
+	public void removeDeviceToken(final Long userId, final String token) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		deviceTokenRepository.findByUserAndToken(user, token)
+			.ifPresent(deviceToken -> {
+				deviceTokenRepository.delete(deviceToken);
+				log.info("디바이스 토큰 삭제 성공 - 사용자: {}, 토큰: {}", userId, token);
+			});
+	}
+
+	/**
+	 * 무효화된 토큰을 삭제합니다.
+	 * FCM에서 토큰이 무효화되었다고 통보받았을 때 호출됩니다.
+	 */
+	@Transactional
+	public void removeInvalidToken(final String token) {
+		deviceTokenRepository.deleteByToken(token);
+		log.info("무효화된 토큰 삭제 - 토큰: {}", token);
+	}
+
+	/**
+	 * 사용자의 모든 디바이스 토큰을 조회합니다.
+	 */
+	@Transactional(readOnly = true)
+	public List<DeviceToken> getUserDeviceTokens(final Long userId) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		return deviceTokenRepository.findAllByUser(user);
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/service/NotificationService.java
+++ b/src/main/java/im/toduck/domain/notification/domain/service/NotificationService.java
@@ -1,0 +1,64 @@
+package im.toduck.domain.notification.domain.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.notification.common.mapper.NotificationMapper;
+import im.toduck.domain.notification.domain.data.NotificationData;
+import im.toduck.domain.notification.domain.event.NotificationEvent;
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.persistence.repository.NotificationRepository;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+	private final NotificationRepository notificationRepository;
+	private final UserService userService;
+
+	@Transactional
+	public <T extends NotificationData> Notification createNotification(NotificationEvent<T> event) {
+		User user = userService.getUserById(event.getUserId())
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		Notification notification = NotificationMapper.toNotification(user, event);
+
+		return notificationRepository.save(notification);
+	}
+
+	@Transactional(readOnly = true)
+	public List<Notification> getUserInAppNotifications(Long userId, int page, int size) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		return notificationRepository.findByUserAndIsInAppShownTrueOrderByCreatedAtDesc(
+			user, PageRequest.of(page, size));
+	}
+
+	@Transactional
+	public void markAsRead(Long notificationId, Long userId) {
+		Notification notification = notificationRepository.findByIdAndUser_Id(notificationId, userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_NOTIFICATION));
+
+		notification.markAsRead();
+	}
+
+	@Transactional
+	public void markAllAsRead(Long userId) {
+		notificationRepository.markAllAsRead(userId);
+	}
+
+	@Transactional
+	public void markAsSent(Notification notification) {
+		notification.markAsSent();
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/service/NotificationSettingService.java
+++ b/src/main/java/im/toduck/domain/notification/domain/service/NotificationSettingService.java
@@ -1,0 +1,58 @@
+package im.toduck.domain.notification.domain.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.notification.persistence.entity.NotificationSetting;
+import im.toduck.domain.notification.persistence.entity.NotificationType;
+import im.toduck.domain.notification.persistence.repository.NotificationSettingRepository;
+import im.toduck.domain.notification.presentation.dto.request.NotificationSettingUpdateRequest;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService {
+	private final NotificationSettingRepository notificationSettingRepository;
+	private final UserService userService;
+
+	@Transactional
+	public NotificationSetting getOrCreateSettings(final Long userId) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		return notificationSettingRepository.findByUser(user)
+			.orElseGet(() -> {
+				NotificationSetting setting = NotificationSetting.builder()
+					.user(user)
+					.build();
+				return notificationSettingRepository.save(setting);
+			});
+	}
+
+	@Transactional
+	public NotificationSetting updateSettings(final Long userId, final NotificationSettingUpdateRequest request) {
+		NotificationSetting setting = getOrCreateSettings(userId);
+
+		setting.updateAllEnabled(request.allEnabled());
+		setting.updateNotificationMethod(request.notificationMethod());
+		setting.updateNoticeEnabled(request.noticeEnabled());
+		setting.updateHomeEnabled(request.homeEnabled());
+		setting.updateConcentrationEnabled(request.concentrationEnabled());
+		setting.updateDiaryEnabled(request.diaryEnabled());
+		setting.updateSocialEnabled(request.socialEnabled());
+
+		return setting;
+	}
+
+	@Transactional(readOnly = true)
+	public boolean isTypeEnabled(final Long userId, final NotificationType type) {
+		NotificationSetting setting = getOrCreateSettings(userId);
+		return setting.isTypeEnabled(type);
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/service/PushNotificationService.java
+++ b/src/main/java/im/toduck/domain/notification/domain/service/PushNotificationService.java
@@ -1,0 +1,64 @@
+package im.toduck.domain.notification.domain.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.notification.persistence.entity.DeviceToken;
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.persistence.entity.NotificationMethod;
+import im.toduck.domain.notification.persistence.entity.NotificationSetting;
+import im.toduck.infra.push.FcmService;
+import im.toduck.infra.push.payload.FcmPayloadFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushNotificationService {
+	private final DeviceTokenService deviceTokenService;
+	private final NotificationSettingService notificationSettingService;
+	private final NotificationService notificationService;
+	private final FcmService fcmService;
+	private final FcmPayloadFactory fcmPayloadFactory;
+
+	@Transactional
+	public void sendPushNotification(final Notification notification) {
+		Long userId = notification.getUser().getId();
+
+		List<DeviceToken> deviceTokens = deviceTokenService.getUserDeviceTokens(userId);
+
+		if (deviceTokens.isEmpty()) {
+			log.info("등록된 디바이스 토큰 없음 - 사용자: {}", userId);
+			return;
+		}
+
+		NotificationSetting settings = notificationSettingService.getOrCreateSettings(userId);
+		NotificationMethod method = settings.getNotificationMethod();
+
+		Map<String, String> payload = fcmPayloadFactory.createPayload(notification, method);
+
+		boolean anySuccess = false;
+		for (DeviceToken deviceToken : deviceTokens) {
+			boolean success = fcmService.sendNotification(
+				deviceToken.getToken(),
+				notification.getPushTitle(),
+				notification.getPushBody(),
+				payload
+			);
+
+			if (success) {
+				anySuccess = true;
+			} else {
+				log.warn("알림 전송 실패 - 토큰: {}", deviceToken.getToken());
+			}
+		}
+
+		if (anySuccess) {
+			notificationService.markAsSent(notification);
+		}
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/usecase/NotificationUseCase.java
+++ b/src/main/java/im/toduck/domain/notification/domain/usecase/NotificationUseCase.java
@@ -1,0 +1,75 @@
+package im.toduck.domain.notification.domain.usecase;
+
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.notification.common.mapper.NotificationMapper;
+import im.toduck.domain.notification.domain.service.DeviceTokenService;
+import im.toduck.domain.notification.domain.service.NotificationService;
+import im.toduck.domain.notification.domain.service.NotificationSettingService;
+import im.toduck.domain.notification.persistence.entity.DeviceType;
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.persistence.entity.NotificationSetting;
+import im.toduck.domain.notification.presentation.dto.request.NotificationSettingUpdateRequest;
+import im.toduck.domain.notification.presentation.dto.response.NotificationListResponse;
+import im.toduck.domain.notification.presentation.dto.response.NotificationSettingResponse;
+import im.toduck.global.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class NotificationUseCase {
+
+	private final DeviceTokenService deviceTokenService;
+	private final NotificationSettingService notificationSettingService;
+	private final NotificationService notificationService;
+
+	@Transactional
+	public void registerDeviceToken(final Long userId, final String token, final DeviceType deviceType) {
+		deviceTokenService.registerDeviceToken(userId, token, deviceType);
+		log.info("디바이스 토큰 등록 성공 - UserId: {}, DeviceType: {}", userId, deviceType);
+	}
+
+	@Transactional
+	public void removeDeviceToken(final Long userId, final String token) {
+		deviceTokenService.removeDeviceToken(userId, token);
+		log.info("디바이스 토큰 삭제 성공 - UserId: {}", userId);
+	}
+
+	@Transactional(readOnly = true)
+	public NotificationSettingResponse getNotificationSettings(final Long userId) {
+		NotificationSetting settings = notificationSettingService.getOrCreateSettings(userId);
+		return NotificationMapper.toNotificationSettingResponse(settings);
+	}
+
+	@Transactional
+	public NotificationSettingResponse updateNotificationSettings(
+		final Long userId,
+		final NotificationSettingUpdateRequest request
+	) {
+		NotificationSetting settings = notificationSettingService.updateSettings(userId, request);
+		log.info("알림 설정 업데이트 성공 - UserId: {}", userId);
+		return NotificationMapper.toNotificationSettingResponse(settings);
+	}
+
+	@Transactional(readOnly = true)
+	public NotificationListResponse getNotifications(final Long userId, final int page, final int size) {
+		List<Notification> notifications = notificationService.getUserInAppNotifications(userId, page, size);
+		return NotificationMapper.toNotificationListResponse(notifications);
+	}
+
+	@Transactional
+	public void markNotificationAsRead(final Long userId, final Long notificationId) {
+		notificationService.markAsRead(notificationId, userId);
+		log.info("알림 읽음 표시 성공 - UserId: {}, NotificationId: {}", userId, notificationId);
+	}
+
+	@Transactional
+	public void markAllNotificationsAsRead(final Long userId) {
+		notificationService.markAllAsRead(userId);
+		log.info("모든 알림 읽음 표시 성공 - UserId: {}", userId);
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/entity/DeviceToken.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/entity/DeviceToken.java
@@ -1,0 +1,51 @@
+package im.toduck.domain.notification.persistence.entity;
+
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.base.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "device_token")
+@Getter
+@NoArgsConstructor
+public class DeviceToken extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(nullable = false, length = 512)
+	private String token;
+
+	@Column(nullable = false, length = 50)
+	@Enumerated(EnumType.STRING)
+	private DeviceType deviceType;
+
+	@Builder
+	private DeviceToken(User user, String token, DeviceType deviceType) {
+		this.user = user;
+		this.token = token;
+		this.deviceType = deviceType;
+	}
+
+	public void updateToken(String token) {
+		this.token = token;
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/entity/DeviceType.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/entity/DeviceType.java
@@ -1,0 +1,5 @@
+package im.toduck.domain.notification.persistence.entity;
+
+public enum DeviceType {
+	IOS
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/entity/Notification.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/entity/Notification.java
@@ -1,0 +1,145 @@
+package im.toduck.domain.notification.persistence.entity;
+
+import java.util.Arrays;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+
+import im.toduck.domain.notification.domain.data.NotificationData;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.base.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notification")
+@Getter
+@NoArgsConstructor
+public class Notification extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private NotificationType type;
+
+	@Column(name = "in_app_title", nullable = false, length = 100)
+	private String inAppTitle;
+
+	@Column(name = "in_app_body", nullable = false, length = 500)
+	private String inAppBody;
+
+	@Column(name = "push_title", nullable = false, length = 100)
+	private String pushTitle;
+
+	@Column(name = "push_body", nullable = false, length = 500)
+	private String pushBody;
+
+	@Column(length = 1024)
+	private String actionUrl;
+
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(name = "data", columnDefinition = "json")
+	@Getter(AccessLevel.NONE)
+	private NotificationData data;
+
+	@Column(nullable = false)
+	private Boolean isRead;
+
+	@Column(nullable = false)
+	private Boolean isInAppShown;
+
+	@Column(nullable = false)
+	private Boolean isSent;
+
+	private static final ObjectMapper objectMapper;
+
+	static {
+		objectMapper = new ObjectMapper();
+
+		Arrays.stream(NotificationType.values()).forEach(type -> {
+			Class<? extends NotificationData> dataClass = type.getDataClass();
+			if (dataClass != null) {
+				objectMapper.registerSubtypes(new NamedType(dataClass, type.name()));
+			}
+		});
+
+		objectMapper.activateDefaultTyping(
+			objectMapper.getPolymorphicTypeValidator(),
+			ObjectMapper.DefaultTyping.NON_FINAL,
+			JsonTypeInfo.As.PROPERTY
+		);
+	}
+
+	@Builder
+	private Notification(
+		final User user,
+		final NotificationType type,
+		final String inAppTitle,
+		final String inAppBody,
+		final String pushTitle,
+		final String pushBody,
+		final String actionUrl,
+		final Boolean isInAppShown,
+		final NotificationData notificationData
+	) {
+		this.user = user;
+		this.type = type;
+		this.inAppTitle = inAppTitle;
+		this.inAppBody = inAppBody;
+		this.pushTitle = pushTitle;
+		this.pushBody = pushBody;
+		this.actionUrl = actionUrl;
+		this.isRead = false;
+		this.isInAppShown = isInAppShown;
+		this.isSent = false;
+		this.data = notificationData;
+	}
+
+	public void markAsRead() {
+		this.isRead = true;
+	}
+
+	public void markAsSent() {
+		this.isSent = true;
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T extends NotificationData> T getTypedData() {
+		if (data == null) {
+			return null;
+		}
+
+		Class<? extends NotificationData> dataClass = type.getDataClass();
+		if (dataClass.isInstance(data)) {
+			return (T)data;
+		}
+
+		throw new ClassCastException(
+			"NotificationType " + type + "에 맞는 데이터 타입으로 변환할 수 없습니다. 실제 타입: " + data.getClass().getName()
+		);
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationCategory.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationCategory.java
@@ -1,0 +1,18 @@
+package im.toduck.domain.notification.persistence.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationCategory {
+	NOTICE("공지 알림"),
+	HOME("일정, 루틴 알림"),
+	CONCENTRATION("집중 알림"),
+	DIARY("일기 알림"),
+	SOCIAL("소셜 알림");
+
+	private final String description;
+
+	NotificationCategory(String description) {
+		this.description = description;
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationMethod.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationMethod.java
@@ -1,0 +1,6 @@
+package im.toduck.domain.notification.persistence.entity;
+
+public enum NotificationMethod {
+	SOUND_ONLY,
+	VIBRATION_ONLY
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationSetting.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationSetting.java
@@ -1,0 +1,109 @@
+package im.toduck.domain.notification.persistence.entity;
+
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.base.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notification_setting")
+@Getter
+@NoArgsConstructor
+public class NotificationSetting extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "all_enabled", nullable = false)
+	private boolean allEnabled;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "notification_method", nullable = false)
+	private NotificationMethod notificationMethod;
+
+	@Column(name = "notice_enabled", nullable = false)
+	private boolean noticeEnabled;
+
+	@Column(name = "home_enabled", nullable = false)
+	private boolean homeEnabled;
+
+	@Column(name = "concentration_enabled", nullable = false)
+	private boolean concentrationEnabled;
+
+	@Column(name = "diary_enabled", nullable = false)
+	private boolean diaryEnabled;
+
+	@Column(name = "social_enabled", nullable = false)
+	private boolean socialEnabled;
+
+	@Builder
+	private NotificationSetting(User user) {
+		this.user = user;
+		this.allEnabled = true;
+		this.notificationMethod = NotificationMethod.SOUND_ONLY;
+		this.noticeEnabled = true;
+		this.homeEnabled = true;
+		this.concentrationEnabled = true;
+		this.diaryEnabled = true;
+		this.socialEnabled = true;
+	}
+
+	public void updateAllEnabled(boolean enabled) {
+		this.allEnabled = enabled;
+	}
+
+	public void updateNotificationMethod(NotificationMethod method) {
+		this.notificationMethod = method;
+	}
+
+	public void updateNoticeEnabled(boolean enabled) {
+		this.noticeEnabled = enabled;
+	}
+
+	public void updateHomeEnabled(boolean enabled) {
+		this.homeEnabled = enabled;
+	}
+
+	public void updateConcentrationEnabled(boolean enabled) {
+		this.concentrationEnabled = enabled;
+	}
+
+	public void updateDiaryEnabled(boolean enabled) {
+		this.diaryEnabled = enabled;
+	}
+
+	public void updateSocialEnabled(boolean enabled) {
+		this.socialEnabled = enabled;
+	}
+
+	public boolean isTypeEnabled(NotificationType type) {
+		if (!allEnabled) {
+			return false;
+		}
+
+		return switch (type.getCategory()) {
+			case NOTICE -> noticeEnabled;
+			case HOME -> homeEnabled;
+			case CONCENTRATION -> concentrationEnabled;
+			case DIARY -> diaryEnabled;
+			case SOCIAL -> socialEnabled;
+		};
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationType.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationType.java
@@ -1,0 +1,60 @@
+package im.toduck.domain.notification.persistence.entity;
+
+import im.toduck.domain.notification.domain.data.CommentNotificationData;
+import im.toduck.domain.notification.domain.data.DiaryReminderData;
+import im.toduck.domain.notification.domain.data.FollowNotificationData;
+import im.toduck.domain.notification.domain.data.InactivityReminderData;
+import im.toduck.domain.notification.domain.data.LikeCommentNotificationData;
+import im.toduck.domain.notification.domain.data.LikePostNotificationData;
+import im.toduck.domain.notification.domain.data.NotificationData;
+import im.toduck.domain.notification.domain.data.ReplyNotificationData;
+import im.toduck.domain.notification.domain.data.ReplyOnMyPostNotificationData;
+import im.toduck.domain.notification.domain.data.RoutineReminderData;
+import im.toduck.domain.notification.domain.data.RoutineShareMilestoneData;
+import im.toduck.domain.notification.domain.data.ScheduleReminderData;
+import lombok.Getter;
+
+@Getter
+public enum NotificationType {
+	COMMENT(NotificationCategory.SOCIAL, CommentNotificationData.class, "내 게시글에 댓글"),
+	REPLY(NotificationCategory.SOCIAL, ReplyNotificationData.class, "내 댓글에 답글"),
+	REPLY_ON_MY_POST(NotificationCategory.SOCIAL, ReplyOnMyPostNotificationData.class, "내 게시글의 내 댓글에 답글"),
+	LIKE_POST(NotificationCategory.SOCIAL, LikePostNotificationData.class, "내 게시글에 좋아요"),
+	LIKE_COMMENT(NotificationCategory.SOCIAL, LikeCommentNotificationData.class, "내 댓글 좋아요"),
+	FOLLOW(NotificationCategory.SOCIAL, FollowNotificationData.class, "나를 팔로우"),
+	ROUTINE_SHARE_MILESTONE(NotificationCategory.SOCIAL, RoutineShareMilestoneData.class, "루틴 공유 마일스톤"),
+
+	SCHEDULE_REMINDER(NotificationCategory.HOME, ScheduleReminderData.class, "일정 임박", false),
+	ROUTINE_REMINDER(NotificationCategory.HOME, RoutineReminderData.class, "루틴 임박", false),
+
+	DIARY_REMINDER(NotificationCategory.DIARY, DiaryReminderData.class, "일기 작성 유도", false),
+	INACTIVITY_REMINDER(NotificationCategory.NOTICE, InactivityReminderData.class, "미접속 알림", false);
+
+	private final NotificationCategory category;
+	private final Class<? extends NotificationData> dataClass;
+	private final String description;
+	private final boolean defaultInAppShown; // 앱 내 알림창에 표시할지 여부의 기본값
+
+	NotificationType(
+		NotificationCategory category,
+		Class<? extends NotificationData> dataClass,
+		String description,
+		boolean defaultInAppShown
+	) {
+		this.category = category;
+		this.dataClass = dataClass;
+		this.description = description;
+		this.defaultInAppShown = defaultInAppShown;
+	}
+
+	NotificationType(
+		NotificationCategory category,
+		Class<? extends NotificationData> dataClass,
+		String description
+	) {
+		this.category = category;
+		this.dataClass = dataClass;
+		this.description = description;
+		this.defaultInAppShown = true;
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/repository/DeviceTokenRepository.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/repository/DeviceTokenRepository.java
@@ -1,0 +1,24 @@
+package im.toduck.domain.notification.persistence.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import im.toduck.domain.notification.persistence.entity.DeviceToken;
+import im.toduck.domain.user.persistence.entity.User;
+
+@Repository
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+	List<DeviceToken> findAllByUser(User user);
+
+	Optional<DeviceToken> findByUserAndToken(User user, String token);
+
+	@Modifying
+	@Query("DELETE FROM DeviceToken dt WHERE dt.token = :token")
+	void deleteByToken(@Param("token") String token);
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/repository/NotificationRepository.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/repository/NotificationRepository.java
@@ -1,0 +1,26 @@
+package im.toduck.domain.notification.persistence.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.persistence.repository.querydsl.NotificationRepositoryCustom;
+import im.toduck.domain.user.persistence.entity.User;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+	List<Notification> findByUserAndIsInAppShownTrueOrderByCreatedAtDesc(User user, Pageable pageable);
+
+	Optional<Notification> findByIdAndUser_Id(Long id, Long userId);
+
+	@Modifying
+	@Query("UPDATE Notification n SET n.isRead = true WHERE n.user.id = :userId AND n.isRead = false")
+	void markAllAsRead(@Param("userId") Long userId);
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/repository/NotificationSettingRepository.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/repository/NotificationSettingRepository.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.persistence.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import im.toduck.domain.notification.persistence.entity.NotificationSetting;
+import im.toduck.domain.user.persistence.entity.User;
+
+@Repository
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+	Optional<NotificationSetting> findByUser(User user);
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/repository/querydsl/NotificationRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/repository/querydsl/NotificationRepositoryCustom.java
@@ -1,0 +1,13 @@
+package im.toduck.domain.notification.persistence.repository.querydsl;
+
+import java.util.List;
+
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.persistence.entity.NotificationType;
+import im.toduck.domain.user.persistence.entity.User;
+
+public interface NotificationRepositoryCustom {
+	List<Notification> findRecentByUserAndType(User user, NotificationType type, int limit);
+
+	long countUnreadByUser(User user);
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/repository/querydsl/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/repository/querydsl/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package im.toduck.domain.notification.persistence.repository.querydsl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.persistence.entity.NotificationType;
+import im.toduck.domain.notification.persistence.entity.QNotification;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+	private final QNotification qNotification = QNotification.notification;
+
+	@Override
+	public List<Notification> findRecentByUserAndType(User user, NotificationType type, int limit) {
+		return queryFactory
+			.selectFrom(qNotification)
+			.where(
+				qNotification.user.eq(user),
+				qNotification.type.eq(type)
+			)
+			.orderBy(qNotification.createdAt.desc())
+			.limit(limit)
+			.fetch();
+	}
+
+	@Override
+	public long countUnreadByUser(User user) {
+		return queryFactory
+			.select(qNotification.count())
+			.from(qNotification)
+			.where(
+				qNotification.user.eq(user),
+				qNotification.isRead.isFalse()
+			)
+			.fetchOne();
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/presentation/api/NotificationApi.java
+++ b/src/main/java/im/toduck/domain/notification/presentation/api/NotificationApi.java
@@ -1,0 +1,125 @@
+package im.toduck.domain.notification.presentation.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import im.toduck.domain.notification.presentation.dto.request.DeviceTokenRegisterRequest;
+import im.toduck.domain.notification.presentation.dto.request.NotificationSettingUpdateRequest;
+import im.toduck.domain.notification.presentation.dto.response.NotificationListResponse;
+import im.toduck.domain.notification.presentation.dto.response.NotificationSettingResponse;
+import im.toduck.global.annotation.swagger.ApiResponseExplanations;
+import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "Notification")
+public interface NotificationApi {
+	@Operation(
+		summary = "디바이스 토큰 등록",
+		description = "푸시 알림을 위한 디바이스 토큰을 등록합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "디바이스 토큰 등록 성공"
+		)
+	)
+	ResponseEntity<ApiResponse<?>> registerDeviceToken(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@RequestBody @Valid final DeviceTokenRegisterRequest request
+	);
+
+	@Operation(
+		summary = "디바이스 토큰 삭제",
+		description = "등록된 디바이스 토큰을 삭제합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "디바이스 토큰 삭제 성공"
+		)
+	)
+	ResponseEntity<ApiResponse<?>> removeDeviceToken(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final String token
+	);
+
+	@Operation(
+		summary = "알림 설정 조회",
+		description = "사용자의 알림 설정을 조회합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = NotificationSettingResponse.class,
+			description = "알림 설정 조회 성공"
+		)
+	)
+	ResponseEntity<ApiResponse<NotificationSettingResponse>> getNotificationSettings(
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	);
+
+	@Operation(
+		summary = "알림 설정 업데이트",
+		description = "사용자의 알림 설정을 업데이트합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = NotificationSettingResponse.class,
+			description = "알림 설정 업데이트 성공"
+		)
+	)
+	ResponseEntity<ApiResponse<NotificationSettingResponse>> updateNotificationSettings(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@RequestBody @Valid final NotificationSettingUpdateRequest request
+	);
+
+	@Operation(
+		summary = "알림 목록 조회",
+		description = "사용자의 알림 목록을 조회합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = NotificationListResponse.class,
+			description = "알림 목록 조회 성공"
+		)
+	)
+	ResponseEntity<ApiResponse<NotificationListResponse>> getNotifications(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+		@RequestParam(defaultValue = "0") final int page,
+		@Parameter(description = "페이지 크기", example = "20")
+		@RequestParam(defaultValue = "20") final int size
+	);
+
+	@Operation(
+		summary = "알림 읽음 표시",
+		description = "특정 알림을 읽음 상태로 표시합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "알림 읽음 표시 성공"
+		)
+	)
+	ResponseEntity<ApiResponse<?>> markNotificationAsRead(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long notificationId
+	);
+
+	@Operation(
+		summary = "모든 알림 읽음 표시",
+		description = "사용자의 모든 알림을 읽음 상태로 표시합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "모든 알림 읽음 표시 성공"
+		)
+	)
+	ResponseEntity<ApiResponse<?>> markAllNotificationsAsRead(
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	);
+}

--- a/src/main/java/im/toduck/domain/notification/presentation/controller/NotificationController.java
+++ b/src/main/java/im/toduck/domain/notification/presentation/controller/NotificationController.java
@@ -1,0 +1,128 @@
+package im.toduck.domain.notification.presentation.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import im.toduck.domain.notification.domain.usecase.NotificationUseCase;
+import im.toduck.domain.notification.presentation.api.NotificationApi;
+import im.toduck.domain.notification.presentation.dto.request.DeviceTokenRegisterRequest;
+import im.toduck.domain.notification.presentation.dto.request.NotificationSettingUpdateRequest;
+import im.toduck.domain.notification.presentation.dto.response.NotificationListResponse;
+import im.toduck.domain.notification.presentation.dto.response.NotificationSettingResponse;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/notifications")
+public class NotificationController implements NotificationApi {
+
+	private final NotificationUseCase notificationUseCase;
+
+	@Override
+	@PostMapping("/device-tokens")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> registerDeviceToken(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid DeviceTokenRegisterRequest request
+	) {
+		notificationUseCase.registerDeviceToken(
+			userDetails.getUserId(),
+			request.token(),
+			request.deviceType()
+		);
+
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@Override
+	@DeleteMapping("/device-tokens/{token}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> removeDeviceToken(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable String token
+	) {
+		notificationUseCase.removeDeviceToken(userDetails.getUserId(), token);
+
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@Override
+	@GetMapping("/settings")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<NotificationSettingResponse>> getNotificationSettings(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		NotificationSettingResponse response = notificationUseCase.getNotificationSettings(userDetails.getUserId());
+
+		return ResponseEntity.ok(ApiResponse.createSuccess(response));
+	}
+
+	@Override
+	@PutMapping("/settings")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<NotificationSettingResponse>> updateNotificationSettings(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid NotificationSettingUpdateRequest request
+	) {
+		NotificationSettingResponse response = notificationUseCase.updateNotificationSettings(
+			userDetails.getUserId(),
+			request
+		);
+
+		return ResponseEntity.ok(ApiResponse.createSuccess(response));
+	}
+
+	@Override
+	@GetMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<NotificationListResponse>> getNotifications(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size
+	) {
+		NotificationListResponse response = notificationUseCase.getNotifications(
+			userDetails.getUserId(),
+			page,
+			size
+		);
+
+		return ResponseEntity.ok(ApiResponse.createSuccess(response));
+	}
+
+	@Override
+	@PatchMapping("/{notificationId}/read")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> markNotificationAsRead(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable Long notificationId
+	) {
+		notificationUseCase.markNotificationAsRead(userDetails.getUserId(), notificationId);
+
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@Override
+	@PatchMapping("/read-all")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> markAllNotificationsAsRead(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		notificationUseCase.markAllNotificationsAsRead(userDetails.getUserId());
+
+		return ResponseEntity.ok(ApiResponse.createSuccessWithNoContent());
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/presentation/dto/request/DeviceTokenRegisterRequest.java
+++ b/src/main/java/im/toduck/domain/notification/presentation/dto/request/DeviceTokenRegisterRequest.java
@@ -1,0 +1,17 @@
+package im.toduck.domain.notification.presentation.dto.request;
+
+import im.toduck.domain.notification.persistence.entity.DeviceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DeviceTokenRegisterRequest(
+	@NotBlank(message = "디바이스 토큰은 필수입니다.")
+	@Schema(description = "디바이스 토큰", example = "exampleDeviceToken123456")
+	String token,
+
+	@NotNull(message = "디바이스 타입은 필수입니다.")
+	@Schema(description = "디바이스 타입", example = "IOS")
+	DeviceType deviceType
+) {
+}

--- a/src/main/java/im/toduck/domain/notification/presentation/dto/request/NotificationSettingUpdateRequest.java
+++ b/src/main/java/im/toduck/domain/notification/presentation/dto/request/NotificationSettingUpdateRequest.java
@@ -1,0 +1,28 @@
+package im.toduck.domain.notification.presentation.dto.request;
+
+import im.toduck.domain.notification.persistence.entity.NotificationMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record NotificationSettingUpdateRequest(
+	@Schema(description = "전체 알림 활성화 여부", example = "true")
+	boolean allEnabled,
+
+	@Schema(description = "알림 방식", example = "SOUND_ONLY, VIBRATION_ONLY")
+	NotificationMethod notificationMethod,
+
+	@Schema(description = "공지 알림 활성화 여부", example = "true")
+	boolean noticeEnabled,
+
+	@Schema(description = "집중 타이머 알림 활성화 여부", example = "true")
+	boolean homeEnabled,
+
+	@Schema(description = "집중 타이머 알림 활성화 여부", example = "true")
+	boolean concentrationEnabled,
+
+	@Schema(description = "일기 알림 활성화 여부", example = "true")
+	boolean diaryEnabled,
+
+	@Schema(description = "소셜 알림 활성화 여부", example = "true")
+	boolean socialEnabled
+) {
+}

--- a/src/main/java/im/toduck/domain/notification/presentation/dto/response/NotificationDto.java
+++ b/src/main/java/im/toduck/domain/notification/presentation/dto/response/NotificationDto.java
@@ -1,0 +1,42 @@
+package im.toduck.domain.notification.presentation.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+
+import im.toduck.domain.notification.persistence.entity.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "알림 정보 DTO")
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record NotificationDto(
+	@Schema(description = "알림 ID", example = "1")
+	Long id,
+
+	@Schema(description = "알림 타입", example = "COMMENT")
+	NotificationType type,
+
+	@Schema(description = "알림 제목", example = "새로운 댓글")
+	String title,
+
+	@Schema(description = "알림 내용", example = "홍길동님이 내 게시물에 댓글을 남겼어요.")
+	String body,
+
+	@Schema(description = "액션 URL", example = "/social/42/1")
+	String actionUrl,
+
+	@Schema(description = "알림 데이터")
+	Object data,
+
+	@Schema(description = "읽음 여부", example = "false")
+	Boolean isRead,
+
+	@Schema(description = "생성 시간", example = "2025-05-08T12:30:45")
+	@JsonSerialize(using = LocalTimeSerializer.class)
+	LocalDateTime createdAt
+) {
+}

--- a/src/main/java/im/toduck/domain/notification/presentation/dto/response/NotificationDto.java
+++ b/src/main/java/im/toduck/domain/notification/presentation/dto/response/NotificationDto.java
@@ -2,9 +2,10 @@ package im.toduck.domain.notification.presentation.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import im.toduck.domain.notification.persistence.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -35,8 +36,9 @@ public record NotificationDto(
 	@Schema(description = "읽음 여부", example = "false")
 	Boolean isRead,
 
-	@Schema(description = "생성 시간", example = "2025-05-08T12:30:45")
-	@JsonSerialize(using = LocalTimeSerializer.class)
+	@Schema(description = "생성 시간", example = "2025-05-08 12:30:45")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-ddTHH:mm")
 	LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/im/toduck/domain/notification/presentation/dto/response/NotificationListResponse.java
+++ b/src/main/java/im/toduck/domain/notification/presentation/dto/response/NotificationListResponse.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.notification.presentation.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "알림 목록 응답 DTO")
+@Builder
+public record NotificationListResponse(
+	@Schema(description = "알림 목록")
+	List<NotificationDto> notifications
+) {
+}

--- a/src/main/java/im/toduck/domain/notification/presentation/dto/response/NotificationSettingResponse.java
+++ b/src/main/java/im/toduck/domain/notification/presentation/dto/response/NotificationSettingResponse.java
@@ -1,0 +1,31 @@
+package im.toduck.domain.notification.presentation.dto.response;
+
+import im.toduck.domain.notification.persistence.entity.NotificationMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "알림 설정 응답 DTO")
+@Builder
+public record NotificationSettingResponse(
+	@Schema(description = "전체 알림 활성화 여부", example = "true")
+	boolean allEnabled,
+
+	@Schema(description = "알림 방식", example = "SOUND_ONLY, VIBRATION_ONLY")
+	NotificationMethod notificationMethod,
+
+	@Schema(description = "공지 알림 활성화 여부", example = "true")
+	boolean noticeEnabled,
+
+	@Schema(description = "집중 타이머 알림 활성화 여부", example = "true")
+	boolean homeEnabled,
+
+	@Schema(description = "집중 타이머 알림 활성화 여부", example = "true")
+	boolean concentrationEnabled,
+
+	@Schema(description = "일기 알림 활성화 여부", example = "true")
+	boolean diaryEnabled,
+
+	@Schema(description = "소셜 알림 활성화 여부", example = "true")
+	boolean socialEnabled
+) {
+}

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -120,6 +120,9 @@ public enum ExceptionCode {
 	EXCEED_ROUTINE_DATE_RANGE(HttpStatus.BAD_REQUEST, 43204, "기간 범위가 유효하지 않거나, 최대 조회 범위를 초과했습니다.",
 		"루틴 범위 조회는 14일로 제한됩니다."),
 
+	/* 407xx */
+	NOT_FOUND_NOTIFICATION(HttpStatus.NOT_FOUND, 40701, "해당 알림을 찾을 수 없습니다."),
+
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),
 	METHOD_FORBIDDEN(HttpStatus.METHOD_NOT_ALLOWED, 49902, "지원하지 않는 HTTP 메서드를 사용합니다."),

--- a/src/main/java/im/toduck/infra/push/FcmService.java
+++ b/src/main/java/im/toduck/infra/push/FcmService.java
@@ -1,0 +1,110 @@
+package im.toduck.infra.push;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.springframework.stereotype.Service;
+
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.AndroidNotification;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
+
+import im.toduck.domain.notification.domain.service.DeviceTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+	private final DeviceTokenService deviceTokenService;
+
+	/**
+	 * FCM을 통해 알림을 전송합니다.
+	 *
+	 * @param token 디바이스 토큰
+	 * @param title 알림 제목
+	 * @param body 알림 내용
+	 * @param data 추가 데이터
+	 * @return 알림 전송 결과
+	 */
+	public boolean sendNotification(String token, String title, String body, Map<String, String> data) {
+		try {
+			// FCM 메시지 구성
+			Message message = Message.builder()
+				.setToken(token)
+				.setNotification(
+					Notification.builder()
+						.setTitle(title)
+						.setBody(body)
+						.build()
+				)
+				.putAllData(data)
+				.setApnsConfig(getApnsConfig(data))
+				.setAndroidConfig(getAndroidConfig())
+				.build();
+
+			String response = FirebaseMessaging.getInstance().sendAsync(message).get();
+			log.info("FCM 알림 전송 성공 - token: {}, messageId: {}", token, response);
+			return true;
+		} catch (ExecutionException e) {
+			if (e.getCause() instanceof FirebaseMessagingException fcmException) {
+				if (fcmException.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
+					log.warn("FCM 토큰 만료 감지 - 토큰: {}", token);
+					deviceTokenService.removeInvalidToken(token);
+					return false;
+				}
+			}
+			log.error("FCM 알림 전송 실패 - token: {}", token, e);
+			return false;
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			log.error("FCM 알림 전송 중 인터럽트 - token: {}", token, e);
+			return false;
+		}
+	}
+
+	/**
+	 * iOS용 알림 설정 생성
+	 */
+	private ApnsConfig getApnsConfig(Map<String, String> data) {
+		String sound = data.get("sound");
+		Map<String, Object> customData = new HashMap<>(data);
+		customData.remove("sound");
+
+		Aps.Builder apsBuilder = Aps.builder()
+			.setContentAvailable(true)
+			.setMutableContent(true);
+
+		if (sound != null) {
+			apsBuilder.setSound(sound);
+		}
+
+		return ApnsConfig.builder()
+			.setAps(apsBuilder.build())
+			.putAllCustomData(customData)
+			.build();
+	}
+
+	/**
+	 * Android용 알림 설정 생성
+	 */
+	private AndroidConfig getAndroidConfig() {
+		return AndroidConfig.builder()
+			.setPriority(AndroidConfig.Priority.HIGH)
+			.setNotification(AndroidNotification.builder()
+				.setSound("default")
+				.setDefaultSound(true)
+				.setDefaultVibrateTimings(true)
+				.setDefaultLightSettings(true)
+				.build())
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/infra/push/FirebaseConfig.java
+++ b/src/main/java/im/toduck/infra/push/FirebaseConfig.java
@@ -1,0 +1,44 @@
+package im.toduck.infra.push;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+	@Value("${firebase.config-path}")
+	private String firebaseConfigPath;
+
+	@PostConstruct
+	public void initialize() {
+		try {
+			if (FirebaseApp.getApps().isEmpty()) {
+				ClassPathResource resource = new ClassPathResource(firebaseConfigPath);
+				InputStream serviceAccount = resource.getInputStream();
+
+				FirebaseOptions options = FirebaseOptions.builder()
+					.setCredentials(GoogleCredentials.fromStream(serviceAccount))
+					.build();
+
+				FirebaseApp.initializeApp(options);
+				log.info("Firebase 애플리케이션 초기화 완료");
+			}
+		} catch (IOException e) {
+			log.error("Firebase 초기화 오류", e);
+			throw new RuntimeException("Firebase 초기화 중 오류가 발생했습니다", e);
+		}
+	}
+}

--- a/src/main/java/im/toduck/infra/push/payload/DefaultFcmPayloadFactory.java
+++ b/src/main/java/im/toduck/infra/push/payload/DefaultFcmPayloadFactory.java
@@ -1,0 +1,35 @@
+package im.toduck.infra.push.payload;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.persistence.entity.NotificationMethod;
+
+/**
+ * 기본 FCM 페이로드 생성 구현체
+ */
+@Component
+public class DefaultFcmPayloadFactory implements FcmPayloadFactory {
+
+	@Override
+	public Map<String, String> createPayload(final Notification notification, final NotificationMethod method) {
+		Map<String, String> data = new HashMap<>();
+
+		data.put("notificationType", notification.getType().name());
+		data.put("notificationId", notification.getId().toString());
+		data.put("actionUrl", notification.getActionUrl() != null ? notification.getActionUrl() : "");
+		data.put("sound", getSoundSetting(method));
+
+		return data;
+	}
+
+	private String getSoundSetting(final NotificationMethod method) {
+		return switch (method) {
+			case SOUND_ONLY -> "default";
+			case VIBRATION_ONLY -> null;
+		};
+	}
+}

--- a/src/main/java/im/toduck/infra/push/payload/FcmPayloadFactory.java
+++ b/src/main/java/im/toduck/infra/push/payload/FcmPayloadFactory.java
@@ -1,0 +1,16 @@
+package im.toduck.infra.push.payload;
+
+import java.util.Map;
+
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.persistence.entity.NotificationMethod;
+
+/**
+ * FCM 페이로드 생성을 위한 인터페이스
+ */
+public interface FcmPayloadFactory {
+	/**
+	 * FCM 메시지에 포함될 데이터를 생성합니다.
+	 */
+	Map<String, String> createPayload(Notification notification, NotificationMethod method);
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,8 +13,8 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
-        show_sql: true
-        format_sql: true
+        show_sql: false
+        format_sql: false
     open-in-view: false
 
 decorator:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -47,4 +47,5 @@ oauth2:
       kakao:
         jwks-uri: ${OIDC_KAKAO_JWKS_URI}
         secret: ${OIDC_KAKAO_SECRET_KEY}
-
+firebase:
+  config-path: serviceAccountKey.json

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -47,4 +47,5 @@ oauth2:
       kakao:
         jwks-uri: ${OIDC_KAKAO_JWKS_URI}
         secret: ${OIDC_KAKAO_SECRET_KEY}
-
+firebase:
+  config-path: serviceAccountKey.json

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,5 @@ oauth2:
       kakao:
         jwks-uri: ${OIDC_KAKAO_JWKS_URI}
         secret: ${OIDC_KAKAO_SECRET_KEY}
+firebase:
+  config-path: serviceAccountKey.json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,4 +30,3 @@ cloud:
     credentials:
       access-key: ${AWS_ACCESS_KEY}
       secret-key: ${AWS_SECRET_KEY}
-

--- a/src/main/resources/templates/exception-codes-view.html
+++ b/src/main/resources/templates/exception-codes-view.html
@@ -281,6 +281,8 @@
                 return 'Diary';
             case 406:
                 return 'Focus';
+            case 407:
+                return 'Notification';
             case 300:
             case 500:
                 return 'Not 4XXXX';

--- a/src/test/java/im/toduck/RepositoryTest.java
+++ b/src/test/java/im/toduck/RepositoryTest.java
@@ -6,13 +6,17 @@ import org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataR
 import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTypeExcludeFilter;
 import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+
 import im.toduck.builder.BuilderSupporter;
 import im.toduck.builder.TestFixtureBuilder;
 import im.toduck.global.config.querydsl.QueryDslConfig;
+import im.toduck.infra.push.FirebaseConfig;
 
 /**
  * 이 추상 클래스는 JPA와 Redis 기능을 모두 필요로 하는 리포지토리 테스트를 위한 기본 구성을 제공합니다.
@@ -44,4 +48,10 @@ public abstract class RepositoryTest {
 
 	@Autowired
 	protected TestFixtureBuilder testFixtureBuilder;
+
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
+
+	@MockBean
+	private FirebaseConfig firebaseConfig;
 }

--- a/src/test/java/im/toduck/ServiceTest.java
+++ b/src/test/java/im/toduck/ServiceTest.java
@@ -6,10 +6,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+
 import im.toduck.builder.BuilderSupporter;
 import im.toduck.builder.TestFixtureBuilder;
 import im.toduck.global.security.jwt.access.AccessTokenProvider;
 import im.toduck.global.security.jwt.refresh.RefreshTokenProvider;
+import im.toduck.infra.push.FirebaseConfig;
 import im.toduck.infra.redis.forbidden.ForbiddenTokenService;
 import im.toduck.infra.redis.refresh.RefreshTokenService;
 import im.toduck.infra.sms.VerifiyCodeUtil;
@@ -35,4 +38,10 @@ public abstract class ServiceTest {
 
 	@MockBean
 	protected VerifiyCodeUtil verifiyCodeUtil;
+
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
+
+	@MockBean
+	private FirebaseConfig firebaseConfig;
 }

--- a/src/test/java/im/toduck/ToduckBackendApplicationTests.java
+++ b/src/test/java/im/toduck/ToduckBackendApplicationTests.java
@@ -2,14 +2,24 @@ package im.toduck;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+
+import im.toduck.infra.push.FirebaseConfig;
 
 @SpringBootTest
 @ActiveProfiles("test")
 class ToduckBackendApplicationTests {
 
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
+
+	@MockBean
+	private FirebaseConfig firebaseConfig;
+
 	@Test
 	void contextLoads() {
 	}
-
 }

--- a/src/test/java/im/toduck/UseCaseTest.java
+++ b/src/test/java/im/toduck/UseCaseTest.java
@@ -6,12 +6,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+
 import im.toduck.builder.BuilderSupporter;
 import im.toduck.builder.TestFixtureBuilder;
 import im.toduck.domain.auth.common.helper.OAuthOidcHelper;
 import im.toduck.domain.auth.domain.service.JwtService;
 import im.toduck.domain.auth.domain.service.NickNameGenerateService;
 import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.infra.push.FirebaseConfig;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -31,4 +34,10 @@ public abstract class UseCaseTest {
 
 	@MockBean
 	protected NickNameGenerateService nickNameGenerateService;
+
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
+
+	@MockBean
+	private FirebaseConfig firebaseConfig;
 }

--- a/src/test/java/im/toduck/architecture/main/domain/LayeredArchitectureTest.java
+++ b/src/test/java/im/toduck/architecture/main/domain/LayeredArchitectureTest.java
@@ -6,12 +6,26 @@ import static im.toduck.architecture.main.domain.ArchitectureConstants.Layer.*;
 
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-@AnalyzeClasses(packages = "im.toduck.domain", importOptions = ImportOption.DoNotIncludeTests.class)
+@AnalyzeClasses(
+	packages = "im.toduck.domain",
+	importOptions = {
+		ImportOption.DoNotIncludeTests.class,
+		LayeredArchitectureTest.NotificationPackageIgnore.class
+	}
+)
 public class LayeredArchitectureTest {
+	// notification 패키지 제외를 위한 커스텀 ImportOption
+	public static class NotificationPackageIgnore implements ImportOption {
+		@Override
+		public boolean includes(Location location) {
+			return !location.contains("notification");
+		}
+	}
 
 	@ArchTest
 	static final ArchRule 레이어_의존성_규칙을_준수한다 = layeredArchitecture()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,12 +16,12 @@ spring:
   aop:
     auto:
       false # test 환경에서 aop 를 사용하지 않도록 설정
-      
+
 decorator:
   datasource:
     p6spy:
       enable-logging: false
-      
+
 jwt:
   secret-key:
     access-token: toduckAccessAccessAccessTokenSecretKeyForToduck
@@ -43,3 +43,5 @@ oauth2:
       kakao:
         jwks-uri: https://kauth.kakao.com
         secret: kakaoSecret
+firebase:
+  config-path: ""


### PR DESCRIPTION
## ✨ 작업 내용
푸시 알림 전송을 위한 공통 모듈을 작업했습니다.
변경사항 많은거 죄송합니당 ㅎㅎ;
아래 이벤트 등록하고 발행하는 방법 작성해 두었는데 참고하시면 될 것 같습니다.

**향후 계획:**
1. 해당 PR 배포 후 테스트 진행 (현재 댓글 알림만 구현된 상태)
2. RabbitMQ 기반 메시지 큐 시스템으로 전환
3. 각 도메인별 담당자의 알림 이벤트 구현 지원 (간단한것들 몇개는 제가 해둘 것 같아요)
4. Spring Batch, Scheduler 활용 정기 알림 구현 (리마인더, 일정/루틴 임박 알림)
5. 코드 리팩토링 및 성능 최적화

**1️⃣ FCM 기반 푸시 알림 시스템 구현**
- Firebase Cloud Messaging(FCM)을 활용한 푸시 알림 기능 구현
- 알림 송/수신을 위한 디바이스 토큰 관리 기능 개발
- 알림 채널별 설정 기능 추가 (소셜, 일정, 집중, 일기 등)
- iOS 디바이스 푸시 알림 지원 (소리/진동 옵션 선택 가능)
  <br/>

**2️⃣ 이벤트 기반 알림 아키텍처 설계**
- 도메인 이벤트 패턴을 활용한 관심사 분리 및 느슨한 결합 구현
- 비동기 이벤트 처리를 통한 성능 개선 (`@Async` 및 `@TransactionalEventListener` 활용)
- 이벤트 발행/수신 기반 푸시 알림 처리 흐름 구현
  <br/>

**3️⃣ 다양한 알림 타입 및 데이터 정의**
- 알림 타입별 폴리모픽 데이터 객체 설계 (JSON 타입 컨버터 활용)
- 알림 카테고리 및 타입 구분으로 세밀한 사용자 설정 지원
- 다양한 소셜 상호작용에 대한 알림 이벤트 구현 (댓글, 좋아요, 팔로우 등)
  <br/>

**4️⃣ 알림 관련 API 엔드포인트 추가**
- 디바이스 토큰 등록/삭제 API 
- 알림 설정 조회/업데이트 API
- 알림 목록 조회 및 읽음 처리 API
  <br/>

**5️⃣ 데이터베이스 스키마 확장**
- 디바이스 토큰, 알림 설정, 알림 데이터를 위한 테이블 추가
- JSON 타입 컬럼을 활용한 유연한 알림 데이터 저장 구조
  <br/>

### 전체 프로세스 흐름
```mermaid
flowchart TD
    subgraph "이벤트 발생 및 발행"
      A["사용자 상호작용<br>예: 댓글 작성"] --> B["SocialInteractionUseCase<br>댓글 생성 로직 처리"]
      B --> C["eventPublisher.publishEvent()<br>댓글 알림 이벤트 발행"]
    end
    
    subgraph "이벤트 리스닝 및 처리"
      C --> D["NotificationEventListener<br>@TransactionalEventListener"]
      D --> E["새 트랜잭션으로 알림 저장<br>@Transactional(REQUIRES_NEW)"]
      E --> F["알림 설정 확인<br>isTypeEnabled() 호출"]
      
      F -->|알림 활성화됨| G["푸시 알림 전송<br>FCM 서비스 호출"]
      F -->|알림 비활성화됨| H["알림 저장만 하고 종료"]
    end
    
    subgraph "FCM 푸시 전송"
      G --> I["디바이스 토큰 조회"]
      I --> J["알림 메시지 생성"]
      J --> K["FCM API 호출<br>(iOS/Android)"]
      K --> L["알림 전송 완료 표시"]
    end
    
    style A fill:#f9d5e5,stroke:#333,stroke-width:2px
    style C fill:#eeeeee,stroke:#333,stroke-width:2px,stroke-dasharray: 5 5
    style D fill:#d5f9e5,stroke:#333,stroke-width:2px
    style G fill:#d5e5f9,stroke:#333,stroke-width:2px
    style K fill:#f9e5d5,stroke:#333,stroke-width:2px
```

# 알림 이벤트 시스템 - 새로운 알림 유형 추가 가이드

기존 알림 시스템을 활용하여 새로운 알림 이벤트를 각 도메인에서 발행하는 방법을 설명합니다.

> ## TL;DR
> 새로운 알림 이벤트를 추가하는 과정은 다음과 같이 요약.
> 
> 1. 알림 데이터 클래스 생성 (`AbstractNotificationData` 상속)
> 2. `NotificationType` Enum에 새 타입 추가
> 3. 알림 이벤트 클래스 생성 (`NotificationEvent<T>` 상속)
> 4. 비즈니스 로직에서 이벤트 발행 (`ApplicationEventPublisher` 사용)
> 
> 이 패턴을 따르면 기존 알림 시스템의 인프라를 활용하여 손쉽게 새로운 알림 기능을 확장할 수 있습니다. `NotificationType`은 알림 데이터와 처리 방식을 연결하는 중요한 역할을 하므로, 새 알림 유형 추가 시 관련 항목을 빠짐없이 정의해야 합니다.

## 1. 알림 유형(NotificationType) 이해하기

`NotificationType` 열거형(Enum)은 알림 시스템의 핵심 구성 요소로, 다음과 같은 역할을 합니다:

- **알림 유형 정의**: 애플리케이션에서 발생 가능한 모든 알림 유형을 명시적으로 정의
- **카테고리 분류**: 각 알림을 기능적 카테고리(소셜, 홈, 집중, 일기, 공지)로 그룹화
- **데이터 클래스 연결**: 각 알림 유형과 해당 알림에 필요한 데이터 클래스를 연결
- **이벤트-데이터 매핑**: 이벤트 객체와 데이터 객체 간의 타입 안전성 보장
- **UI 동작 제어**: 앱 내 알림창 표시 여부 등의 UI 동작 제어

```java
@Getter
public enum NotificationType {
    // 소셜 관련 알림
    COMMENT(NotificationCategory.SOCIAL, CommentNotificationData.class, "내 게시글에 댓글"),
    REPLY(NotificationCategory.SOCIAL, ReplyNotificationData.class, "내 댓글에 답글"),
    LIKE_POST(NotificationCategory.SOCIAL, LikePostNotificationData.class, "내 게시글에 좋아요"),
    // 더 많은 알림 타입들...
    
    // 알림창에 표시하지 않는 알림 예시
    SCHEDULE_REMINDER(NotificationCategory.HOME, ScheduleReminderData.class, "일정 임박", false);

    private final NotificationCategory category;
    private final Class<? extends NotificationData> dataClass;
    private final String description;
    private final boolean defaultInAppShown; // 앱 내 알림창에 표시할지 여부의 기본값
    
    // 생성자들...
}
```

## 2. 새 알림 이벤트 추가 절차 (단계별 가이드)

새로운 알림 이벤트를 추가하려면 다음 단계를 따르세요:

### 2.1. 알림 데이터 클래스 생성

1. `AbstractNotificationData`를 상속받는 새 데이터 클래스를 생성합니다. (현재 노션 문서에 명시된 유형들에 대한 클래스는 미리 만들어 둠)

```java
@Getter
@NoArgsConstructor
@AllArgsConstructor
public class TaskCompletedNotificationData extends AbstractNotificationData {
    private String taskTitle;      // 완료된 태스크 제목
    private Long taskId;           // 태스크 ID
    private LocalDateTime completedAt; // 완료 시간
    
    public static TaskCompletedNotificationData of(
        final String taskTitle,
        final Long taskId,
        final LocalDateTime completedAt
    ) {
        return new TaskCompletedNotificationData(taskTitle, taskId, completedAt);
    }
}
```

### 2.2. NotificationType에 새 알림 유형 추가

`NotificationType` 열거형에 새 알림 유형을 추가합니다. (현재 노션 문서에 명시된 유형들에 대한 클래스는 미리 만들어 둠)

```java
public enum NotificationType {
    // 기존 알림 타입들...
    
    // 새로 추가하는 알림 타입
    TASK_COMPLETED(NotificationCategory.HOME, TaskCompletedNotificationData.class, "태스크 완료");
    
    // 나머지 코드는 동일...
}
```

### 2.3. 알림 이벤트 클래스 생성

1. `NotificationEvent<T>`를 상속받는 새 이벤트 클래스를 생성합니다.

```java
@Getter
public class TaskCompletedNotificationEvent extends NotificationEvent<TaskCompletedNotificationData> {

    private TaskCompletedNotificationEvent(Long userId, TaskCompletedNotificationData data) {
        super(userId, NotificationType.TASK_COMPLETED, data);
    }

    public static TaskCompletedNotificationEvent of(
        Long userId, String taskTitle, Long taskId, LocalDateTime completedAt
    ) {
        return new TaskCompletedNotificationEvent(
            userId,
            TaskCompletedNotificationData.of(taskTitle, taskId, completedAt)
        );
    }

    @Override
    public String getInAppTitle() {
        return "태스크 완료";
    }

    @Override
    public String getInAppBody() {
        return "'" + getData().getTaskTitle() + "' 태스크가 완료되었습니다.";
    }

    @Override
    public String getPushTitle() {
        return getInAppTitle();
    }

    @Override
    public String getPushBody() {
        return getInAppBody();
    }

    @Override
    public String getActionUrl() {
        return "toduck://task?taskId=" + getData().getTaskId();
    }
}
```

### 2.4. 비즈니스 로직에서 이벤트 발행

비즈니스 로직을 처리하는 서비스나 유스케이스 클래스에서 이벤트를 발행합니다:

```java
@Service
@RequiredArgsConstructor
public class TaskService {
    private final ApplicationEventPublisher eventPublisher;
    
    @Transactional
    public void completeTask(Long userId, Long taskId) {
        // 1. 태스크 완료 비즈니스 로직
        Task task = taskRepository.findById(taskId)
            .orElseThrow(() -> new EntityNotFoundException("Task not found"));
            
        task.markAsCompleted();
        taskRepository.save(task);
        
        // 2. 알림 이벤트 발행
        eventPublisher.publishEvent(
            TaskCompletedNotificationEvent.of(
                userId,                  // 알림을 받을 사용자 ID
                task.getTitle(),         // 태스크 제목
                taskId,                  // 태스크 ID
                LocalDateTime.now()      // 완료 시간
            )
        );
    }
}
```

이벤트 처리 과정은 기존 리스너에서 자동으로 처리되므로, 새 알림 유형을 추가하기 위해 리스너를 수정할 필요가 없습니다.

## 4. 중요 고려사항

### 4.1. 데이터 클래스 설계

- 알림에 필요한 **최소한의 데이터만 포함**하세요.
- 민감한 정보나 너무 많은 데이터는 피하세요.
- 클래스를 **불변(immutable)으로 설계**하세요.

### 4.2. 타입 안전성

- `NotificationType` Enum과 데이터 클래스 간의 일관성을 유지하세요.
- 데이터 클래스가 정의되기 전에 `NotificationType`에서 참조하지 마세요.

### 4.3. 알림 내용 작성

- 푸시 알림 텍스트는 **간결하고 명확하게** 작성하세요.
- `actionUrl`은 앱 내 딥링크 형식을 따르고, 필요한 파라미터를 포함하세요. (노션 문서에 명시)

## 📈 향후 개선 계획: RabbitMQ 도입 검토

현재 구현된 이벤트 기반 알림 시스템은 Spring의 이벤트 메커니즘을 사용하고 있어 다음과 같은 한계가 있습니다:

1. **단일 인스턴스 제한**: 현재 이벤트는 단일 애플리케이션 인스턴스 내에서만 처리되며, 분산 환경에서 이벤트를 공유할 수 없습니다.
7. **메시지 지속성 부족**: 애플리케이션 재시작 시 처리 중인 이벤트가 유실될 수 있습니다.
8. **대규모 부하 처리 제한**: 대량의 알림 이벤트 발생 시 성능 병목이 발생할 수 있습니다. 특히 배치와 스케쥴러를 활용해 알림 일괄 전송이 예정되어 있어 처리가 필요합니다.

이러한 한계를 극복하기 위해 RabbitMQ와 같은 메시지 브로커 도입을 검토하고 있습니다.

- **지속성 보장**: 메시지 지속성을 통해 서버 장애 시에도 안전한 메시지 처리 가능
- **부하 분산**: 워커 풀을 통한 알림 처리 부하 분산 지원
- **확장성 개선**: 대량 알림 처리를 위한 안정적인 아키텍처 구성
- **재시도 메커니즘**: 알림 전송 실패 시 자동 재시도 처리 기능
- **다중 인스턴스 지원**: 멀티 인스턴스 환경에서 안정적인 이벤트 배포 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 알림(푸시 및 인앱) 시스템이 추가되었습니다. 기기 토큰 등록, 알림 설정, 알림 목록 조회, 읽음 처리, 알림별 세부 데이터 제공, 알림 유형별 설정이 가능합니다.
  - Firebase Cloud Messaging(Firebase Admin SDK) 기반의 푸시 알림 발송이 지원됩니다.
  - 알림 관련 REST API 엔드포인트가 제공됩니다.
  - 사용자별 알림 설정(카테고리별, 전체, 진동/소리 등) 관리 기능이 추가되었습니다.
- **버그 수정**
  - 없음
- **문서화**
  - 알림 API 및 DTO에 대한 Swagger 문서가 추가되었습니다.
- **테스트**
  - Firebase 관련 모의 객체가 테스트 환경에 추가되었습니다.
- **환경설정**
  - Firebase 서비스 계정 경로 등 환경설정(yml) 및 빌드 설정(gradle)이 추가/수정되었습니다.
- **기타**
  - 알림 관련 예외 코드 및 예외 코드 뷰가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->