### PR TITLE
RabbitMQ를 활용한 비동기 알림 처리 시스템 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor:3.3.1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.3.1'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
     /* Lombok */
     compileOnly 'org.projectlombok:lombok:1.18.32'

--- a/docker-infra/docker-compose.yml
+++ b/docker-infra/docker-compose.yml
@@ -29,3 +29,18 @@ services:
       - "${REDIS_HOST_PORT}:6379"
     environment:
       TZ: Asia/Seoul
+
+  rabbitmq:
+    image: rabbitmq:4.1-management
+    container_name: todcuk_rabbitmq
+    hostname: rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+      TZ: Asia/Seoul
+    volumes:
+      - ./rabbitmq_data:/var/lib/rabbitmq
+    restart: always

--- a/src/main/java/im/toduck/domain/notification/common/converter/NotificationDataConverter.java
+++ b/src/main/java/im/toduck/domain/notification/common/converter/NotificationDataConverter.java
@@ -1,15 +1,12 @@
 package im.toduck.domain.notification.common.converter;
 
 import java.io.IOException;
-import java.util.Arrays;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
 
+import im.toduck.domain.notification.common.serializer.NotificationMapperFactory;
 import im.toduck.domain.notification.domain.data.NotificationData;
-import im.toduck.domain.notification.persistence.entity.NotificationType;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import lombok.extern.slf4j.Slf4j;
@@ -17,23 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Converter
 public class NotificationDataConverter implements AttributeConverter<NotificationData, String> {
-	private static final ObjectMapper objectMapper;
-
-	static {
-		objectMapper = new ObjectMapper();
-
-		Arrays.stream(NotificationType.values())
-			.filter(type -> type.getDataClass() != null)
-			.forEach(type -> objectMapper.registerSubtypes(
-				new NamedType(type.getDataClass(), type.name())
-			));
-
-		objectMapper.activateDefaultTyping(
-			objectMapper.getPolymorphicTypeValidator(),
-			ObjectMapper.DefaultTyping.NON_FINAL,
-			JsonTypeInfo.As.PROPERTY
-		);
-	}
+	private static final ObjectMapper objectMapper = NotificationMapperFactory.createObjectMapper();
 
 	@Override
 	public String convertToDatabaseColumn(NotificationData attribute) {

--- a/src/main/java/im/toduck/domain/notification/common/serializer/NotificationMapperFactory.java
+++ b/src/main/java/im/toduck/domain/notification/common/serializer/NotificationMapperFactory.java
@@ -1,0 +1,39 @@
+package im.toduck.domain.notification.common.serializer;
+
+import java.util.Arrays;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+
+import im.toduck.domain.notification.persistence.entity.NotificationType;
+
+@Component
+public class NotificationMapperFactory {
+
+	/**
+	 * 알림 데이터 처리를 위한 공통 ObjectMapper를 생성합니다.
+	 * 이 메서드는 데이터베이스 컨버터와 메시지 브로커에서 동일하게 사용됩니다.
+	 *
+	 * @return 다형성 객체 변환을 위해 설정된 ObjectMapper
+	 */
+	public static ObjectMapper createObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		Arrays.stream(NotificationType.values())
+			.filter(type -> type.getDataClass() != null)
+			.forEach(type -> objectMapper.registerSubtypes(
+				new NamedType(type.getDataClass(), type.name())
+			));
+
+		objectMapper.activateDefaultTyping(
+			objectMapper.getPolymorphicTypeValidator(),
+			ObjectMapper.DefaultTyping.NON_FINAL,
+			JsonTypeInfo.As.PROPERTY
+		);
+
+		return objectMapper;
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/event/CommentNotificationEvent.java
+++ b/src/main/java/im/toduck/domain/notification/domain/event/CommentNotificationEvent.java
@@ -2,9 +2,12 @@ package im.toduck.domain.notification.domain.event;
 
 import im.toduck.domain.notification.domain.data.CommentNotificationData;
 import im.toduck.domain.notification.persistence.entity.NotificationType;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentNotificationEvent extends NotificationEvent<CommentNotificationData> {
 
 	private CommentNotificationEvent(Long userId, CommentNotificationData data) {

--- a/src/main/java/im/toduck/domain/notification/domain/event/NotificationEvent.java
+++ b/src/main/java/im/toduck/domain/notification/domain/event/NotificationEvent.java
@@ -1,8 +1,14 @@
 package im.toduck.domain.notification.domain.event;
 
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import im.toduck.domain.notification.domain.data.NotificationData;
 import im.toduck.domain.notification.persistence.entity.NotificationType;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 알림 이벤트의 기본 추상 클래스.
@@ -11,21 +17,23 @@ import lombok.Getter;
  * @param <T> 알림에 필요한 추가 데이터 타입 (NotificationData 상속)
  */
 @Getter
-public abstract class NotificationEvent<T extends NotificationData> {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class NotificationEvent<T extends NotificationData> implements Serializable {
 	/**
 	 * 알림을 받을 사용자의 ID
 	 */
-	private final Long userId;
+	private Long userId;
 
 	/**
 	 * 알림의 유형
 	 */
-	private final NotificationType type;
+	private NotificationType type;
 
 	/**
 	 * 알림 유형별 구체적인 데이터
 	 */
-	private final T data;
+	private T data;
 
 	/**
 	 * 알림 이벤트 생성자

--- a/src/main/java/im/toduck/domain/notification/domain/event/NotificationEventListener.java
+++ b/src/main/java/im/toduck/domain/notification/domain/event/NotificationEventListener.java
@@ -1,16 +1,10 @@
 package im.toduck.domain.notification.domain.event;
 
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import im.toduck.domain.notification.domain.service.NotificationService;
-import im.toduck.domain.notification.domain.service.NotificationSettingService;
-import im.toduck.domain.notification.domain.service.PushNotificationService;
-import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.domain.notification.messaging.NotificationMessagePublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,24 +12,11 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class NotificationEventListener {
-	private final NotificationService notificationService;
-	private final PushNotificationService pushNotificationService;
-	private final NotificationSettingService notificationSettingService;
+	private final NotificationMessagePublisher messagePublisher;
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	@Async
-	@Transactional(propagation = Propagation.REQUIRES_NEW) // 항상 새로운 트랜잭션 시작
 	public void handleNotificationEvent(final NotificationEvent<?> event) {
-		log.info("알림 이벤트 처리 - 타입: {}, 사용자: {}", event.getType(), event.getUserId());
-
-		Notification notification = notificationService.createNotification(event);
-		log.info("알림 저장 완료 - ID: {}", notification.getId());
-
-		if (notificationSettingService.isTypeEnabled(event.getUserId(), event.getType())) {
-			pushNotificationService.sendPushNotification(notification);
-			return;
-		}
-
-		log.info("푸시 알림 비활성화 - 사용자: {}, 타입: {}", event.getUserId(), event.getType());
+		log.info("알림 이벤트 감지 - 타입: {}, 사용자: {}", event.getType(), event.getUserId());
+		messagePublisher.publishNotificationEvent(event);
 	}
 }

--- a/src/main/java/im/toduck/domain/notification/messaging/NotificationMessageConsumer.java
+++ b/src/main/java/im/toduck/domain/notification/messaging/NotificationMessageConsumer.java
@@ -1,0 +1,54 @@
+package im.toduck.domain.notification.messaging;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.notification.domain.event.NotificationEvent;
+import im.toduck.domain.notification.domain.service.NotificationService;
+import im.toduck.domain.notification.domain.service.NotificationSettingService;
+import im.toduck.domain.notification.domain.service.PushNotificationService;
+import im.toduck.domain.notification.persistence.entity.Notification;
+import im.toduck.global.config.rabbitmq.RabbitMqConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationMessageConsumer {
+
+	private final NotificationService notificationService;
+	private final NotificationSettingService notificationSettingService;
+	private final PushNotificationService pushNotificationService;
+
+	@RabbitListener(queues = RabbitMqConfig.NOTIFICATION_QUEUE)
+	@Transactional
+	public void processNotification(NotificationEvent<?> event) {
+		log.info("알림 처리 시작 - 타입: {}, 사용자: {}", event.getType(), event.getUserId());
+		processNotificationEvent(event);
+	}
+
+	private void processNotificationEvent(NotificationEvent<?> event) {
+		try {
+			Notification notification = notificationService.createNotification(event);
+			log.info("알림 저장 완료 - ID: {}", notification.getId());
+
+			if (notificationSettingService.isTypeEnabled(event.getUserId(), event.getType())) {
+				pushNotificationService.sendPushNotification(notification);
+				return;
+			}
+
+			log.info("푸시 알림 비활성화 - 사용자: {}, 타입: {}", event.getUserId(), event.getType());
+		} catch (Exception e) {
+			log.error("알림 처리 중 오류 발생 - 타입: {}, 사용자: {}", event.getType(), event.getUserId(), e);
+			throw e;
+		}
+	}
+
+	@RabbitListener(queues = RabbitMqConfig.NOTIFICATION_DLQ)
+	public void processDlq(NotificationEvent<?> event) {
+		log.error("알림 처리 최종 실패 (DLQ) - 타입: {}, 사용자: {}", event.getType(), event.getUserId());
+		// 추가적인 복구 로직, 추후 모니터링 시 사용
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/messaging/NotificationMessagePublisher.java
+++ b/src/main/java/im/toduck/domain/notification/messaging/NotificationMessagePublisher.java
@@ -1,0 +1,39 @@
+package im.toduck.domain.notification.messaging;
+
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import im.toduck.domain.notification.domain.event.NotificationEvent;
+import im.toduck.global.config.rabbitmq.RabbitMqConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationMessagePublisher {
+
+	private final RabbitTemplate rabbitTemplate;
+
+	public void publishNotificationEvent(NotificationEvent<?> event) {
+		int priority = determineNotificationPriority(event);
+
+		log.info("알림 이벤트 발행 - 타입: {}, 사용자: {}, 우선순위: {}", event.getType(), event.getUserId(), priority);
+
+		rabbitTemplate.convertAndSend(
+			RabbitMqConfig.NOTIFICATION_EXCHANGE,
+			RabbitMqConfig.NOTIFICATION_ROUTING_KEY,
+			event,
+			message -> {
+				MessageProperties props = message.getMessageProperties();
+				props.setPriority(priority);
+				return message;
+			}
+		);
+	}
+
+	private int determineNotificationPriority(NotificationEvent<?> event) {
+		return event.getType().getPriority().getLevel();
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationType.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/entity/NotificationType.java
@@ -16,45 +16,68 @@ import lombok.Getter;
 
 @Getter
 public enum NotificationType {
-	COMMENT(NotificationCategory.SOCIAL, CommentNotificationData.class, "내 게시글에 댓글"),
-	REPLY(NotificationCategory.SOCIAL, ReplyNotificationData.class, "내 댓글에 답글"),
-	REPLY_ON_MY_POST(NotificationCategory.SOCIAL, ReplyOnMyPostNotificationData.class, "내 게시글의 내 댓글에 답글"),
-	LIKE_POST(NotificationCategory.SOCIAL, LikePostNotificationData.class, "내 게시글에 좋아요"),
-	LIKE_COMMENT(NotificationCategory.SOCIAL, LikeCommentNotificationData.class, "내 댓글 좋아요"),
-	FOLLOW(NotificationCategory.SOCIAL, FollowNotificationData.class, "나를 팔로우"),
-	ROUTINE_SHARE_MILESTONE(NotificationCategory.SOCIAL, RoutineShareMilestoneData.class, "루틴 공유 마일스톤"),
+	COMMENT(NotificationCategory.SOCIAL, CommentNotificationData.class, "내 게시글에 댓글", Priority.NORMAL),
+	REPLY(NotificationCategory.SOCIAL, ReplyNotificationData.class, "내 댓글에 답글", Priority.NORMAL),
+	REPLY_ON_MY_POST(
+		NotificationCategory.SOCIAL, ReplyOnMyPostNotificationData.class, "내 게시글의 내 댓글에 답글", Priority.NORMAL
+	),
+	LIKE_POST(NotificationCategory.SOCIAL, LikePostNotificationData.class, "내 게시글에 좋아요", Priority.NORMAL),
+	LIKE_COMMENT(NotificationCategory.SOCIAL, LikeCommentNotificationData.class, "내 댓글 좋아요", Priority.NORMAL),
+	FOLLOW(NotificationCategory.SOCIAL, FollowNotificationData.class, "나를 팔로우", Priority.NORMAL),
+	ROUTINE_SHARE_MILESTONE(
+		NotificationCategory.SOCIAL, RoutineShareMilestoneData.class, "루틴 공유 마일스톤", Priority.NORMAL
+	),
 
-	SCHEDULE_REMINDER(NotificationCategory.HOME, ScheduleReminderData.class, "일정 임박", false),
-	ROUTINE_REMINDER(NotificationCategory.HOME, RoutineReminderData.class, "루틴 임박", false),
+	SCHEDULE_REMINDER(NotificationCategory.HOME, ScheduleReminderData.class, "일정 임박", Priority.HIGH, false),
+	ROUTINE_REMINDER(NotificationCategory.HOME, RoutineReminderData.class, "루틴 임박", Priority.HIGH, false),
 
-	DIARY_REMINDER(NotificationCategory.DIARY, DiaryReminderData.class, "일기 작성 유도", false),
-	INACTIVITY_REMINDER(NotificationCategory.NOTICE, InactivityReminderData.class, "미접속 알림", false);
+	DIARY_REMINDER(NotificationCategory.DIARY, DiaryReminderData.class, "일기 작성 유도", Priority.NORMAL, false),
+	INACTIVITY_REMINDER(NotificationCategory.NOTICE, InactivityReminderData.class, "미접속 알림", Priority.LOW, false);
 
 	private final NotificationCategory category;
 	private final Class<? extends NotificationData> dataClass;
 	private final String description;
+	private final Priority priority; // 알림 우선순위
 	private final boolean defaultInAppShown; // 앱 내 알림창에 표시할지 여부의 기본값
 
 	NotificationType(
 		NotificationCategory category,
 		Class<? extends NotificationData> dataClass,
 		String description,
+		Priority priority,
 		boolean defaultInAppShown
 	) {
 		this.category = category;
 		this.dataClass = dataClass;
 		this.description = description;
+		this.priority = priority;
 		this.defaultInAppShown = defaultInAppShown;
 	}
 
 	NotificationType(
 		NotificationCategory category,
 		Class<? extends NotificationData> dataClass,
-		String description
+		String description,
+		Priority priority
 	) {
 		this.category = category;
 		this.dataClass = dataClass;
 		this.description = description;
 		this.defaultInAppShown = true;
+		this.priority = priority;
+	}
+
+	@Getter
+	public enum Priority {
+		LOW(1),
+		NORMAL(5),
+		HIGH(8),
+		URGENT(10);
+
+		private final int level;
+
+		Priority(int level) {
+			this.level = level;
+		}
 	}
 }

--- a/src/main/java/im/toduck/global/config/rabbitmq/RabbitMqConfig.java
+++ b/src/main/java/im/toduck/global/config/rabbitmq/RabbitMqConfig.java
@@ -1,0 +1,87 @@
+package im.toduck.global.config.rabbitmq;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import im.toduck.domain.notification.common.serializer.NotificationMapperFactory;
+
+@Configuration
+public class RabbitMqConfig {
+	public static final String NOTIFICATION_QUEUE = "notification.queue";
+	public static final String NOTIFICATION_DLQ = "notification.dlq";
+
+	public static final String NOTIFICATION_EXCHANGE = "notification.exchange";
+	public static final String NOTIFICATION_DLX = "notification.dlx";
+
+	public static final String NOTIFICATION_ROUTING_KEY = "notification.key";
+
+	@Bean
+	public ObjectMapper rabbitObjectMapper() {
+		return NotificationMapperFactory.createObjectMapper();
+	}
+
+	@Bean
+	public Jackson2JsonMessageConverter messageConverter(final ObjectMapper rabbitObjectMapper) {
+		return new Jackson2JsonMessageConverter(rabbitObjectMapper);
+	}
+
+	@Bean
+	public RabbitTemplate rabbitTemplate(
+		final ConnectionFactory connectionFactory,
+		final Jackson2JsonMessageConverter messageConverter
+	) {
+		RabbitTemplate template = new RabbitTemplate(connectionFactory);
+		template.setMessageConverter(messageConverter);
+		return template;
+	}
+
+	@Bean
+	public Queue notificationQueue() {
+		Map<String, Object> args = new HashMap<>();
+		args.put("x-dead-letter-exchange", NOTIFICATION_DLX);
+		args.put("x-dead-letter-routing-key", NOTIFICATION_ROUTING_KEY);
+		args.put("x-max-priority", 10);
+		return new Queue(NOTIFICATION_QUEUE, true, false, false, args);
+	}
+
+	@Bean
+	public Queue notificationDlq() {
+		return new Queue(NOTIFICATION_DLQ, true);
+	}
+
+	@Bean
+	public DirectExchange notificationExchange() {
+		return new DirectExchange(NOTIFICATION_EXCHANGE);
+	}
+
+	@Bean
+	public DirectExchange notificationDlx() {
+		return new DirectExchange(NOTIFICATION_DLX);
+	}
+
+	@Bean
+	public Binding notificationBinding() {
+		return BindingBuilder.bind(notificationQueue())
+			.to(notificationExchange())
+			.with(NOTIFICATION_ROUTING_KEY);
+	}
+
+	@Bean
+	public Binding dlqBinding() {
+		return BindingBuilder.bind(notificationDlq())
+			.to(notificationDlx())
+			.with(NOTIFICATION_ROUTING_KEY);
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,6 +16,24 @@ spring:
         show_sql: false
         format_sql: false
     open-in-view: false
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER}
+    password: ${RABBITMQ_PASSWORD}
+    listener:
+      simple:
+        concurrency: 3
+        max-concurrency: 10
+        prefetch: 5
+        default-requeue-rejected: false
+        retry:
+          enabled: true
+          initial-interval: 1000
+          max-attempts: 3
+          max-interval: 10000
+          multiplier: 2
+        acknowledge-mode: auto
 
 decorator:
   datasource:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,6 +16,24 @@ spring:
         show_sql: true
         format_sql: true
     open-in-view: false
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER}
+    password: ${RABBITMQ_PASSWORD}
+    listener:
+      simple:
+        concurrency: 3
+        max-concurrency: 10
+        prefetch: 5
+        default-requeue-rejected: false
+        retry:
+          enabled: true
+          initial-interval: 1000
+          max-attempts: 3
+          max-interval: 10000
+          multiplier: 2
+        acknowledge-mode: auto
 
 decorator:
   datasource:

--- a/src/test/java/im/toduck/RepositoryTest.java
+++ b/src/test/java/im/toduck/RepositoryTest.java
@@ -1,5 +1,6 @@
 package im.toduck;
 
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataRedis;
@@ -15,6 +16,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 
 import im.toduck.builder.BuilderSupporter;
 import im.toduck.builder.TestFixtureBuilder;
+import im.toduck.domain.notification.messaging.NotificationMessagePublisher;
 import im.toduck.global.config.querydsl.QueryDslConfig;
 import im.toduck.infra.push.FirebaseConfig;
 
@@ -54,4 +56,10 @@ public abstract class RepositoryTest {
 
 	@MockBean
 	private FirebaseConfig firebaseConfig;
+
+	@MockBean
+	private RabbitTemplate rabbitTemplate;
+
+	@MockBean
+	private NotificationMessagePublisher notificationMessagePublisher;
 }

--- a/src/test/java/im/toduck/ServiceTest.java
+++ b/src/test/java/im/toduck/ServiceTest.java
@@ -1,5 +1,6 @@
 package im.toduck;
 
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -10,6 +11,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 
 import im.toduck.builder.BuilderSupporter;
 import im.toduck.builder.TestFixtureBuilder;
+import im.toduck.domain.notification.messaging.NotificationMessagePublisher;
 import im.toduck.global.security.jwt.access.AccessTokenProvider;
 import im.toduck.global.security.jwt.refresh.RefreshTokenProvider;
 import im.toduck.infra.push.FirebaseConfig;
@@ -44,4 +46,10 @@ public abstract class ServiceTest {
 
 	@MockBean
 	private FirebaseConfig firebaseConfig;
+
+	@MockBean
+	private RabbitTemplate rabbitTemplate;
+
+	@MockBean
+	private NotificationMessagePublisher notificationMessagePublisher;
 }

--- a/src/test/java/im/toduck/ToduckBackendApplicationTests.java
+++ b/src/test/java/im/toduck/ToduckBackendApplicationTests.java
@@ -1,12 +1,14 @@
 package im.toduck;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 
+import im.toduck.domain.notification.messaging.NotificationMessagePublisher;
 import im.toduck.infra.push.FirebaseConfig;
 
 @SpringBootTest
@@ -18,6 +20,12 @@ class ToduckBackendApplicationTests {
 
 	@MockBean
 	private FirebaseConfig firebaseConfig;
+
+	@MockBean
+	private RabbitTemplate rabbitTemplate;
+
+	@MockBean
+	private NotificationMessagePublisher notificationMessagePublisher;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/im/toduck/UseCaseTest.java
+++ b/src/test/java/im/toduck/UseCaseTest.java
@@ -1,5 +1,6 @@
 package im.toduck;
 
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -13,6 +14,7 @@ import im.toduck.builder.TestFixtureBuilder;
 import im.toduck.domain.auth.common.helper.OAuthOidcHelper;
 import im.toduck.domain.auth.domain.service.JwtService;
 import im.toduck.domain.auth.domain.service.NickNameGenerateService;
+import im.toduck.domain.notification.messaging.NotificationMessagePublisher;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.infra.push.FirebaseConfig;
 
@@ -40,4 +42,10 @@ public abstract class UseCaseTest {
 
 	@MockBean
 	private FirebaseConfig firebaseConfig;
+
+	@MockBean
+	private RabbitTemplate rabbitTemplate;
+
+	@MockBean
+	private NotificationMessagePublisher notificationMessagePublisher;
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -17,6 +17,14 @@ spring:
     auto:
       false # test 환경에서 aop 를 사용하지 않도록 설정
 
+  rabbitmq:
+    listener:
+      simple:
+        auto-startup: false
+    template:
+      exchange: ""
+      routing-key: ""
+
 decorator:
   datasource:
     p6spy:


### PR DESCRIPTION
## ✨ 작업 내용

기존 동기식 알림 처리 방식을 RabbitMQ 기반 비동기 메시지 큐 시스템으로 전환하여 시스템 확장성과 안정성을 개선했습니다. 알림 우선순위 시스템을 도입하고, 메시지 직렬화 및 재시도 정책을 구성하여 안정적인 알림 처리 기반을 마련했습니다.

**1️⃣ RabbitMQ 인프라 구성 및 의존성 추가**
- Spring Boot AMQP starter 의존성 추가로 RabbitMQ 연동 기능 활성화
- Docker Compose에 RabbitMQ 4.1 management 이미지 추가
- RabbitMQ Management UI 접근을 위한 포트 설정 (5672: AMQP, 15672: Management UI)
- 환경변수를 통한 사용자 인증 설정 및 데이터 볼륨 마운트 구성

**2️⃣ 알림 이벤트 객체 직렬화 개선**
- `NotificationEvent` 클래스에 `Serializable` 인터페이스 구현
- Jackson 직렬화를 위한 기본 생성자 및 `@JsonIgnoreProperties` 어노테이션 추가
- final 필드를 일반 필드로 변경하여 역직렬화 지원
- `NotificationDataConverter`에서 ObjectMapper 설정을 별도 팩토리 클래스로 분리

**3️⃣ 비동기 메시지 처리 시스템 도입**
- `NotificationEventListener`에서 직접 알림 처리 로직을 메시지 퍼블리셔로 위임
- 동기식 `@Async` 처리에서 RabbitMQ 기반 비동기 메시지 큐 처리로 전환
- 트랜잭션 커밋 후 이벤트를 메시지 큐로 발행하는 구조로 변경
- 메시지 처리 실패 시 재시도 정책 및 데드레터 큐 설정

**4️⃣ 알림 우선순위 시스템 추가**
- `NotificationType`에 `Priority` enum 추가 (LOW, NORMAL, HIGH, URGENT)
- 각 알림 타입별 우선순위 레벨 설정 (1~10)
- 일정/루틴 리마인더는 HIGH 우선순위, 소셜 알림은 NORMAL 우선순위로 분류
- 향후 우선순위별 처리 로직 구현을 위한 기반 마련

**5️⃣ RabbitMQ 연결 설정 및 리스너 구성**
- 개발/로컬 환경별 RabbitMQ 연결 정보 설정
- 동시 처리를 위한 concurrency 설정 (기본 3, 최대 10)
- 메시지 prefetch 수 제한 및 재시도 정책 구성
- 실패한 메시지의 requeue 방지 설정

**6️⃣ 테스트 환경 Mock 설정**
- 모든 테스트 클래스에 `RabbitTemplate` 및 `NotificationMessagePublisher` Mock Bean 추가
- 테스트 환경에서 RabbitMQ 자동 시작 비활성화
- 테스트 격리를 위한 메시지 큐 의존성 제거

## 🚨 배포 및 개발 환경 설정 주의사항

**📋 서버 측 배포 전 필수 작업**
- RabbitMQ 서버 설치 및 활성화 필요
- Management UI 접근을 위한 포트 개방 필요 (15672)
- RabbitMQ 사용자 계정 생성 및 환경변수 설정 필요 (`RABBITMQ_USER`, `RABBITMQ_PASSWORD`)

**💻 로컬 개발 환경 설정**
- PR merge 후 로컬 개발 시 추가된 RabbitMQ 컨테이너 실행 필요 (Notion에 명령어 업데이트 해뒀습니다)
- RabbitMQ Management UI: http://localhost:15672
