### PR TITLE
소셜 게시글 본문 제한 길이 수정

### DIFF
--- a/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialCreateRequest.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/request/SocialCreateRequest.java
@@ -16,7 +16,7 @@ public record SocialCreateRequest(
 	String title,
 
 	@NotBlank(message = "내용은 공백일 수 없습니다.")
-	@Size(max = 255, message = "내용은 255자 이하여야 합니다.")
+	@Size(max = 500, message = "내용은 500자 이하여야 합니다.")
 	@Schema(description = "게시글 내용", example = "어제 잠들기 전 새로운 루틴을 추가했다👀")
 	String content,
 


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣ 소셜 게시글 본문 제한 길이 수정**
- 수정전 : 255자 
- 수정후 : 500자

> `init.sql` 은 기존에 수정 했어서 dto만 수정했습니다!