### PR TITLE
반복 일정 특정 날짜 이후 수정시 발생하는 논리적 오류 해결 

### DIFF
--- a/src/main/java/im/toduck/domain/auth/domain/service/NickNameGenerateService.java
+++ b/src/main/java/im/toduck/domain/auth/domain/service/NickNameGenerateService.java
@@ -13,21 +13,21 @@ public class NickNameGenerateService { //TODO : 닉네임 랜덤 생성 팀원�
 	private final UserRepository userRepository;
 
 	private static final String[] ADJECTIVES = {
-		"행복한", "밝은", "활기찬", "용감한", "호기심많은", "장난꾸러기", "매력적인", "똑똑한", "힘찬", "유쾌한"
+		"행복한", "밝은", "활기찬", "용감한", "장난치는", "매력적인", "똑똑한", "힘찬", "유쾌한"
 	};
 	private static final String[] NOUNS = {
-		"오리", "꽥꽥이", "깃털", "연못", "뒤뚱이", "부리", "날개", "둥지", "청둥오리", "물갈퀴"
+		"오리", "꽥꽥이", "깃털", "연못", "뒤뚱이", "부리", "날개", "둥지", "물갈퀴"
 	};
 
 	public String generateRandomNickname() {
 		Random random = new Random();
 		String adjective;
 		String noun;
-		int number; // 1000부터 9999까지의 4자리 숫자
+		int number; // 100부터 999까지의 3자리 숫자
 		do {
 			adjective = ADJECTIVES[random.nextInt(ADJECTIVES.length)];
 			noun = NOUNS[random.nextInt(NOUNS.length)];
-			number = 1000 + random.nextInt(9000); // 1000부터 9999까지의 4자리 숫자
+			number = 100 + random.nextInt(900); // 100부터 999까지의 3자리 숫자
 
 		} while (userRepository.existsByNickname(adjective + noun + number));
 		return adjective + noun + number;

--- a/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleModifyService.java
+++ b/src/main/java/im/toduck/domain/schedule/domain/service/ScheduleModifyService.java
@@ -108,9 +108,10 @@ public class ScheduleModifyService {
 		// 특정 날짜가 시작일이라면 해당 일정 삭제
 		if (schedule.getScheduleDate().getStartDate().equals(request.queryDate())) {
 			scheduleRepository.delete(schedule);
+		} else {
+			// 특정 날짜가 시작일이 아니라면 종료일을 특정 날짜 하루 전으로 변경
+			schedule.changeEndDate(request.queryDate().minusDays(1));
 		}
-		// 특정 날짜가 시작일이 아니라면 종료일을 특정 날짜 하루 전으로 변경
-		schedule.changeEndDate(request.queryDate().minusDays(1));
 
 		// 새로운 일정 생성
 		Schedule newSchedule = ScheduleMapper.toSchedule(schedule.getUser(), request.scheduleData());


### PR DESCRIPTION
## ✨ 작업 내용

> 해당 안내는 지워주세요.  
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.  
> 스크린샷을 적극적으로 활용해 주세요.

**1️⃣ 반복 일정 특정 날짜 이후 수정시 발생하는 논리적 오류 해결**

- 반복 일정에 특정 날짜 이후 수정 요청에 대한 처리 로직은 반복 일정의 endDate 를 특정 날짜 - 1 날짜로 수정을 합니다
- 이 과정에서 endDate가 startDate 이전이 될 수 있는 경우의 수가 존재했습니다 (원래는 if문으로 분기해서 막았지만 코드 구현 단계의 실수로 안되어 있었음)
- 해당 에러를 해결하고 test 코드로 검증했습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 닉네임 생성 시 사용되는 형용사와 명사 목록이 일부 조정되고, 숫자 접미사가 4자리에서 3자리로 변경되었습니다.
  - 일정 수정 시, 시작일과 요청일이 같은 경우와 다른 경우의 처리 흐름이 명확하게 분리되었습니다.

- **테스트**
  - 반복 일정 수정 시 특정 날짜가 시작일과 같은 경우의 논리 오류를 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->