### PR TITLE
[Hotfix] 일정 enum 값 수정 및 종일 일정 생성시 논리적 에러 해결

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -163,7 +163,7 @@ CREATE TABLE schedule
     is_all_day   BOOLEAN      NOT NULL,
     time         TIME                                                                                                                                       DEFAULT NULL,
     days_of_week TINYINT                                                                                                                                    DEFAULT NULL,
-    alarm        ENUM ('TEN_MINUTE', 'ONE_HOUR', 'ONE_DAY')                                                                                                 DEFAULT NULL,
+    alarm        ENUM ('TEN_MINUTE', 'THIRTY_MINUTE', 'ONE_DAY')                                                                                                 DEFAULT NULL,
     location     VARCHAR(255)                                                                                                                               DEFAULT NULL,
     memo         VARCHAR(255)                                                                                                                               DEFAULT NULL,
     user_id      BIGINT       NOT NULL,

--- a/src/main/java/im/toduck/domain/schedule/persistence/vo/ScheduleAlram.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/vo/ScheduleAlram.java
@@ -2,6 +2,6 @@ package im.toduck.domain.schedule.persistence.vo;
 
 public enum ScheduleAlram {
 	TEN_MINUTE, // 10분전
-	ONE_HOUR, // 1시간전
+	THIRTY_MINUTE, // 30분전
 	ONE_DAY, // 1일전
 }

--- a/src/main/java/im/toduck/domain/schedule/persistence/vo/ScheduleTime.java
+++ b/src/main/java/im/toduck/domain/schedule/persistence/vo/ScheduleTime.java
@@ -42,7 +42,9 @@ public class ScheduleTime {
 				throw new VoException("종일 여부가 true 이면 시간은 null 이어야 합니다.");
 			}
 			if (alarm != null) {
-				throw new VoException("종일 여부가 true 이면 알람은 null 이어야 합니다.");
+				if (!alarm.equals(ScheduleAlram.ONE_DAY)) {
+					throw new VoException("종일 여부가 true 이면 알람은 1일전이거나 null 이어야 합니다.");
+				}
 			}
 		} else if (time == null) {
 			throw new VoException("종일 여부가 false 이면 시간은 필수입니다.");

--- a/src/test/java/im/toduck/domain/schedule/domain/usecase/ScheduleUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/schedule/domain/usecase/ScheduleUseCaseTest.java
@@ -78,6 +78,20 @@ class ScheduleUseCaseTest extends ServiceTest {
 			.memo("일정 메모")
 			.build();
 
+		private final ScheduleCreateRequest successAllDayAlarmOneDayRequest = ScheduleCreateRequest.builder()
+			.title("종일 일정")
+			.category(PlanCategory.COMPUTER)
+			.startDate(LocalDate.of(2025, 1, 1)) // 필수 값
+			.endDate(LocalDate.of(2025, 1, 1))
+			.isAllDay(true)
+			.color("#FFFFFF")
+			.time(null)
+			.daysOfWeek(List.of(DayOfWeek.MONDAY))
+			.alarm(ScheduleAlram.ONE_DAY)
+			.location("일정 장소")
+			.memo("일정 메모")
+			.build();
+
 		@BeforeEach
 		void setUp() {
 			savedUser = testFixtureBuilder.buildUser(GENERAL_USER());
@@ -106,6 +120,18 @@ class ScheduleUseCaseTest extends ServiceTest {
 			//then
 			assertSoftly(softly -> {
 				softly.assertThat(response.scheduleId()).isNotNull();
+			});
+		}
+
+		@Test
+		void 종일_일정에서_알람은_null이거나_1일전이어야_성공한다() {
+			// given -> when
+			ScheduleIdResponse result = scheduleUsecase.createSchedule(savedUser.getId(),
+				successAllDayAlarmOneDayRequest);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result.scheduleId()).isNotNull();
 			});
 		}
 
@@ -157,7 +183,7 @@ class ScheduleUseCaseTest extends ServiceTest {
 			}
 
 			@Test
-			void 종일_여부가_true인데_알람이_null이_아니면_실패한다() {
+			void 종일_여부가_true인데_알람이_null이거나_1일전이_아니면_실패한다() {
 				// given
 				ScheduleCreateRequest isAllDayTrueAlarmNonNULLRequest = ERROR_TRUE_IS_ALL_DAY_ALARM_NON_NULL_REQUEST();
 


### PR DESCRIPTION
## ✨ 작업 내용



**1️⃣ 일정 알람 enum 값 수정**

- 일정 enum 값 수정 10분전/1시간전/1일전 → 10분전/30분전/1일전
  <br/>

**2️⃣ 종일일 때 1일전 알람도 받을 수 있게 로직 변경**

- 기존에는 종일 일정은 알림 설정이 불가능 했습니다
  <br/>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 종일 일정에서 알람이 null이거나 1일 전일 때만 등록이 가능하도록 개선되었습니다.

- **버그 수정**
  - 일정 알람 옵션에서 '1시간 전'이 '30분 전'으로 변경되었습니다.

- **테스트**
  - 종일 일정의 알람 유효성에 대한 테스트가 추가되고, 기존 테스트가 더 정확하게 반영되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->