### PR TITLE
일기 작성 리마인더 스케줄러 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ dependencies {
     /* Redis */
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.1'
 
+    /* ShedLock */
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.2'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.10.2'
+
     /* QueryDSL */
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"

--- a/src/main/java/im/toduck/ToduckBackendApplication.java
+++ b/src/main/java/im/toduck/ToduckBackendApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
 @EnableAsync
+@EnableScheduling
 @ConfigurationPropertiesScan
 public class ToduckBackendApplication {
 	public static void main(String[] args) {

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiarySchedulerUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiarySchedulerUseCase.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.annotation.Transactional;
 
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+
 import im.toduck.domain.notification.domain.event.DiaryReminderNotificationEvent;
 import im.toduck.domain.notification.messaging.NotificationMessagePublisher;
 import im.toduck.domain.user.domain.service.UserService;
@@ -21,6 +23,7 @@ public class DiarySchedulerUseCase {
 	private final NotificationMessagePublisher notificationMessagePublisher;
 
 	@Scheduled(cron = "0 0 22 * * *")
+	@SchedulerLock(name = "DiarySchedulerUseCase_sendDailyDiaryReminder", lockAtMostFor = "9m", lockAtLeastFor = "1m")
 	@Transactional(readOnly = true)
 	public void sendDailyDiaryReminder() {
 		log.info("일기 작성 유도 알림 발송 시작");

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiarySchedulerUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiarySchedulerUseCase.java
@@ -22,7 +22,7 @@ public class DiarySchedulerUseCase {
 	private final UserService userService;
 	private final NotificationMessagePublisher notificationMessagePublisher;
 
-	@Scheduled(cron = "0 0 22 * * *")
+	@Scheduled(cron = "0 0 22 * * *", zone = "Asia/Seoul")
 	@SchedulerLock(name = "DiarySchedulerUseCase_sendDailyDiaryReminder", lockAtMostFor = "9m", lockAtLeastFor = "1m")
 	@Transactional(readOnly = true)
 	public void sendDailyDiaryReminder() {

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiarySchedulerUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiarySchedulerUseCase.java
@@ -1,0 +1,37 @@
+package im.toduck.domain.diary.domain.usecase;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.notification.domain.event.DiaryReminderNotificationEvent;
+import im.toduck.domain.notification.messaging.NotificationMessagePublisher;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.global.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class DiarySchedulerUseCase {
+
+	private final UserService userService;
+	private final NotificationMessagePublisher notificationMessagePublisher;
+
+	@Scheduled(cron = "0 0 22 * * *")
+	@Transactional(readOnly = true)
+	public void sendDailyDiaryReminder() {
+		log.info("일기 작성 유도 알림 발송 시작");
+
+		List<Long> userIds = userService.getAllActiveUserIds();
+		for (Long userId : userIds) {
+			DiaryReminderNotificationEvent event = DiaryReminderNotificationEvent.of(userId);
+			notificationMessagePublisher.publishNotificationEvent(event);
+		}
+
+		log.info("일기 작성 유도 알림 이벤트 발행 완료");
+	}
+}
+

--- a/src/main/java/im/toduck/domain/notification/domain/data/DiaryReminderData.java
+++ b/src/main/java/im/toduck/domain/notification/domain/data/DiaryReminderData.java
@@ -1,5 +1,6 @@
 package im.toduck.domain.notification.domain.data;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,8 +8,9 @@ import lombok.NoArgsConstructor;
  * 일기 작성 유도 알림에 사용하는 데이터
  */
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DiaryReminderData extends AbstractNotificationData {
-	// TODO: 필요한 필드 추가
-	// 예상 필드: 유도 타입, 마지막 일기 작성 날짜 등
+	public static DiaryReminderData create() {
+		return new DiaryReminderData();
+	}
 }

--- a/src/main/java/im/toduck/domain/notification/domain/event/DiaryReminderNotificationEvent.java
+++ b/src/main/java/im/toduck/domain/notification/domain/event/DiaryReminderNotificationEvent.java
@@ -1,0 +1,48 @@
+package im.toduck.domain.notification.domain.event;
+
+import im.toduck.domain.notification.domain.data.DiaryReminderData;
+import im.toduck.domain.notification.persistence.entity.NotificationType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiaryReminderNotificationEvent extends NotificationEvent<DiaryReminderData> {
+
+	private DiaryReminderNotificationEvent(Long userId, DiaryReminderData data) {
+		super(userId, NotificationType.DIARY_REMINDER, data);
+	}
+
+	public static DiaryReminderNotificationEvent of(Long userId) {
+		return new DiaryReminderNotificationEvent(
+			userId,
+			DiaryReminderData.create()
+		);
+	}
+
+	@Override
+	public String getInAppTitle() {
+		return "";
+	}
+
+	@Override
+	public String getInAppBody() {
+		return "";
+	}
+
+	@Override
+	public String getPushTitle() {
+		return "일기로 오늘 하루를 기록해요.";
+	}
+
+	@Override
+	public String getPushBody() {
+		return "기분과 성과를 기록하며 하루를 돌아보세요.";
+	}
+
+	@Override
+	public String getActionUrl() {
+		return "toduck://diary";
+	}
+}

--- a/src/main/java/im/toduck/domain/notification/domain/service/DeviceTokenService.java
+++ b/src/main/java/im/toduck/domain/notification/domain/service/DeviceTokenService.java
@@ -8,10 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import im.toduck.domain.notification.persistence.entity.DeviceToken;
 import im.toduck.domain.notification.persistence.entity.DeviceType;
 import im.toduck.domain.notification.persistence.repository.DeviceTokenRepository;
-import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
-import im.toduck.global.exception.CommonException;
-import im.toduck.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,42 +17,28 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class DeviceTokenService {
 	private final DeviceTokenRepository deviceTokenRepository;
-	private final UserService userService;
 
 	@Transactional
-	public void registerDeviceToken(final Long userId, final String token, final DeviceType deviceType) {
-		User user = userService.getUserById(userId)
-			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+	public void registerDeviceToken(final User user, final String token, final DeviceType deviceType) {
+		if (deviceTokenRepository.existsByUserAndToken(user, token)) {
+			return;
+		}
 
-		deviceTokenRepository.findByUserAndToken(user, token)
-			.ifPresentOrElse(
-				existingToken -> log.debug("디바이스 토큰 이미 등록됨 - 사용자: {}, 토큰: {}", userId, token),
-				() -> {
-					DeviceToken deviceToken = DeviceToken.builder()
-						.user(user)
-						.token(token)
-						.deviceType(deviceType)
-						.build();
-					deviceTokenRepository.save(deviceToken);
-					log.info("디바이스 토큰 등록 성공 - 사용자: {}, 디바이스: {}", userId, deviceType);
-				}
-			);
+		DeviceToken deviceToken = DeviceToken.builder()
+			.user(user)
+			.token(token)
+			.deviceType(deviceType)
+			.build();
+		deviceTokenRepository.save(deviceToken);
 	}
 
 	/**
 	 * 디바이스 토큰을 삭제합니다.
-	 * 사용자가 로그아웃하거나 앱을 제거할 때 호출됩니다.
 	 */
 	@Transactional
-	public void removeDeviceToken(final Long userId, final String token) {
-		User user = userService.getUserById(userId)
-			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-
+	public void removeDeviceToken(final User user, final String token) {
 		deviceTokenRepository.findByUserAndToken(user, token)
-			.ifPresent(deviceToken -> {
-				deviceTokenRepository.delete(deviceToken);
-				log.info("디바이스 토큰 삭제 성공 - 사용자: {}, 토큰: {}", userId, token);
-			});
+			.ifPresent(deviceTokenRepository::delete);
 	}
 
 	/**
@@ -65,17 +48,13 @@ public class DeviceTokenService {
 	@Transactional
 	public void removeInvalidToken(final String token) {
 		deviceTokenRepository.deleteByToken(token);
-		log.info("무효화된 토큰 삭제 - 토큰: {}", token);
 	}
 
 	/**
 	 * 사용자의 모든 디바이스 토큰을 조회합니다.
 	 */
 	@Transactional(readOnly = true)
-	public List<DeviceToken> getUserDeviceTokens(final Long userId) {
-		User user = userService.getUserById(userId)
-			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
-
+	public List<DeviceToken> getUserDeviceTokens(final User user) {
 		return deviceTokenRepository.findAllByUser(user);
 	}
 }

--- a/src/main/java/im/toduck/domain/notification/domain/service/PushNotificationService.java
+++ b/src/main/java/im/toduck/domain/notification/domain/service/PushNotificationService.java
@@ -29,7 +29,7 @@ public class PushNotificationService {
 	public void sendPushNotification(final Notification notification) {
 		Long userId = notification.getUser().getId();
 
-		List<DeviceToken> deviceTokens = deviceTokenService.getUserDeviceTokens(userId);
+		List<DeviceToken> deviceTokens = deviceTokenService.getUserDeviceTokens(notification.getUser());
 
 		if (deviceTokens.isEmpty()) {
 			log.info("등록된 디바이스 토큰 없음 - 사용자: {}", userId);

--- a/src/main/java/im/toduck/domain/notification/domain/usecase/NotificationUseCase.java
+++ b/src/main/java/im/toduck/domain/notification/domain/usecase/NotificationUseCase.java
@@ -14,7 +14,11 @@ import im.toduck.domain.notification.persistence.entity.NotificationSetting;
 import im.toduck.domain.notification.presentation.dto.request.NotificationSettingUpdateRequest;
 import im.toduck.domain.notification.presentation.dto.response.NotificationListResponse;
 import im.toduck.domain.notification.presentation.dto.response.NotificationSettingResponse;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.annotation.UseCase;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,16 +30,23 @@ public class NotificationUseCase {
 	private final DeviceTokenService deviceTokenService;
 	private final NotificationSettingService notificationSettingService;
 	private final NotificationService notificationService;
+	private final UserService userService;
 
 	@Transactional
 	public void registerDeviceToken(final Long userId, final String token, final DeviceType deviceType) {
-		deviceTokenService.registerDeviceToken(userId, token, deviceType);
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		deviceTokenService.registerDeviceToken(user, token, deviceType);
 		log.info("디바이스 토큰 등록 성공 - UserId: {}, DeviceType: {}", userId, deviceType);
 	}
 
 	@Transactional
 	public void removeDeviceToken(final Long userId, final String token) {
-		deviceTokenService.removeDeviceToken(userId, token);
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		deviceTokenService.removeDeviceToken(user, token);
 		log.info("디바이스 토큰 삭제 성공 - UserId: {}", userId);
 	}
 

--- a/src/main/java/im/toduck/domain/notification/persistence/repository/DeviceTokenRepository.java
+++ b/src/main/java/im/toduck/domain/notification/persistence/repository/DeviceTokenRepository.java
@@ -18,6 +18,8 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
 
 	Optional<DeviceToken> findByUserAndToken(User user, String token);
 
+	boolean existsByUserAndToken(User user, String token);
+
 	@Modifying
 	@Query("DELETE FROM DeviceToken dt WHERE dt.token = :token")
 	void deleteByToken(@Param("token") String token);

--- a/src/main/java/im/toduck/domain/user/domain/service/UserService.java
+++ b/src/main/java/im/toduck/domain/user/domain/service/UserService.java
@@ -1,5 +1,6 @@
 package im.toduck.domain.user.domain.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -26,6 +27,11 @@ public class UserService {
 	@Transactional(readOnly = true)
 	public Optional<User> getUserById(Long id) {
 		return userRepository.findById(id);
+	}
+
+	@Transactional(readOnly = true)
+	public List<Long> getAllActiveUserIds() {
+		return userRepository.findAllActiveUserIds();
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustom.java
@@ -5,6 +5,8 @@ import java.util.List;
 import im.toduck.domain.user.persistence.entity.User;
 
 public interface UserRepositoryCustom {
+	List<Long> findAllActiveUserIds();
+
 	void updateNickname(User user, String nickname);
 
 	void updateProfileImageUrl(User user, String imageUrl);

--- a/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
+++ b/src/main/java/im/toduck/domain/user/persistence/repository/querydsl/UserRepositoryCustomImpl.java
@@ -20,6 +20,14 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 	private final QBlock qBlock = QBlock.block;
 
 	@Override
+	public List<Long> findAllActiveUserIds() {
+		return queryFactory.select(qUser.id)
+			.from(qUser)
+			.where(qUser.deletedAt.isNull())
+			.fetch();
+	}
+
+	@Override
 	public void updateNickname(User user, String nickname) {
 		queryFactory.update(qUser)
 			.set(qUser.nickname, nickname)

--- a/src/main/java/im/toduck/global/config/shedlock/ShedLockConfig.java
+++ b/src/main/java/im/toduck/global/config/shedlock/ShedLockConfig.java
@@ -1,0 +1,31 @@
+package im.toduck.global.config.shedlock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+
+/**
+ * ShedLock 설정 클래스
+ * <p>
+ * Redis를 사용하여 분산 환경에서 스케줄러의 중복 실행을 방지합니다.
+ * <p>
+ */
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+public class ShedLockConfig {
+
+	/**
+	 * Redis 기반 락 프로바이더를 생성합니다.
+	 *
+	 * @param connectionFactory Redis 연결 팩토리
+	 * @return Redis 락 프로바이더
+	 */
+	@Bean
+	public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+		return new RedisLockProvider(connectionFactory, "toduck");
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용

매일 오후 10시에 모든 사용자에게 일기 작성 유도 알림을 발송하는 스케줄러를 구현했습니다.  

**1️⃣ 일기 작성 리마인더 스케줄러 구현**
- 매일 오후 10시(22:00)에 실행되는 일기 작성 유도 알림 스케줄러 추가
- `DiarySchedulerUseCase`를 통해 모든 활성 사용자에게 일기 작성 알림 이벤트 발행
- `@Scheduled(cron = "0 0 22 * * *")` 어노테이션을 사용한 정시 실행

**2️⃣ ShedLock 분산 락 적용**
- 다중 서버 환경에서 스케줄러 중복 실행 방지
- Redis 기반 분산 락으로 안전한 스케줄링 보장

**3️⃣ 일기 리마인더 알림 이벤트 구현**
- 푸시 알림 메시지 및 딥링크(`toduck://diary`) 설정
- 기존 알림 시스템과 연동하여 이벤트 발행

## ✅ 리뷰 요구사항
- 현재는 사용자 수가 많지 않아 단순한 for loop으로 처리했습니다.
- 추후 사용자가 증가하면 Spring Batch나 청크 단위 처리로 개선할 예정인데, 이에 대한 의견이나 다른 접근 방법이 있다면 공유 부탁드립니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 매일 오후 10시에 모든 활성 사용자에게 일기 작성 알림이 자동으로 발송됩니다.
    - 일기 알림 푸시 메시지에는 고정된 제목과 내용, 그리고 일기 작성 화면으로 이동하는 딥링크가 포함됩니다.

- **버그 수정**
    - 사용자 존재 여부를 명확히 확인한 후 디바이스 토큰 등록 및 삭제가 이루어집니다.

- **리팩터링**
    - 디바이스 토큰 관련 서비스에서 사용자 객체를 직접 전달받도록 개선되어 코드가 간결해졌습니다.

- **기타**
    - 스케줄러의 중복 실행 방지를 위해 분산 락 기능(ShedLock)이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->