### PR TITLE
루틴 배치 작업 관련 문제 해결

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -371,7 +371,7 @@ CREATE TABLE notification (
                               FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
-CREATE TABLE qrtz_job_details (
+CREATE TABLE qrtz_JOB_DETAILS (
                                   sched_name VARCHAR(120) NOT NULL,
                                   job_name VARCHAR(190) NOT NULL,
                                   job_group VARCHAR(190) NOT NULL,
@@ -385,7 +385,7 @@ CREATE TABLE qrtz_job_details (
                                   PRIMARY KEY (sched_name, job_name, job_group)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_triggers (
+CREATE TABLE qrtz_TRIGGERS (
                                sched_name VARCHAR(120) NOT NULL,
                                trigger_name VARCHAR(190) NOT NULL,
                                trigger_group VARCHAR(190) NOT NULL,
@@ -404,10 +404,10 @@ CREATE TABLE qrtz_triggers (
                                job_data BLOB NULL,
                                PRIMARY KEY (sched_name, trigger_name, trigger_group),
                                FOREIGN KEY (sched_name, job_name, job_group)
-                                   REFERENCES qrtz_job_details(sched_name, job_name, job_group)
+                                   REFERENCES qrtz_JOB_DETAILS(sched_name, job_name, job_group)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_simple_triggers (
+CREATE TABLE qrtz_SIMPLE_TRIGGERS (
                                       sched_name VARCHAR(120) NOT NULL,
                                       trigger_name VARCHAR(190) NOT NULL,
                                       trigger_group VARCHAR(190) NOT NULL,
@@ -416,10 +416,10 @@ CREATE TABLE qrtz_simple_triggers (
                                       times_triggered BIGINT(10) NOT NULL,
                                       PRIMARY KEY (sched_name, trigger_name, trigger_group),
                                       FOREIGN KEY (sched_name, trigger_name, trigger_group)
-                                          REFERENCES qrtz_triggers(sched_name, trigger_name, trigger_group)
+                                          REFERENCES qrtz_TRIGGERS(sched_name, trigger_name, trigger_group)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_cron_triggers (
+CREATE TABLE qrtz_CRON_TRIGGERS (
                                     sched_name VARCHAR(120) NOT NULL,
                                     trigger_name VARCHAR(190) NOT NULL,
                                     trigger_group VARCHAR(190) NOT NULL,
@@ -427,10 +427,10 @@ CREATE TABLE qrtz_cron_triggers (
                                     time_zone_id VARCHAR(80),
                                     PRIMARY KEY (sched_name, trigger_name, trigger_group),
                                     FOREIGN KEY (sched_name, trigger_name, trigger_group)
-                                        REFERENCES qrtz_triggers(sched_name, trigger_name, trigger_group)
+                                        REFERENCES qrtz_TRIGGERS(sched_name, trigger_name, trigger_group)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_simprop_triggers (
+CREATE TABLE qrtz_SIMPROP_TRIGGERS (
                                        sched_name VARCHAR(120) NOT NULL,
                                        trigger_name VARCHAR(190) NOT NULL,
                                        trigger_group VARCHAR(190) NOT NULL,
@@ -447,10 +447,10 @@ CREATE TABLE qrtz_simprop_triggers (
                                        bool_prop_2 VARCHAR(1) NULL,
                                        PRIMARY KEY (sched_name, trigger_name, trigger_group),
                                        FOREIGN KEY (sched_name, trigger_name, trigger_group)
-                                           REFERENCES qrtz_triggers(sched_name, trigger_name, trigger_group)
+                                           REFERENCES qrtz_TRIGGERS(sched_name, trigger_name, trigger_group)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_blob_triggers (
+CREATE TABLE qrtz_BLOB_TRIGGERS (
                                     sched_name VARCHAR(120) NOT NULL,
                                     trigger_name VARCHAR(190) NOT NULL,
                                     trigger_group VARCHAR(190) NOT NULL,
@@ -458,23 +458,23 @@ CREATE TABLE qrtz_blob_triggers (
                                     PRIMARY KEY (sched_name, trigger_name, trigger_group),
                                     INDEX (sched_name, trigger_name, trigger_group),
                                     FOREIGN KEY (sched_name, trigger_name, trigger_group)
-                                        REFERENCES qrtz_triggers(sched_name, trigger_name, trigger_group)
+                                        REFERENCES qrtz_TRIGGERS(sched_name, trigger_name, trigger_group)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_calendars (
+CREATE TABLE qrtz_CALENDARS (
                                 sched_name VARCHAR(120) NOT NULL,
                                 calendar_name VARCHAR(190) NOT NULL,
                                 calendar BLOB NOT NULL,
                                 PRIMARY KEY (sched_name, calendar_name)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_paused_trigger_grps (
+CREATE TABLE qrtz_PAUSED_TRIGGER_GRPS (
                                           sched_name VARCHAR(120) NOT NULL,
                                           trigger_group VARCHAR(190) NOT NULL,
                                           PRIMARY KEY (sched_name, trigger_group)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_fired_triggers (
+CREATE TABLE qrtz_FIRED_TRIGGERS (
                                      sched_name VARCHAR(120) NOT NULL,
                                      entry_id VARCHAR(95) NOT NULL,
                                      trigger_name VARCHAR(190) NOT NULL,
@@ -491,7 +491,7 @@ CREATE TABLE qrtz_fired_triggers (
                                      PRIMARY KEY (sched_name, entry_id)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_scheduler_state (
+CREATE TABLE qrtz_SCHEDULER_STATE (
                                       sched_name VARCHAR(120) NOT NULL,
                                       instance_name VARCHAR(190) NOT NULL,
                                       last_checkin_time BIGINT(13) NOT NULL,
@@ -499,35 +499,35 @@ CREATE TABLE qrtz_scheduler_state (
                                       PRIMARY KEY (sched_name, instance_name)
 ) ENGINE=InnoDB;
 
-CREATE TABLE qrtz_locks (
+CREATE TABLE qrtz_LOCKS (
                             sched_name VARCHAR(120) NOT NULL,
                             lock_name VARCHAR(40) NOT NULL,
                             PRIMARY KEY (sched_name, lock_name)
 ) ENGINE=InnoDB;
 
 -- 인덱스 생성
-CREATE INDEX idx_qrtz_j_req_recovery ON qrtz_job_details(sched_name, requests_recovery);
-CREATE INDEX idx_qrtz_j_grp ON qrtz_job_details(sched_name, job_group);
+CREATE INDEX idx_qrtz_j_req_recovery ON qrtz_JOB_DETAILS(sched_name, requests_recovery);
+CREATE INDEX idx_qrtz_j_grp ON qrtz_JOB_DETAILS(sched_name, job_group);
 
-CREATE INDEX idx_qrtz_t_j ON qrtz_triggers(sched_name, job_name, job_group);
-CREATE INDEX idx_qrtz_t_jg ON qrtz_triggers(sched_name, job_group);
-CREATE INDEX idx_qrtz_t_c ON qrtz_triggers(sched_name, calendar_name);
-CREATE INDEX idx_qrtz_t_g ON qrtz_triggers(sched_name, trigger_group);
-CREATE INDEX idx_qrtz_t_state ON qrtz_triggers(sched_name, trigger_state);
-CREATE INDEX idx_qrtz_t_n_state ON qrtz_triggers(sched_name, trigger_name, trigger_group, trigger_state);
-CREATE INDEX idx_qrtz_t_n_g_state ON qrtz_triggers(sched_name, trigger_group, trigger_state);
-CREATE INDEX idx_qrtz_t_next_fire_time ON qrtz_triggers(sched_name, next_fire_time);
-CREATE INDEX idx_qrtz_t_nft_st ON qrtz_triggers(sched_name, trigger_state, next_fire_time);
-CREATE INDEX idx_qrtz_t_nft_misfire ON qrtz_triggers(sched_name, misfire_instr, next_fire_time);
-CREATE INDEX idx_qrtz_t_nft_st_misfire ON qrtz_triggers(sched_name, misfire_instr, next_fire_time, trigger_state);
-CREATE INDEX idx_qrtz_t_nft_st_misfire_grp ON qrtz_triggers(sched_name, misfire_instr, next_fire_time, trigger_group, trigger_state);
+CREATE INDEX idx_qrtz_t_j ON qrtz_TRIGGERS(sched_name, job_name, job_group);
+CREATE INDEX idx_qrtz_t_jg ON qrtz_TRIGGERS(sched_name, job_group);
+CREATE INDEX idx_qrtz_t_c ON qrtz_TRIGGERS(sched_name, calendar_name);
+CREATE INDEX idx_qrtz_t_g ON qrtz_TRIGGERS(sched_name, trigger_group);
+CREATE INDEX idx_qrtz_t_state ON qrtz_TRIGGERS(sched_name, trigger_state);
+CREATE INDEX idx_qrtz_t_n_state ON qrtz_TRIGGERS(sched_name, trigger_name, trigger_group, trigger_state);
+CREATE INDEX idx_qrtz_t_n_g_state ON qrtz_TRIGGERS(sched_name, trigger_group, trigger_state);
+CREATE INDEX idx_qrtz_t_next_fire_time ON qrtz_TRIGGERS(sched_name, next_fire_time);
+CREATE INDEX idx_qrtz_t_nft_st ON qrtz_TRIGGERS(sched_name, trigger_state, next_fire_time);
+CREATE INDEX idx_qrtz_t_nft_misfire ON qrtz_TRIGGERS(sched_name, misfire_instr, next_fire_time);
+CREATE INDEX idx_qrtz_t_nft_st_misfire ON qrtz_TRIGGERS(sched_name, misfire_instr, next_fire_time, trigger_state);
+CREATE INDEX idx_qrtz_t_nft_st_misfire_grp ON qrtz_TRIGGERS(sched_name, misfire_instr, next_fire_time, trigger_group, trigger_state);
 
-CREATE INDEX idx_qrtz_ft_trig_inst_name ON qrtz_fired_triggers(sched_name, instance_name);
-CREATE INDEX idx_qrtz_ft_inst_job_req_rcvry ON qrtz_fired_triggers(sched_name, instance_name, requests_recovery);
-CREATE INDEX idx_qrtz_ft_j_g ON qrtz_fired_triggers(sched_name, job_name, job_group);
-CREATE INDEX idx_qrtz_ft_jg ON qrtz_fired_triggers(sched_name, job_group);
-CREATE INDEX idx_qrtz_ft_t_g ON qrtz_fired_triggers(sched_name, trigger_name, trigger_group);
-CREATE INDEX idx_qrtz_ft_tg ON qrtz_fired_triggers(sched_name, trigger_group);
+CREATE INDEX idx_qrtz_ft_trig_inst_name ON qrtz_FIRED_TRIGGERS(sched_name, instance_name);
+CREATE INDEX idx_qrtz_ft_inst_job_req_rcvry ON qrtz_FIRED_TRIGGERS(sched_name, instance_name, requests_recovery);
+CREATE INDEX idx_qrtz_ft_j_g ON qrtz_FIRED_TRIGGERS(sched_name, job_name, job_group);
+CREATE INDEX idx_qrtz_ft_jg ON qrtz_FIRED_TRIGGERS(sched_name, job_group);
+CREATE INDEX idx_qrtz_ft_t_g ON qrtz_FIRED_TRIGGERS(sched_name, trigger_name, trigger_group);
+CREATE INDEX idx_qrtz_ft_tg ON qrtz_FIRED_TRIGGERS(sched_name, trigger_group);
 
 -- 루틴 알림 작업 기록 테이블
 CREATE TABLE routine_reminder_job (

--- a/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineReminderBatchSchedulerUseCase.java
+++ b/src/main/java/im/toduck/domain/routine/domain/usecase/RoutineReminderBatchSchedulerUseCase.java
@@ -30,7 +30,7 @@ public class RoutineReminderBatchSchedulerUseCase {
 		lockAtMostFor = "55m",
 		lockAtLeastFor = "1m"
 	)
-	@Transactional(readOnly = true)
+	@Transactional
 	public void scheduleDailyRoutineReminders() {
 		LocalDateTime currentDateTime = LocalDateTime.now();
 		LocalDate today = currentDateTime.toLocalDate();


### PR DESCRIPTION
## ✨ 작업 내용
- `@Transactional(readOnly = true)` 로 인해 정상적으로 배치 작업이 이루어지지 않는 문제 해결
- `Quartz` 관련 테이블 대문자로 변경
	 - Mac에서 MySQL의 `lower_case_table_names=2` 설정으로 인한 Linux 배포 환경과의 테이블명 대소문자 처리 차이 해결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Quartz 스케줄러 관련 테이블 이름이 모두 대문자로 변경되어 데이터베이스 호환성이 개선되었습니다.
  * 일일 루틴 리마인더 예약 작업의 트랜잭션 동작이 읽기 전용에서 읽기/쓰기 모드로 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->