### PR TITLE
일기 키워드 기능 개발

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -297,7 +297,7 @@ CREATE TABLE diary_image_file
     FOREIGN KEY (diary_id) REFERENCES diary (id) ON DELETE CASCADE
 );
 
-CREATE TABLE keywords
+CREATE TABLE master_keywords
 (
     id          BIGINT PRIMARY KEY auto_increment,
     category    ENUM('FREQUENT', 'PERSON', 'PLACE', 'SITUATION', 'RESULT')  NOT NULL,
@@ -306,7 +306,7 @@ CREATE TABLE keywords
     UNIQUE KEY uniq_category_keyword (category, keyword)
 );
 
-CREATE TABLE keywords_user
+CREATE TABLE user_keywords
 (
     id          BIGINT PRIMARY KEY auto_increment,
     user_id     BIGINT                                                      NOT NULL,

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -321,12 +321,17 @@ CREATE TABLE user_keywords
 
 CREATE TABLE diary_keywords
 (
-    diary_id BIGINT     NOT NULL,
-    keyword_id BIGINT   NOT NULL,
-    checked BOOLEAN     NOT NULL DEFAULT FALSE,
-    PRIMARY KEY(diary_id, keyword_id),
+    id                  BIGINT      PRIMARY KEY AUTO_INCREMENT,
+    diary_id            BIGINT      NOT NULL,
+    user_keyword_id     BIGINT      NOT NULL,
+    checked             BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at          DATETIME    NOT NULL,
+    updated_at          DATETIME    NOT NULL,
+    deleted_at          DATETIME    NULL,
+
+    UNIQUE KEY uniq_diary_keyword (diary_id, keyword_id),
     FOREIGN KEY (diary_id) REFERENCES diary(id) ON DELETE CASCADE,
-    FOREIGN KEY (keyword_id) REFERENCES keywords(id) ON DELETE CASCADE
+    FOREIGN KEY (user_keyword_id) REFERENCES user_keywords(id) ON DELETE CASCADE
 );
 
 CREATE TABLE concentration

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -297,6 +297,38 @@ CREATE TABLE diary_image_file
     FOREIGN KEY (diary_id) REFERENCES diary (id) ON DELETE CASCADE
 );
 
+CREATE TABLE keywords
+(
+    id          BIGINT PRIMARY KEY auto_increment,
+    category    ENUM('FREQUENT', 'PERSON', 'PLACE', 'SITUATION', 'RESULT')  NOT NULL,
+    keyword     VARCHAR(255)                                                NOT NULL,
+    created_at  DATETIME                                                    NOT NULL,
+    UNIQUE KEY uniq_category_keyword (category, keyword)
+);
+
+CREATE TABLE keywords_user
+(
+    id          BIGINT PRIMARY KEY auto_increment,
+    user_id     BIGINT  NOT NULL,
+    category    ENUM('FREQUENT', 'PERSON', 'PLACE', 'SITUATION', 'RESULT')  NOT NULL,
+    keyword     VARCHAR(255)                                                NOT NULL,
+    count       BIGINT                                                      NOT NULL DEFAULT 0,
+    created_at  DATETIME                                                    NOT NULL,
+    updated_at  DATETIME                                                    NOT NULL,
+    deleted_at  DATETIME                                                    NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE diary_keywords
+(
+    diary_id BIGINT     NOT NULL,
+    keyword_id BIGINT   NOT NULL,
+    checked BOOLEAN     NOT NULL DEFAULT FALSE,
+    PRIMARY KEY(diary_id, keyword_id),
+    FOREIGN KEY (diary_id) REFERENCES diary(id) ON DELETE CASCADE,
+    FOREIGN KEY (keyword_id) REFERENCES keywords(id) ON DELETE CASCADE
+);
+
 CREATE TABLE concentration
 (
     id                  BIGINT PRIMARY KEY auto_increment,

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -308,14 +308,14 @@ CREATE TABLE master_keywords
 
 CREATE TABLE user_keywords
 (
-    id          BIGINT PRIMARY KEY auto_increment,
-    user_id     BIGINT                                                      NOT NULL,
-    category    ENUM('FREQUENT', 'PERSON', 'PLACE', 'SITUATION', 'RESULT')  NOT NULL,
-    keyword     VARCHAR(255)                                                NOT NULL,
-    count       BIGINT                                                      NOT NULL DEFAULT 0,
-    created_at  DATETIME                                                    NOT NULL,
-    updated_at  DATETIME                                                    NOT NULL,
-    deleted_at  DATETIME                                                    NULL,
+    id                  BIGINT PRIMARY KEY auto_increment,
+    user_id             BIGINT                                                      NOT NULL,
+    category            ENUM('FREQUENT', 'PERSON', 'PLACE', 'SITUATION', 'RESULT')  NOT NULL,
+    keyword             VARCHAR(255)                                                NOT NULL,
+    keyword_count       BIGINT                                                      NOT NULL DEFAULT 0,
+    created_at          DATETIME                                                    NOT NULL,
+    updated_at          DATETIME                                                    NOT NULL,
+    deleted_at          DATETIME                                                    NULL,
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
 

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -302,7 +302,9 @@ CREATE TABLE master_keywords
     id          BIGINT PRIMARY KEY auto_increment,
     category    ENUM('FREQUENT', 'PERSON', 'PLACE', 'SITUATION', 'RESULT')  NOT NULL,
     keyword     VARCHAR(255)                                                NOT NULL,
-    created_at  DATETIME                                                    NOT NULL,
+    created_at          DATETIME                                            NOT NULL,
+    updated_at          DATETIME                                            NOT NULL,
+    deleted_at          DATETIME                                            NULL,
     UNIQUE KEY uniq_category_keyword (category, keyword)
 );
 
@@ -312,7 +314,6 @@ CREATE TABLE user_keywords
     user_id             BIGINT                                                      NOT NULL,
     category            ENUM('FREQUENT', 'PERSON', 'PLACE', 'SITUATION', 'RESULT')  NOT NULL,
     keyword             VARCHAR(255)                                                NOT NULL,
-    keyword_count       BIGINT                                                      NOT NULL DEFAULT 0,
     created_at          DATETIME                                                    NOT NULL,
     updated_at          DATETIME                                                    NOT NULL,
     deleted_at          DATETIME                                                    NULL,

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -309,7 +309,7 @@ CREATE TABLE keywords
 CREATE TABLE keywords_user
 (
     id          BIGINT PRIMARY KEY auto_increment,
-    user_id     BIGINT  NOT NULL,
+    user_id     BIGINT                                                      NOT NULL,
     category    ENUM('FREQUENT', 'PERSON', 'PLACE', 'SITUATION', 'RESULT')  NOT NULL,
     keyword     VARCHAR(255)                                                NOT NULL,
     count       BIGINT                                                      NOT NULL DEFAULT 0,

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -324,7 +324,6 @@ CREATE TABLE diary_keywords
     id                  BIGINT      PRIMARY KEY AUTO_INCREMENT,
     diary_id            BIGINT      NOT NULL,
     user_keyword_id     BIGINT      NOT NULL,
-    checked             BOOLEAN     NOT NULL DEFAULT FALSE,
     created_at          DATETIME    NOT NULL,
     updated_at          DATETIME    NOT NULL,
     deleted_at          DATETIME    NULL,

--- a/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/DiaryMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import im.toduck.domain.diary.persistence.entity.Diary;
 import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryKeywordDto;
 import im.toduck.domain.diary.presentation.dto.response.DiaryListResponse;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.domain.diary.presentation.dto.response.MonthDiaryResponse;
@@ -35,6 +36,9 @@ public class DiaryMapper {
 			diary.getMemo(),
 			diary.getDiaryImages().stream()
 				.map(DiaryImageFileMapper::fromDiaryImage)
+				.toList(),
+			diary.getDiaryKeywords().stream()
+				.map(DiaryKeywordDto::from)
 				.toList()
 		);
 	}

--- a/src/main/java/im/toduck/domain/diary/common/mapper/UserKeywordMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/UserKeywordMapper.java
@@ -14,7 +14,6 @@ public class UserKeywordMapper {
 			.user(user)
 			.category(masterKeyword.getCategory())
 			.keyword(masterKeyword.getKeyword())
-			.count(0L)
 			.build();
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/common/mapper/UserKeywordMapper.java
+++ b/src/main/java/im/toduck/domain/diary/common/mapper/UserKeywordMapper.java
@@ -1,0 +1,20 @@
+package im.toduck.domain.diary.common.mapper;
+
+import im.toduck.domain.diary.persistence.entity.MasterKeyword;
+import im.toduck.domain.diary.persistence.entity.UserKeyword;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserKeywordMapper {
+
+	public static UserKeyword fromMasterKeyword(User user, MasterKeyword masterKeyword) {
+		return UserKeyword.builder()
+			.user(user)
+			.category(masterKeyword.getCategory())
+			.keyword(masterKeyword.getKeyword())
+			.count(0L)
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryKeywordService.java
@@ -25,7 +25,6 @@ public class DiaryKeywordService {
 			.map(uk -> DiaryKeyword.builder()
 				.diary(diary)
 				.userKeyword(uk)
-				.checked(false)
 				.build()
 			).toList();
 

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryKeywordService.java
@@ -1,0 +1,34 @@
+package im.toduck.domain.diary.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.persistence.entity.DiaryKeyword;
+import im.toduck.domain.diary.persistence.entity.UserKeyword;
+import im.toduck.domain.diary.persistence.repository.DiaryKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiaryKeywordService {
+
+	private final DiaryKeywordRepository diaryKeywordRepository;
+
+	@Transactional
+	public void createDiaryKeywords(Diary diary, List<UserKeyword> userKeywords) {
+		List<DiaryKeyword> diaryKeywords = userKeywords.stream()
+			.map(uk -> DiaryKeyword.builder()
+				.diary(diary)
+				.userKeyword(uk)
+				.checked(false)
+				.build()
+			).toList();
+
+		diaryKeywordRepository.saveAll(diaryKeywords);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/DiaryService.java
@@ -19,6 +19,8 @@ import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
 import im.toduck.domain.diary.presentation.dto.request.DiaryUpdateRequest;
 import im.toduck.domain.diary.presentation.dto.response.DiaryResponse;
 import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -114,5 +116,11 @@ public class DiaryService {
 		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth()).plusDays(1);
 
 		return diaryRepository.countByUserIdAndDateBetween(userId, startDate, endDate);
+	}
+
+	@Transactional(readOnly = true)
+	public Diary getDiaryByIdAndUserId(Long userId, Long diaryId) {
+		return diaryRepository.getDiaryByUserIdAndId(userId, diaryId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_DIARY));
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/MasterKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/MasterKeywordService.java
@@ -1,0 +1,21 @@
+package im.toduck.domain.diary.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import im.toduck.domain.diary.persistence.entity.MasterKeyword;
+import im.toduck.domain.diary.persistence.repository.MasterKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MasterKeywordService {
+	private final MasterKeywordRepository masterKeywordRepository;
+
+	public List<MasterKeyword> findAll() {
+		return masterKeywordRepository.findAll();
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
@@ -11,6 +11,7 @@ import im.toduck.domain.diary.persistence.entity.MasterKeyword;
 import im.toduck.domain.diary.persistence.entity.UserKeyword;
 import im.toduck.domain.diary.persistence.repository.UserKeywordRepository;
 import im.toduck.domain.diary.presentation.dto.request.UserKeywordRequest;
+import im.toduck.domain.diary.presentation.dto.response.UserKeywordResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.exception.CommonException;
 import im.toduck.global.exception.ExceptionCode;
@@ -73,4 +74,16 @@ public class UserKeywordService {
 		keyword.restore(request.keywordCategory());
 	}
 
+	@Transactional(readOnly = true)
+	public List<UserKeywordResponse> getUserKeywordsById(final Long userId) {
+		List<UserKeyword> keywords = userKeywordRepository.findByUserId(userId);
+
+		return keywords.stream()
+			.map(uk -> new UserKeywordResponse(
+				uk.getCategory(),
+				uk.getKeyword(),
+				uk.getCount()
+			))
+			.toList();
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
@@ -1,0 +1,52 @@
+package im.toduck.domain.diary.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.diary.common.mapper.UserKeywordMapper;
+import im.toduck.domain.diary.persistence.entity.MasterKeyword;
+import im.toduck.domain.diary.persistence.entity.UserKeyword;
+import im.toduck.domain.diary.persistence.repository.UserKeywordRepository;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreate;
+import im.toduck.domain.user.persistence.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserKeywordService {
+	private final UserKeywordRepository userKeywordRepository;
+
+	public boolean existsAnyKeywordByUser(final User user) {
+		return userKeywordRepository.existsByUser(user);
+	}
+
+	@Transactional
+	public void setupKeywordsFromMaster(final User user, final List<MasterKeyword> masterKeywords) {
+		List<UserKeyword> userKeywords = masterKeywords.stream()
+			.map(mk -> UserKeywordMapper.fromMasterKeyword(user, mk))
+			.toList();
+
+		userKeywordRepository.saveAll(userKeywords);
+	}
+
+	@Transactional
+	public boolean existKeyword(final User user, final UserKeywordCreate request) {
+		return userKeywordRepository.existsByUserAndKeyword(user, request.keyword());
+	}
+
+	@Transactional
+	public void createKeyword(final User user, final UserKeywordCreate request) {
+		UserKeyword newKeyword = UserKeyword.builder()
+			.user(user)
+			.category(request.keywordCategory())
+			.keyword(request.keyword())
+			.count(0L)
+			.build();
+
+		userKeywordRepository.save(newKeyword);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
@@ -9,7 +9,7 @@ import im.toduck.domain.diary.common.mapper.UserKeywordMapper;
 import im.toduck.domain.diary.persistence.entity.MasterKeyword;
 import im.toduck.domain.diary.persistence.entity.UserKeyword;
 import im.toduck.domain.diary.persistence.repository.UserKeywordRepository;
-import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreate;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreateRequest;
 import im.toduck.domain.user.persistence.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,12 +34,12 @@ public class UserKeywordService {
 	}
 
 	@Transactional
-	public boolean existKeyword(final User user, final UserKeywordCreate request) {
+	public boolean existKeyword(final User user, final UserKeywordCreateRequest request) {
 		return userKeywordRepository.existsByUserAndKeyword(user, request.keyword());
 	}
 
 	@Transactional
-	public void createKeyword(final User user, final UserKeywordCreate request) {
+	public void createKeyword(final User user, final UserKeywordCreateRequest request) {
 		UserKeyword newKeyword = UserKeyword.builder()
 			.user(user)
 			.category(request.keywordCategory())

--- a/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
@@ -1,6 +1,7 @@
 package im.toduck.domain.diary.domain.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,8 +10,10 @@ import im.toduck.domain.diary.common.mapper.UserKeywordMapper;
 import im.toduck.domain.diary.persistence.entity.MasterKeyword;
 import im.toduck.domain.diary.persistence.entity.UserKeyword;
 import im.toduck.domain.diary.persistence.repository.UserKeywordRepository;
-import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreateRequest;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordRequest;
 import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserKeywordService {
 	private final UserKeywordRepository userKeywordRepository;
 
+	@Transactional(readOnly = true)
 	public boolean existsAnyKeywordByUser(final User user) {
 		return userKeywordRepository.existsByUser(user);
 	}
@@ -34,12 +38,12 @@ public class UserKeywordService {
 	}
 
 	@Transactional
-	public boolean existKeyword(final User user, final UserKeywordCreateRequest request) {
+	public boolean existKeyword(final User user, final UserKeywordRequest request) {
 		return userKeywordRepository.existsByUserAndKeyword(user, request.keyword());
 	}
 
 	@Transactional
-	public void createKeyword(final User user, final UserKeywordCreateRequest request) {
+	public void createKeyword(final User user, final UserKeywordRequest request) {
 		UserKeyword newKeyword = UserKeyword.builder()
 			.user(user)
 			.category(request.keywordCategory())
@@ -49,4 +53,24 @@ public class UserKeywordService {
 
 		userKeywordRepository.save(newKeyword);
 	}
+
+	@Transactional
+	public void deleteKeyword(final User user, final UserKeywordRequest request) {
+		UserKeyword keyword = userKeywordRepository
+			.findByUserAndKeyword(user, request.keyword())
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_KEYWORD));
+
+		userKeywordRepository.delete(keyword);
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<UserKeyword> findByUserAndKeywordIncludingDeleted(User user, String keyword) {
+		return userKeywordRepository.findByUserAndKeywordIncludingDeleted(user, keyword);
+	}
+
+	@Transactional
+	public void restoreKeyword(UserKeyword keyword, UserKeywordRequest request) {
+		keyword.restore(request.keywordCategory());
+	}
+
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
@@ -87,4 +87,14 @@ public class UserKeywordService {
 			))
 			.toList();
 	}
+
+	@Transactional(readOnly = true)
+	public List<UserKeyword> getUserKeywordsByIds(Long userId, List<Long> keywordIds) {
+		List<UserKeyword> userKeywords = userKeywordRepository.findByUserIdAndIdIn(userId, keywordIds);
+
+		if (userKeywords.size() != keywordIds.size()) {
+			throw CommonException.from(ExceptionCode.INVALID_KEYWORD_ID);
+		}
+		return userKeywords;
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
@@ -80,6 +80,7 @@ public class UserKeywordService {
 
 		return keywords.stream()
 			.map(uk -> new UserKeywordResponse(
+				uk.getId(),
 				uk.getCategory(),
 				uk.getKeyword(),
 				uk.getCount()

--- a/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
+++ b/src/main/java/im/toduck/domain/diary/domain/service/UserKeywordService.java
@@ -49,7 +49,6 @@ public class UserKeywordService {
 			.user(user)
 			.category(request.keywordCategory())
 			.keyword(request.keyword())
-			.count(0L)
 			.build();
 
 		userKeywordRepository.save(newKeyword);
@@ -82,8 +81,7 @@ public class UserKeywordService {
 			.map(uk -> new UserKeywordResponse(
 				uk.getId(),
 				uk.getCategory(),
-				uk.getKeyword(),
-				uk.getCount()
+				uk.getKeyword()
 			))
 			.toList();
 	}

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryKeywordUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryKeywordUseCase.java
@@ -25,7 +25,7 @@ public class DiaryKeywordUseCase {
 	private final UserKeywordService userKeywordService;
 
 	@Transactional
-	public void createDiaryKeyword(final Long userId, @Valid DiaryKeywordCreateRequest request) {
+	public void createDiaryKeyword(final Long userId, @Valid final DiaryKeywordCreateRequest request) {
 		Diary diary = diaryService.getDiaryByIdAndUserId(userId, request.diaryId());
 
 		List<UserKeyword> userKeywords = userKeywordService.getUserKeywordsByIds(userId, request.keywordIds());

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryKeywordUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryKeywordUseCase.java
@@ -1,0 +1,35 @@
+package im.toduck.domain.diary.domain.usecase;
+
+import java.util.List;
+
+import im.toduck.domain.diary.domain.service.DiaryKeywordService;
+import im.toduck.domain.diary.domain.service.DiaryService;
+import im.toduck.domain.diary.domain.service.UserKeywordService;
+import im.toduck.domain.diary.persistence.entity.Diary;
+import im.toduck.domain.diary.persistence.entity.UserKeyword;
+import im.toduck.domain.diary.presentation.dto.request.DiaryKeywordCreateRequest;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.global.annotation.UseCase;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class DiaryKeywordUseCase {
+	private final UserService userService;
+	private final DiaryService diaryService;
+	private final DiaryKeywordService diaryKeywordService;
+	private final UserKeywordService userKeywordService;
+
+	@Transactional
+	public void createDiaryKeyword(Long userId, @Valid DiaryKeywordCreateRequest request) {
+		Diary diary = diaryService.getDiaryByIdAndUserId(userId, request.diaryId());
+
+		List<UserKeyword> userKeywords = userKeywordService.getUserKeywordsByIds(userId, request.keywordIds());
+
+		diaryKeywordService.createDiaryKeywords(diary, userKeywords);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryKeywordUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/DiaryKeywordUseCase.java
@@ -25,7 +25,7 @@ public class DiaryKeywordUseCase {
 	private final UserKeywordService userKeywordService;
 
 	@Transactional
-	public void createDiaryKeyword(Long userId, @Valid DiaryKeywordCreateRequest request) {
+	public void createDiaryKeyword(final Long userId, @Valid DiaryKeywordCreateRequest request) {
 		Diary diary = diaryService.getDiaryByIdAndUserId(userId, request.diaryId());
 
 		List<UserKeyword> userKeywords = userKeywordService.getUserKeywordsByIds(userId, request.keywordIds());

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCase.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import im.toduck.domain.diary.domain.service.MasterKeywordService;
 import im.toduck.domain.diary.domain.service.UserKeywordService;
 import im.toduck.domain.diary.persistence.entity.MasterKeyword;
-import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreate;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreateRequest;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.annotation.UseCase;
@@ -39,7 +39,7 @@ public class UserKeywordUseCase {
 	}
 
 	@Transactional
-	public void createKeyword(final Long userId, final UserKeywordCreate request) {
+	public void createKeyword(final Long userId, final UserKeywordCreateRequest request) {
 		User user = userService.getUserById(userId)
 			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
 

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCase.java
@@ -1,0 +1,52 @@
+package im.toduck.domain.diary.domain.usecase;
+
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import im.toduck.domain.diary.domain.service.MasterKeywordService;
+import im.toduck.domain.diary.domain.service.UserKeywordService;
+import im.toduck.domain.diary.persistence.entity.MasterKeyword;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreate;
+import im.toduck.domain.user.domain.service.UserService;
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.annotation.UseCase;
+import im.toduck.global.exception.CommonException;
+import im.toduck.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class UserKeywordUseCase {
+	private final UserService userService;
+	private final UserKeywordService userKeywordService;
+	private final MasterKeywordService masterKeywordService;
+
+	@Transactional
+	public void setupKeyword(final Long userId) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		if (userKeywordService.existsAnyKeywordByUser(user)) {
+			throw CommonException.from(ExceptionCode.ALREADY_SETUP_KEYWORD);
+		}
+
+		List<MasterKeyword> masterKeywords = masterKeywordService.findAll();
+
+		userKeywordService.setupKeywordsFromMaster(user, masterKeywords);
+	}
+
+	@Transactional
+	public void createKeyword(final Long userId, final UserKeywordCreate request) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+
+		if (userKeywordService.existKeyword(user, request)) {
+			throw CommonException.from(ExceptionCode.ALREADY_EXISTS_KEYWORD);
+		}
+
+		userKeywordService.createKeyword(user, request);
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCase.java
+++ b/src/main/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCase.java
@@ -10,6 +10,8 @@ import im.toduck.domain.diary.domain.service.UserKeywordService;
 import im.toduck.domain.diary.persistence.entity.MasterKeyword;
 import im.toduck.domain.diary.persistence.entity.UserKeyword;
 import im.toduck.domain.diary.presentation.dto.request.UserKeywordRequest;
+import im.toduck.domain.diary.presentation.dto.response.UserKeywordListResponse;
+import im.toduck.domain.diary.presentation.dto.response.UserKeywordResponse;
 import im.toduck.domain.user.domain.service.UserService;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.annotation.UseCase;
@@ -71,5 +73,13 @@ public class UserKeywordUseCase {
 		}
 
 		userKeywordService.deleteKeyword(user, request);
+	}
+
+	@Transactional(readOnly = true)
+	public UserKeywordListResponse getKeywords(final Long userId) {
+		User user = userService.getUserById(userId)
+			.orElseThrow(() -> CommonException.from(ExceptionCode.NOT_FOUND_USER));
+		List<UserKeywordResponse> userKeywords = userKeywordService.getUserKeywordsById(userId);
+		return UserKeywordListResponse.toListUserKeywordResponse(userKeywords);
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/Diary.java
@@ -58,6 +58,9 @@ public class Diary extends BaseEntity {
 	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<DiaryImage> diaryImages = new ArrayList<>();
 
+	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<DiaryKeyword> diaryKeywords = new ArrayList<>();
+
 	@Builder
 	private Diary(User user,
 		LocalDate date,

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryKeyword.java
@@ -1,0 +1,49 @@
+package im.toduck.domain.diary.persistence.entity;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import im.toduck.global.base.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "diary_keywords")
+@Getter
+@NoArgsConstructor
+@SQLDelete(sql = "UPDATE diary SET deleted_at = NOW() where id=?")
+@SQLRestriction(value = "deleted_at is NULL")
+public class DiaryKeyword extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "diary_id", nullable = false)
+	private Diary diary;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_keyword_id", nullable = false)
+	private UserKeyword userKeyword;
+
+	@Column(nullable = false)
+	private boolean checked = false;
+
+	@Builder
+	private DiaryKeyword(Diary diary, UserKeyword userKeyword, boolean checked) {
+		this.diary = diary;
+		this.userKeyword = userKeyword;
+		this.checked = checked;
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryKeyword.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "diary_keywords")
 @Getter
 @NoArgsConstructor
-@SQLDelete(sql = "UPDATE diary SET deleted_at = NOW() where id=?")
+@SQLDelete(sql = "UPDATE diary_keywords SET deleted_at = NOW() where id=?")
 @SQLRestriction(value = "deleted_at is NULL")
 public class DiaryKeyword extends BaseEntity {
 

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/DiaryKeyword.java
@@ -4,7 +4,6 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import im.toduck.global.base.entity.BaseEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -37,13 +36,9 @@ public class DiaryKeyword extends BaseEntity {
 	@JoinColumn(name = "user_keyword_id", nullable = false)
 	private UserKeyword userKeyword;
 
-	@Column(nullable = false)
-	private boolean checked = false;
-
 	@Builder
-	private DiaryKeyword(Diary diary, UserKeyword userKeyword, boolean checked) {
+	private DiaryKeyword(Diary diary, UserKeyword userKeyword) {
 		this.diary = diary;
 		this.userKeyword = userKeyword;
-		this.checked = checked;
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/KeywordCategory.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/KeywordCategory.java
@@ -1,0 +1,9 @@
+package im.toduck.domain.diary.persistence.entity;
+
+public enum KeywordCategory {
+	FREQUENT,
+	PERSON,
+	PLACE,
+	SITUATION,
+	RESULT
+}

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/MasterKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/MasterKeyword.java
@@ -11,8 +11,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "master_keywords", uniqueConstraints = {
@@ -20,6 +23,8 @@ import lombok.Getter;
 })
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class MasterKeyword {
 
 	@Id

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/MasterKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/MasterKeyword.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
 import lombok.Getter;
 
 @Entity
@@ -18,6 +19,7 @@ import lombok.Getter;
 	@UniqueConstraint(name = "uniq_category_keyword", columnNames = {"category", "keyword"})
 })
 @Getter
+@Builder
 public class MasterKeyword {
 
 	@Id

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/MasterKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/MasterKeyword.java
@@ -1,0 +1,36 @@
+package im.toduck.domain.diary.persistence.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+
+@Entity
+@Table(name = "master_keywords", uniqueConstraints = {
+	@UniqueConstraint(name = "uniq_category_keyword", columnNames = {"category", "keyword"})
+})
+@Getter
+public class MasterKeyword {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private KeywordCategory category;
+
+	@Column(nullable = false, length = 255)
+	private String keyword;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/MasterKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/MasterKeyword.java
@@ -1,7 +1,6 @@
 package im.toduck.domain.diary.persistence.entity;
 
-import java.time.LocalDateTime;
-
+import im.toduck.global.base.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -25,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class MasterKeyword {
+public class MasterKeyword extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,7 +36,4 @@ public class MasterKeyword {
 
 	@Column(nullable = false, length = 255)
 	private String keyword;
-
-	@Column(name = "created_at", nullable = false)
-	private LocalDateTime createdAt;
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
@@ -56,4 +56,10 @@ public class UserKeyword extends BaseEntity {
 		this.keyword = keyword;
 		this.count = count != null ? count : 0L;
 	}
+
+	public void restore(KeywordCategory newCategory) {
+		this.deletedAt = null;
+		this.category = newCategory;
+		this.count = 0L;
+	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
@@ -43,7 +43,7 @@ public class UserKeyword extends BaseEntity {
 	@Column(nullable = false, length = 255)
 	private String keyword;
 
-	@Column(nullable = false)
+	@Column(name = "keyword_count", nullable = false)
 	private Long count = 0L;
 
 	@Builder

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
@@ -1,0 +1,59 @@
+package im.toduck.domain.diary.persistence.entity;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import im.toduck.domain.user.persistence.entity.User;
+import im.toduck.global.base.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_keywords")
+@Getter
+@NoArgsConstructor
+@SQLDelete(sql = "UPDATE user_keywords SET deleted_at = NOW() where id=?")
+@SQLRestriction(value = "deleted_at is NULL")
+public class UserKeyword extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private KeywordCategory category;
+
+	@Column(nullable = false, length = 255)
+	private String keyword;
+
+	@Column(nullable = false)
+	private Long count = 0L;
+
+	@Builder
+	private UserKeyword(User user,
+		KeywordCategory category,
+		String keyword,
+		Long count) {
+		this.user = user;
+		this.category = category;
+		this.keyword = keyword;
+		this.count = count != null ? count : 0L;
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
@@ -48,26 +48,20 @@ public class UserKeyword extends BaseEntity {
 	@Column(nullable = false, length = 255)
 	private String keyword;
 
-	@Column(name = "keyword_count", nullable = false)
-	private Long count = 0L;
-
 	@OneToMany(mappedBy = "userKeyword", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<DiaryKeyword> diaryKeywords = new ArrayList<>();
 
 	@Builder
 	private UserKeyword(User user,
 		KeywordCategory category,
-		String keyword,
-		Long count) {
+		String keyword) {
 		this.user = user;
 		this.category = category;
 		this.keyword = keyword;
-		this.count = count != null ? count : 0L;
 	}
 
 	public void restore(KeywordCategory newCategory) {
 		this.deletedAt = null;
 		this.category = newCategory;
-		this.count = 0L;
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/entity/UserKeyword.java
@@ -1,10 +1,14 @@
 package im.toduck.domain.diary.persistence.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.base.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,6 +19,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +50,9 @@ public class UserKeyword extends BaseEntity {
 
 	@Column(name = "keyword_count", nullable = false)
 	private Long count = 0L;
+
+	@OneToMany(mappedBy = "userKeyword", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<DiaryKeyword> diaryKeywords = new ArrayList<>();
 
 	@Builder
 	private UserKeyword(User user,

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryKeywordRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryKeywordRepository.java
@@ -1,9 +1,12 @@
 package im.toduck.domain.diary.persistence.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import im.toduck.domain.diary.persistence.entity.DiaryKeyword;
 
 public interface DiaryKeywordRepository extends JpaRepository<DiaryKeyword, Long> {
 
+	List<DiaryKeyword> findByDiaryId(Long diaryId);
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryKeywordRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryKeywordRepository.java
@@ -1,0 +1,9 @@
+package im.toduck.domain.diary.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import im.toduck.domain.diary.persistence.entity.DiaryKeyword;
+
+public interface DiaryKeywordRepository extends JpaRepository<DiaryKeyword, Long> {
+
+}

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/DiaryRepository.java
@@ -2,6 +2,7 @@ package im.toduck.domain.diary.persistence.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -19,4 +20,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	int countByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 
 	List<Diary> findAllByUser(User user);
+
+	Optional<Diary> getDiaryByUserIdAndId(Long userId, Long diaryId);
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/MasterKeywordRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/MasterKeywordRepository.java
@@ -1,0 +1,8 @@
+package im.toduck.domain.diary.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import im.toduck.domain.diary.persistence.entity.MasterKeyword;
+
+public interface MasterKeywordRepository extends JpaRepository<MasterKeyword, Long> {
+}

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/UserKeywordRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/UserKeywordRepository.java
@@ -30,4 +30,6 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
 	Optional<UserKeyword> findByUserAndKeywordIncludingDeleted(User user, String keyword);
 
 	List<UserKeyword> findByUserId(Long userId);
+
+	List<UserKeyword> findByUserIdAndIdIn(Long userId, List<Long> keywordIds);
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/UserKeywordRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/UserKeywordRepository.java
@@ -1,0 +1,14 @@
+package im.toduck.domain.diary.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import im.toduck.domain.diary.persistence.entity.UserKeyword;
+import im.toduck.domain.user.persistence.entity.User;
+
+@Repository
+public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> {
+	boolean existsByUser(User user);
+
+	boolean existsByUserAndKeyword(User user, String keyword);
+}

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/UserKeywordRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/UserKeywordRepository.java
@@ -1,6 +1,9 @@
 package im.toduck.domain.diary.persistence.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import im.toduck.domain.diary.persistence.entity.UserKeyword;
@@ -11,4 +14,17 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
 	boolean existsByUser(User user);
 
 	boolean existsByUserAndKeyword(User user, String keyword);
+
+	Optional<UserKeyword> findByUserAndKeyword(User user, String keyword);
+
+	@Query(
+		value = """
+			SELECT *
+			FROM user_keywords
+			WHERE user_id = :#{#user.id}
+				AND keyword = :keyword
+			LIMIT 1""",
+		nativeQuery = true
+	)
+	Optional<UserKeyword> findByUserAndKeywordIncludingDeleted(User user, String keyword);
 }

--- a/src/main/java/im/toduck/domain/diary/persistence/repository/UserKeywordRepository.java
+++ b/src/main/java/im/toduck/domain/diary/persistence/repository/UserKeywordRepository.java
@@ -1,5 +1,6 @@
 package im.toduck.domain.diary.persistence.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,4 +28,6 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
 		nativeQuery = true
 	)
 	Optional<UserKeyword> findByUserAndKeywordIncludingDeleted(User user, String keyword);
+
+	List<UserKeyword> findByUserId(Long userId);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/DiaryKeywordApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/DiaryKeywordApi.java
@@ -1,0 +1,33 @@
+package im.toduck.domain.diary.presentation.api;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import im.toduck.domain.diary.presentation.dto.request.DiaryKeywordCreateRequest;
+import im.toduck.global.annotation.swagger.ApiResponseExplanations;
+import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "DiaryKeyword")
+public interface DiaryKeywordApi {
+	@Operation(
+		summary = "일기 키워드 생성",
+		description = "선택된 키워드를 일기에 저장합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "일기 생성 성공. 빈 content 객체를 반환합니다."
+		)
+	)
+	public ResponseEntity<ApiResponse<Map<String, Object>>> createDiaryKeyword(
+		@RequestBody @Valid final DiaryKeywordCreateRequest request,
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	);
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreateRequest;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordRequest;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -45,6 +45,7 @@ public interface UserKeywordApi {
 		description = """
 				1. 해당 사용자에게 키워드를 생성합니다.
 				2. 동일한 키워드가 이미 존재하면 ALREADY_EXISTS_KEYWORD 예외를 반환합니다.
+				3. 동일한 키워드가 이미 삭제된 경우 입력된 카테고리로 다시 생성됩니다.
 			"""
 	)
 	@ApiResponseExplanations(
@@ -57,6 +58,26 @@ public interface UserKeywordApi {
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> createKeyword(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
-		@RequestBody @Valid final UserKeywordCreateRequest request
+		@RequestBody @Valid final UserKeywordRequest request
+	);
+
+	@Operation(
+		summary = "사용자 키워드 삭제",
+		description = """
+				1. 해당 사용자의 키워드를 삭제합니다.
+				2. 삭제하려는 키워드가 존재하지 않으면 NOT_FOUND_KEYWORD를 반환합니다.
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "키워드 생성 성공, 빈 content 객체를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_KEYWORD)
+		}
+	)
+	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteKeyword(
+		@RequestBody @Valid final UserKeywordRequest request,
+		@AuthenticationPrincipal final CustomUserDetails userDetails
 	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreate;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreateRequest;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -57,6 +57,6 @@ public interface UserKeywordApi {
 	)
 	ResponseEntity<ApiResponse<Map<String, Object>>> createKeyword(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
-		@RequestBody @Valid final UserKeywordCreate request
+		@RequestBody @Valid final UserKeywordCreateRequest request
 	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import im.toduck.domain.diary.presentation.dto.request.UserKeywordRequest;
+import im.toduck.domain.diary.presentation.dto.response.UserKeywordListResponse;
 import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
 import im.toduck.global.annotation.swagger.ApiResponseExplanations;
 import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -78,6 +79,23 @@ public interface UserKeywordApi {
 	)
 	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteKeyword(
 		@RequestBody @Valid final UserKeywordRequest request,
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	);
+
+	@Operation(
+		summary = "사용자 키워드 검색",
+		description = """
+				1. 해당 사용자의 키워드 목록을 가져옵니다.
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "키워드 생성 성공, 해당 사용자의 키워드 목록을 반환합니다."
+		),
+		errors = {
+		}
+	)
+	public ResponseEntity<ApiResponse<UserKeywordListResponse>> getKeyword(
 		@AuthenticationPrincipal final CustomUserDetails userDetails
 	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
@@ -23,10 +23,10 @@ public interface UserKeywordApi {
 	@Operation(
 		summary = "사용자 키워드 초기 설정",
 		description = """
-				1. 현재 로그인한 사용자의 키워드가 비어 있는 경우에만 실행됩니다.
-				2. 마스터 키워드를 기반으로 user_keywords 테이블에 데이터를 복사합니다.
-				3. 성공 시 content는 비어 있는 객체를 반환합니다.
-				4. 이미 초기 설정이 돼있으면 ALREADY_SETUP_KEYWORD 예외를 반환합니다.
+			<b>1. 현재 로그인한 사용자의 키워드가 비어 있는 경우에만 실행됩니다.</b><br/>
+			<b>2. 마스터 키워드를 기반으로 user_keywords 테이블에 데이터를 복사합니다.</b><br/>
+			<b>3. 성공 시 content는 비어 있는 객체를 반환합니다.</b><br/>
+			<b>4. 이미 초기 설정이 돼있으면(키워드가 하나라도 있으면) ALREADY_SETUP_KEYWORD 예외를 반환합니다.</b><br/>
 			"""
 	)
 	@ApiResponseExplanations(
@@ -44,9 +44,9 @@ public interface UserKeywordApi {
 	@Operation(
 		summary = "사용자 키워드 생성",
 		description = """
-				1. 해당 사용자에게 키워드를 생성합니다.
-				2. 동일한 키워드가 이미 존재하면 ALREADY_EXISTS_KEYWORD 예외를 반환합니다.
-				3. 동일한 키워드가 이미 삭제된 경우 입력된 카테고리로 다시 생성됩니다.
+			<b>1. 해당 사용자에게 키워드를 생성합니다.</b><br/>
+			<b>2. 동일한 키워드가 이미 존재하면 ALREADY_EXISTS_KEYWORD 예외를 반환합니다.</b><br/>
+			<b>3. 동일한 키워드가 이미 삭제된 경우 입력된 카테고리로 다시 생성됩니다.</b><br/>
 			"""
 	)
 	@ApiResponseExplanations(
@@ -65,8 +65,8 @@ public interface UserKeywordApi {
 	@Operation(
 		summary = "사용자 키워드 삭제",
 		description = """
-				1. 해당 사용자의 키워드를 삭제합니다.
-				2. 삭제하려는 키워드가 존재하지 않으면 NOT_FOUND_KEYWORD를 반환합니다.
+			<b>1. 해당 사용자의 키워드를 삭제합니다.</b><br/>
+			<b>2. 삭제하려는 키워드가 존재하지 않으면 NOT_FOUND_KEYWORD를 반환합니다.</b><br/>
 			"""
 	)
 	@ApiResponseExplanations(
@@ -77,7 +77,7 @@ public interface UserKeywordApi {
 			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.NOT_FOUND_KEYWORD)
 		}
 	)
-	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteKeyword(
+	ResponseEntity<ApiResponse<Map<String, Object>>> deleteKeyword(
 		@RequestBody @Valid final UserKeywordRequest request,
 		@AuthenticationPrincipal final CustomUserDetails userDetails
 	);
@@ -85,17 +85,18 @@ public interface UserKeywordApi {
 	@Operation(
 		summary = "사용자 키워드 검색",
 		description = """
-				1. 해당 사용자의 키워드 목록을 가져옵니다.
+			<b>1. 해당 사용자의 키워드 목록을 가져옵니다.</b><br/>
 			"""
 	)
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
+			responseClass = UserKeywordListResponse.class,
 			description = "키워드 생성 성공, 해당 사용자의 키워드 목록을 반환합니다."
 		),
 		errors = {
 		}
 	)
-	public ResponseEntity<ApiResponse<UserKeywordListResponse>> getKeyword(
+	ResponseEntity<ApiResponse<UserKeywordListResponse>> getKeyword(
 		@AuthenticationPrincipal final CustomUserDetails userDetails
 	);
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/api/UserKeywordApi.java
@@ -1,0 +1,62 @@
+package im.toduck.domain.diary.presentation.api;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreate;
+import im.toduck.global.annotation.swagger.ApiErrorResponseExplanation;
+import im.toduck.global.annotation.swagger.ApiResponseExplanations;
+import im.toduck.global.annotation.swagger.ApiSuccessResponseExplanation;
+import im.toduck.global.exception.ExceptionCode;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "UserKeyword")
+public interface UserKeywordApi {
+	@Operation(
+		summary = "사용자 키워드 초기 설정",
+		description = """
+				1. 현재 로그인한 사용자의 키워드가 비어 있는 경우에만 실행됩니다.
+				2. 마스터 키워드를 기반으로 user_keywords 테이블에 데이터를 복사합니다.
+				3. 성공 시 content는 비어 있는 객체를 반환합니다.
+				4. 이미 초기 설정이 돼있으면 ALREADY_SETUP_KEYWORD 예외를 반환합니다.
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "키워드 생성 성공, 빈 content 객체를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.ALREADY_SETUP_KEYWORD)
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> setupUserKeyword(
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	);
+
+	@Operation(
+		summary = "사용자 키워드 생성",
+		description = """
+				1. 해당 사용자에게 키워드를 생성합니다.
+				2. 동일한 키워드가 이미 존재하면 ALREADY_EXISTS_KEYWORD 예외를 반환합니다.
+			"""
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "키워드 생성 성공, 빈 content 객체를 반환합니다."
+		),
+		errors = {
+			@ApiErrorResponseExplanation(exceptionCode = ExceptionCode.ALREADY_EXISTS_KEYWORD)
+		}
+	)
+	ResponseEntity<ApiResponse<Map<String, Object>>> createKeyword(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@RequestBody @Valid final UserKeywordCreate request
+	);
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryKeywordController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/DiaryKeywordController.java
@@ -1,0 +1,38 @@
+package im.toduck.domain.diary.presentation.controller;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import im.toduck.domain.diary.domain.usecase.DiaryKeywordUseCase;
+import im.toduck.domain.diary.presentation.api.DiaryKeywordApi;
+import im.toduck.domain.diary.presentation.dto.request.DiaryKeywordCreateRequest;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/diaryKeyword")
+public class DiaryKeywordController implements DiaryKeywordApi {
+
+	private final DiaryKeywordUseCase diaryKeywordUseCase;
+
+	@Override
+	@PostMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> createDiaryKeyword(
+		@RequestBody @Valid final DiaryKeywordCreateRequest request,
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	) {
+		diaryKeywordUseCase.createDiaryKeyword(userDetails.getUserId(), request);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/UserKeywordController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/UserKeywordController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import im.toduck.domain.diary.domain.usecase.UserKeywordUseCase;
 import im.toduck.domain.diary.presentation.api.UserKeywordApi;
 import im.toduck.domain.diary.presentation.dto.request.UserKeywordRequest;
+import im.toduck.domain.diary.presentation.dto.response.UserKeywordListResponse;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -58,15 +60,15 @@ public class UserKeywordController implements UserKeywordApi {
 		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
 	}
 
-	// @Override
-	// @GetMapping()
-	// @PreAuthorize("isAuthenticated()")
-	// public ResponseEntity<ApiResponse<Map<String, Object>>> getKeyword(
-	// 	@AuthenticationPrincipal final CustomUserDetails userDetails
-	// ) {
-	// 	keywordUseCase.getKeyword(userDetails.getUserId());
-	// 	return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
-	// }
+	@Override
+	@GetMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<UserKeywordListResponse>> getKeyword(
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	) {
+		UserKeywordListResponse response = userKeywordUseCase.getKeywords(userDetails.getUserId());
+		return ResponseEntity.ok().body(ApiResponse.createSuccess(response));
+	}
 
 	// 이미 가입된 사람들 중에 키워드 없는 사람들한테도 키워드 넣어줘야함
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/UserKeywordController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/UserKeywordController.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import im.toduck.domain.diary.domain.usecase.UserKeywordUseCase;
 import im.toduck.domain.diary.presentation.api.UserKeywordApi;
-import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreateRequest;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordRequest;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -40,23 +41,23 @@ public class UserKeywordController implements UserKeywordApi {
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponse<Map<String, Object>>> createKeyword(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
-		@RequestBody @Valid final UserKeywordCreateRequest request
+		@RequestBody @Valid final UserKeywordRequest request
 	) {
 		userKeywordUseCase.createKeyword(userDetails.getUserId(), request);
 		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
 	}
 
-	// @Override
-	// @DeleteMapping("/delete")
-	// @PreAuthorize("isAuthenticated()")
-	// public ResponseEntity<ApiResponse<Map<String, Object>>> deleteKeyword(
-	// 	@RequestBody @Valid final KeywordDelete request,
-	// 	@AuthenticationPrincipal final CustomUserDetails userDetails
-	// ) {
-	// 	keywordUseCase.deleteKeyword(userDetails.getUserId(), request);
-	// 	return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
-	// }
-	//
+	@Override
+	@DeleteMapping("/delete")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteKeyword(
+		@RequestBody @Valid final UserKeywordRequest request,
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	) {
+		userKeywordUseCase.deleteKeyword(userDetails.getUserId(), request);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	}
+
 	// @Override
 	// @GetMapping()
 	// @PreAuthorize("isAuthenticated()")

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/UserKeywordController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/UserKeywordController.java
@@ -1,0 +1,71 @@
+package im.toduck.domain.diary.presentation.controller;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import im.toduck.domain.diary.domain.usecase.UserKeywordUseCase;
+import im.toduck.domain.diary.presentation.api.UserKeywordApi;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreate;
+import im.toduck.global.presentation.ApiResponse;
+import im.toduck.global.security.authentication.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/user-keywords")
+public class UserKeywordController implements UserKeywordApi {
+
+	private final UserKeywordUseCase userKeywordUseCase;
+
+	@Override
+	@PostMapping("/setup")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> setupUserKeyword(
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	) {
+		userKeywordUseCase.setupKeyword(userDetails.getUserId());
+		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@Override
+	@PostMapping("/create")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> createKeyword(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@RequestBody @Valid final UserKeywordCreate request
+	) {
+		userKeywordUseCase.createKeyword(userDetails.getUserId(), request);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	}
+
+	// @Override
+	// @DeleteMapping("/delete")
+	// @PreAuthorize("isAuthenticated()")
+	// public ResponseEntity<ApiResponse<Map<String, Object>>> deleteKeyword(
+	// 	@RequestBody @Valid final KeywordDelete request,
+	// 	@AuthenticationPrincipal final CustomUserDetails userDetails
+	// ) {
+	// 	keywordUseCase.deleteKeyword(userDetails.getUserId(), request);
+	// 	return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	// }
+	//
+	// @Override
+	// @GetMapping()
+	// @PreAuthorize("isAuthenticated()")
+	// public ResponseEntity<ApiResponse<Map<String, Object>>> getKeyword(
+	// 	@AuthenticationPrincipal final CustomUserDetails userDetails
+	// ) {
+	// 	keywordUseCase.getKeyword(userDetails.getUserId());
+	// 	return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());
+	// }
+
+	// 이미 가입된 사람들 중에 키워드 없는 사람들한테도 키워드 넣어줘야함
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/controller/UserKeywordController.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/controller/UserKeywordController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import im.toduck.domain.diary.domain.usecase.UserKeywordUseCase;
 import im.toduck.domain.diary.presentation.api.UserKeywordApi;
-import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreate;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordCreateRequest;
 import im.toduck.global.presentation.ApiResponse;
 import im.toduck.global.security.authentication.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -40,7 +40,7 @@ public class UserKeywordController implements UserKeywordApi {
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponse<Map<String, Object>>> createKeyword(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
-		@RequestBody @Valid final UserKeywordCreate request
+		@RequestBody @Valid final UserKeywordCreateRequest request
 	) {
 		userKeywordUseCase.createKeyword(userDetails.getUserId(), request);
 		return ResponseEntity.ok().body(ApiResponse.createSuccessWithNoContent());

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryCreateRequest.java
@@ -10,7 +10,9 @@ import im.toduck.domain.user.persistence.entity.Emotion;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 @Schema(description = "다이어리 생성 요청 DTO")
 public record DiaryCreateRequest(
 	@NotNull(message = "날짜는 비어있을 수 없습니다.")

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryKeywordCreateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryKeywordCreateRequest.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 @Schema(description = "일기에 선택된 키워드 생성 요청 DTO")
 public record DiaryKeywordCreateRequest(
 	@NotNull(message = "일기 ID는 비어있을 수 없습니다.")

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryKeywordCreateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/DiaryKeywordCreateRequest.java
@@ -1,0 +1,18 @@
+package im.toduck.domain.diary.presentation.dto.request;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "일기에 선택된 키워드 생성 요청 DTO")
+public record DiaryKeywordCreateRequest(
+	@NotNull(message = "일기 ID는 비어있을 수 없습니다.")
+	@Schema(description = "일기 ID", example = "1")
+	Long diaryId,
+
+	@NotNull(message = "키워드 ID는 비어있을 수 없습니다.")
+	@Schema(description = "키워드 ID", example = "[1, 5]")
+	List<Long> keywordIds
+) {
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/UserKeywordCreate.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/UserKeywordCreate.java
@@ -1,0 +1,19 @@
+package im.toduck.domain.diary.presentation.dto.request;
+
+import im.toduck.domain.diary.persistence.entity.KeywordCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "유저 키워드 생성 요청 DTO")
+public record UserKeywordCreate(
+	@NotNull(message = "카테고리는 비어있을 수 없습니다.")
+	@Schema(description = "카테고리", example = "PLACE")
+	KeywordCategory keywordCategory,
+
+	@Size(max = 255, message = "키워드는 255자를 초과할 수 없습니다.")
+	@Schema(description = "키워드", example = "회사")
+	String keyword
+) {
+
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/UserKeywordCreateRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/UserKeywordCreateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Schema(description = "유저 키워드 생성 요청 DTO")
-public record UserKeywordCreate(
+public record UserKeywordCreateRequest(
 	@NotNull(message = "카테고리는 비어있을 수 없습니다.")
 	@Schema(description = "카테고리", example = "PLACE")
 	KeywordCategory keywordCategory,

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/request/UserKeywordRequest.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/request/UserKeywordRequest.java
@@ -4,9 +4,11 @@ import im.toduck.domain.diary.persistence.entity.KeywordCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 @Schema(description = "유저 키워드 생성 요청 DTO")
-public record UserKeywordCreateRequest(
+public record UserKeywordRequest(
 	@NotNull(message = "카테고리는 비어있을 수 없습니다.")
 	@Schema(description = "카테고리", example = "PLACE")
 	KeywordCategory keywordCategory,

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryKeywordDto.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryKeywordDto.java
@@ -19,7 +19,6 @@ public record DiaryKeywordDto(
 		return DiaryKeywordDto.builder()
 			.keywordId(diaryKeyword.getUserKeyword().getId())
 			.keywordName(diaryKeyword.getUserKeyword().getKeyword())
-			.checked(diaryKeyword.isChecked())
 			.build();
 	}
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryKeywordDto.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryKeywordDto.java
@@ -10,10 +10,7 @@ public record DiaryKeywordDto(
 	Long keywordId,
 
 	@Schema(description = "키워드 이름", example = "행복")
-	String keywordName,
-
-	@Schema(description = "핵심 키워드", example = "true")
-	boolean checked
+	String keywordName
 ) {
 	public static DiaryKeywordDto from(DiaryKeyword diaryKeyword) {
 		return DiaryKeywordDto.builder()

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryKeywordDto.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryKeywordDto.java
@@ -1,0 +1,25 @@
+package im.toduck.domain.diary.presentation.dto.response;
+
+import im.toduck.domain.diary.persistence.entity.DiaryKeyword;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record DiaryKeywordDto(
+	@Schema(description = "사용자 키워드 ID", example = "3")
+	Long keywordId,
+
+	@Schema(description = "키워드 이름", example = "행복")
+	String keywordName,
+
+	@Schema(description = "핵심 키워드", example = "true")
+	boolean checked
+) {
+	public static DiaryKeywordDto from(DiaryKeyword diaryKeyword) {
+		return DiaryKeywordDto.builder()
+			.keywordId(diaryKeyword.getUserKeyword().getId())
+			.keywordName(diaryKeyword.getUserKeyword().getKeyword())
+			.checked(diaryKeyword.isChecked())
+			.build();
+	}
+}

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/DiaryResponse.java
@@ -31,7 +31,10 @@ public record DiaryResponse(
 	String memo,
 
 	@Schema(description = "일기 이미지 목록")
-	List<DiaryImageDto> diaryImages
+	List<DiaryImageDto> diaryImages,
+
+	@Schema(description = "연결된 키워드 목록")
+	List<DiaryKeywordDto> diaryKeywords
 ) {
 
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/UserKeywordListResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/UserKeywordListResponse.java
@@ -1,0 +1,20 @@
+package im.toduck.domain.diary.presentation.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "사용자 키워드 목록 응답")
+@Builder
+public record UserKeywordListResponse(
+	@Schema(description = "사용자 키워드 목록")
+	List<UserKeywordResponse> userKeywordDtos
+) {
+	public static UserKeywordListResponse toListUserKeywordResponse(List<UserKeywordResponse> userKeywords) {
+		return UserKeywordListResponse.builder()
+			.userKeywordDtos(userKeywords)
+			.build();
+	}
+}
+

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/UserKeywordResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/UserKeywordResponse.java
@@ -13,10 +13,7 @@ public record UserKeywordResponse(
 	KeywordCategory category,
 
 	@Schema(description = "키워드", example = "회사")
-	String keyword,
-
-	@Schema(description = "사용 횟수", example = "3")
-	Long count
+	String keyword
 ) {
 
 }

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/UserKeywordResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/UserKeywordResponse.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 
 @Builder
 public record UserKeywordResponse(
+	@Schema(description = "키워드 ID", example = "1")
+	Long id,
+
 	@Schema(description = "카테고리", example = "PLACE")
 	KeywordCategory category,
 

--- a/src/main/java/im/toduck/domain/diary/presentation/dto/response/UserKeywordResponse.java
+++ b/src/main/java/im/toduck/domain/diary/presentation/dto/response/UserKeywordResponse.java
@@ -1,0 +1,19 @@
+package im.toduck.domain.diary.presentation.dto.response;
+
+import im.toduck.domain.diary.persistence.entity.KeywordCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record UserKeywordResponse(
+	@Schema(description = "카테고리", example = "PLACE")
+	KeywordCategory category,
+
+	@Schema(description = "키워드", example = "회사")
+	String keyword,
+
+	@Schema(description = "사용 횟수", example = "3")
+	Long count
+) {
+
+}

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -99,10 +99,13 @@ public enum ExceptionCode {
 	UNAUTHORIZED_ACCESS_DIARY(HttpStatus.FORBIDDEN, 40502, "일기에 접근 권한이 없습니다."),
 	EXISTS_DATE_DIARY(HttpStatus.CONFLICT, 40503, "이미 해당 날짜에 일기가 존재합니다."),
 
-	/* 406xx keyword */
+	/* 406xx userKeyword */
 	ALREADY_SETUP_KEYWORD(HttpStatus.CONFLICT, 40601, "이미 초기화된 유저입니다."),
 	ALREADY_EXISTS_KEYWORD(HttpStatus.CONFLICT, 40602, "이미 존재하는 키워드입니다."),
 	NOT_FOUND_KEYWORD(HttpStatus.NOT_FOUND, 40603, "존재하지 않는 키워드입니다."),
+
+	/* 407xx diaryKeyword */
+	INVALID_KEYWORD_ID(HttpStatus.BAD_REQUEST, 40701, "유효하지 않은 키워드 ID입니다."),
 
 	/* 431xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 43101, "일정 기록을 찾을 수 없습니다.",

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -102,6 +102,7 @@ public enum ExceptionCode {
 	/* 406xx keyword */
 	ALREADY_SETUP_KEYWORD(HttpStatus.CONFLICT, 40601, "이미 초기화된 유저입니다."),
 	ALREADY_EXISTS_KEYWORD(HttpStatus.CONFLICT, 40602, "이미 존재하는 키워드입니다."),
+	NOT_FOUND_KEYWORD(HttpStatus.NOT_FOUND, 40603, "존재하지 않는 키워드입니다."),
 
 	/* 431xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 43101, "일정 기록을 찾을 수 없습니다.",

--- a/src/main/java/im/toduck/global/exception/ExceptionCode.java
+++ b/src/main/java/im/toduck/global/exception/ExceptionCode.java
@@ -99,6 +99,10 @@ public enum ExceptionCode {
 	UNAUTHORIZED_ACCESS_DIARY(HttpStatus.FORBIDDEN, 40502, "일기에 접근 권한이 없습니다."),
 	EXISTS_DATE_DIARY(HttpStatus.CONFLICT, 40503, "이미 해당 날짜에 일기가 존재합니다."),
 
+	/* 406xx keyword */
+	ALREADY_SETUP_KEYWORD(HttpStatus.CONFLICT, 40601, "이미 초기화된 유저입니다."),
+	ALREADY_EXISTS_KEYWORD(HttpStatus.CONFLICT, 40602, "이미 존재하는 키워드입니다."),
+
 	/* 431xx schedule */
 	NOT_FOUND_SCHEDULE_RECORD(HttpStatus.NOT_FOUND, 43101, "일정 기록을 찾을 수 없습니다.",
 		"일정 기록을 찾을 수 없을 때 발생하는 오류입니다."),

--- a/src/test/java/im/toduck/builder/BuilderSupporter.java
+++ b/src/test/java/im/toduck/builder/BuilderSupporter.java
@@ -3,6 +3,8 @@ package im.toduck.builder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import im.toduck.domain.diary.persistence.repository.MasterKeywordRepository;
+import im.toduck.domain.diary.persistence.repository.UserKeywordRepository;
 import im.toduck.domain.routine.persistence.repository.RoutineRecordRepository;
 import im.toduck.domain.routine.persistence.repository.RoutineRepository;
 import im.toduck.domain.schedule.persistence.repository.ScheduleRecordRepository;
@@ -67,6 +69,12 @@ public class BuilderSupporter {
 	@Autowired
 	private FollowRepository followRepository;
 
+	@Autowired
+	private MasterKeywordRepository masterKeywordRepository;
+
+	@Autowired
+	private UserKeywordRepository userKeywordRepository;
+
 	public UserRepository userRepository() {
 		return userRepository;
 	}
@@ -127,4 +135,11 @@ public class BuilderSupporter {
 		return followRepository;
 	}
 
+	public MasterKeywordRepository masterKeywordRepository() {
+		return masterKeywordRepository;
+	}
+
+	public UserKeywordRepository userKeywordRepository() {
+		return userKeywordRepository;
+	}
 }

--- a/src/test/java/im/toduck/builder/TestFixtureBuilder.java
+++ b/src/test/java/im/toduck/builder/TestFixtureBuilder.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import im.toduck.domain.diary.persistence.entity.KeywordCategory;
+import im.toduck.domain.diary.persistence.entity.MasterKeyword;
 import im.toduck.domain.routine.persistence.entity.Routine;
 import im.toduck.domain.routine.persistence.entity.RoutineRecord;
 import im.toduck.domain.schedule.persistence.entity.Schedule;
@@ -122,5 +124,14 @@ public class TestFixtureBuilder {
 			.followed(followed)
 			.build();
 		return bs.followRepository().save(follow);
+	}
+
+	public MasterKeyword buildMasterKeyword(KeywordCategory keywordCategory, String keyword) {
+		MasterKeyword masterKeyword = MasterKeyword.builder()
+			.category(keywordCategory)
+			.keyword(keyword)
+			.createdAt(LocalDateTime.now())
+			.build();
+		return bs.masterKeywordRepository().save(masterKeyword);
 	}
 }

--- a/src/test/java/im/toduck/builder/TestFixtureBuilder.java
+++ b/src/test/java/im/toduck/builder/TestFixtureBuilder.java
@@ -130,7 +130,6 @@ public class TestFixtureBuilder {
 		MasterKeyword masterKeyword = MasterKeyword.builder()
 			.category(keywordCategory)
 			.keyword(keyword)
-			.createdAt(LocalDateTime.now())
 			.build();
 		return bs.masterKeywordRepository().save(masterKeyword);
 	}

--- a/src/test/java/im/toduck/domain/diary/domain/usecase/DiaryKeywordUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/diary/domain/usecase/DiaryKeywordUseCaseTest.java
@@ -1,0 +1,113 @@
+package im.toduck.domain.diary.domain.usecase;
+
+import static im.toduck.fixtures.user.UserFixtures.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import im.toduck.ServiceTest;
+import im.toduck.domain.diary.domain.service.DiaryKeywordService;
+import im.toduck.domain.diary.persistence.entity.DiaryKeyword;
+import im.toduck.domain.diary.persistence.entity.KeywordCategory;
+import im.toduck.domain.diary.persistence.entity.UserKeyword;
+import im.toduck.domain.diary.persistence.repository.DiaryKeywordRepository;
+import im.toduck.domain.diary.persistence.repository.UserKeywordRepository;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.diary.presentation.dto.request.DiaryKeywordCreateRequest;
+import im.toduck.domain.diary.presentation.dto.request.UserKeywordRequest;
+import im.toduck.domain.diary.presentation.dto.response.DiaryListResponse;
+import im.toduck.domain.user.persistence.entity.Emotion;
+import im.toduck.domain.user.persistence.entity.User;
+
+class DiaryKeywordUseCaseTest extends ServiceTest {
+
+	@Autowired
+	private DiaryKeywordUseCase diaryKeywordUseCase;
+
+	@Autowired
+	private DiaryKeywordService diaryKeywordService;
+
+	@Autowired
+	private DiaryKeywordRepository diaryKeywordRepository;
+
+	@Autowired
+	private DiaryUseCase diaryUseCase;
+
+	@Autowired
+	private UserKeywordUseCase userKeywordUseCase;
+
+	@Autowired
+	private UserKeywordRepository userKeywordRepository;
+
+	@Nested
+	@DisplayName("일기-키워드 연결시")
+	class diaryKeyword {
+		private User savedUser;
+		private DiaryCreateRequest diaryCreateRequest;
+		private UserKeywordRequest userKeywordRequest1, userKeywordRequest2;
+		private DiaryKeywordCreateRequest diaryKeywordCreateRequest;
+
+		@BeforeEach
+		void setUp() {
+			savedUser = testFixtureBuilder.buildUser(GENERAL_USER());
+			diaryCreateRequest = DiaryCreateRequest.builder()
+				.date(LocalDate.of(2025, 8, 10))
+				.emotion(Emotion.SAD)
+				.title("슬픔")
+				.memo("출근 전에 지갑을 두고 나오는 바람에 다시 돌아갔다")
+				.diaryImageUrls(List.of("https://cdn.toduck.app/image1.jpg"))
+				.build();
+			userKeywordRequest1 = UserKeywordRequest.builder()
+				.keywordCategory(KeywordCategory.PLACE)
+				.keyword("회사")
+				.build();
+			userKeywordRequest2 = UserKeywordRequest.builder()
+				.keywordCategory(KeywordCategory.PERSON)
+				.keyword("상사")
+				.build();
+
+		}
+
+		@Test
+		void 성공적으로_일기와_키워드를_연결한다() {
+			// given
+			diaryUseCase.createDiary(savedUser.getId(), diaryCreateRequest);
+			userKeywordUseCase.createKeyword(savedUser.getId(), userKeywordRequest1);
+			userKeywordUseCase.createKeyword(savedUser.getId(), userKeywordRequest2);
+
+			DiaryListResponse diaryListResponse = diaryUseCase.getDiariesByMonth(savedUser.getId(),
+				YearMonth.of(2025, 8));
+			Long diaryId = diaryListResponse.diaryDtos().get(0).diaryId();
+			List<Long> keywordIds = userKeywordRepository.findByUserId(savedUser.getId())
+				.stream()
+				.map(UserKeyword::getId)
+				.toList();
+			diaryKeywordCreateRequest = DiaryKeywordCreateRequest.builder()
+				.diaryId(diaryId)
+				.keywordIds(keywordIds)
+				.build();
+
+			// when
+			diaryKeywordUseCase.createDiaryKeyword(diaryId, diaryKeywordCreateRequest);
+
+			// then
+			List<DiaryKeyword> diaryKeywords = diaryKeywordRepository.findByDiaryId(diaryId);
+
+			assertThat(diaryKeywords).hasSize(2);
+
+			List<Long> savedKeywordIds = diaryKeywords.stream()
+				.map(dk -> dk.getUserKeyword().getId())
+				.toList();
+
+			assertThat(savedKeywordIds).containsExactlyInAnyOrderElementsOf(keywordIds);
+		}
+	}
+}

--- a/src/test/java/im/toduck/domain/diary/domain/usecase/DiaryUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/diary/domain/usecase/DiaryUseCaseTest.java
@@ -1,0 +1,73 @@
+package im.toduck.domain.diary.domain.usecase;
+
+import static im.toduck.fixtures.user.UserFixtures.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import im.toduck.ServiceTest;
+import im.toduck.domain.diary.persistence.repository.DiaryImageRepository;
+import im.toduck.domain.diary.persistence.repository.DiaryRepository;
+import im.toduck.domain.diary.presentation.dto.request.DiaryCreateRequest;
+import im.toduck.domain.user.persistence.entity.Emotion;
+import im.toduck.domain.user.persistence.entity.User;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+public class DiaryUseCaseTest extends ServiceTest {
+	private User USER;
+
+	@Autowired
+	private DiaryUseCase diaryUseCase;
+
+	@Autowired
+	private DiaryRepository diaryRepository;
+
+	@Autowired
+	private DiaryImageRepository diaryImageRepository;
+
+	@BeforeEach
+	public void setUp() {
+		USER = testFixtureBuilder.buildUser(GENERAL_USER());
+	}
+
+	@Nested
+	@DisplayName("다이어리 생성시")
+	class CreateDiary {
+		String dateStr = "2025-03-21";
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+		LocalDate date = LocalDate.parse(dateStr, formatter);
+		Emotion emotion = Emotion.valueOf("HAPPY");
+
+		private Validator validator;
+
+		@BeforeEach
+		void setUp() {
+			ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+			validator = factory.getValidator();
+		}
+
+		@Test
+		void 성공() {
+			// given
+			DiaryCreateRequest 일기_생성_요청에_성공한다 = new DiaryCreateRequest(
+				date,
+				emotion,
+				null,
+				null,
+				null
+			);
+
+			// when & then
+			assertDoesNotThrow(() -> diaryUseCase.createDiary(USER.getId(), 일기_생성_요청에_성공한다));
+		}
+	}
+}

--- a/src/test/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCaseTest.java
@@ -155,7 +155,6 @@ class UserKeywordUseCaseTest extends ServiceTest {
 				assertThat(createdKeyword.getUser().getId()).isEqualTo(savedUser.getId());
 				assertThat(createdKeyword.getCategory()).isEqualTo(userKeywordRequest.keywordCategory());
 				assertThat(createdKeyword.getKeyword()).isEqualTo(userKeywordRequest.keyword());
-				assertThat(createdKeyword.getCount()).isEqualTo(0L);
 			}
 
 			@Test
@@ -176,7 +175,6 @@ class UserKeywordUseCaseTest extends ServiceTest {
 				assertThat(createdKeyword.getUser().getId()).isEqualTo(savedUser.getId());
 				assertThat(createdKeyword.getCategory()).isEqualTo(userKeywordRequest2.keywordCategory());
 				assertThat(createdKeyword.getKeyword()).isEqualTo(userKeywordRequest2.keyword());
-				assertThat(createdKeyword.getCount()).isEqualTo(0L);
 			}
 		}
 
@@ -286,15 +284,10 @@ class UserKeywordUseCaseTest extends ServiceTest {
 					.map(UserKeywordResponse::keyword)
 					.toList();
 
-				boolean allCountZero = userKeywordListResponse.userKeywordDtos()
-					.stream()
-					.allMatch(dto -> dto.count() == 0);
-
 				assertThat(categories)
 					.containsExactlyInAnyOrder(KeywordCategory.PLACE, KeywordCategory.SITUATION);
 				assertThat(keywords)
 					.containsExactlyInAnyOrder("서울역", "요리");
-				assertThat(allCountZero).isTrue();
 			}
 		}
 	}

--- a/src/test/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCaseTest.java
@@ -1,0 +1,93 @@
+package im.toduck.domain.diary.domain.usecase;
+
+import static im.toduck.fixtures.user.UserFixtures.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import im.toduck.ServiceTest;
+import im.toduck.domain.diary.domain.service.MasterKeywordService;
+import im.toduck.domain.diary.domain.service.UserKeywordService;
+import im.toduck.domain.diary.persistence.entity.KeywordCategory;
+import im.toduck.domain.diary.persistence.entity.MasterKeyword;
+import im.toduck.domain.diary.persistence.entity.UserKeyword;
+import im.toduck.domain.diary.persistence.repository.UserKeywordRepository;
+import im.toduck.domain.user.persistence.entity.User;
+
+class UserKeywordUseCaseTest extends ServiceTest {
+
+	@Autowired
+	private UserKeywordUseCase userKeywordUsecase;
+
+	@Autowired
+	private UserKeywordService userKeywordService;
+
+	@Autowired
+	private UserKeywordRepository userKeywordRepository;
+
+	@Autowired
+	private MasterKeywordService masterKeywordService;
+
+	@Nested
+	@DisplayName("사용자 키워드 초기 설정")
+	class setupKeyword {
+		private User savedUser;
+
+		@BeforeEach
+		void setUp() {
+			savedUser = testFixtureBuilder.buildUser(GENERAL_USER());
+		}
+
+		@Test
+		void 성공적으로_생성한다() {
+			// given
+			List<MasterKeyword> masterKeywords = List.of(
+				MasterKeyword.builder()
+					.category(KeywordCategory.PLACE)
+					.keyword("학교")
+					.createdAt(LocalDateTime.now())
+					.build(),
+				MasterKeyword.builder()
+					.category(KeywordCategory.SITUATION)
+					.keyword("요리")
+					.createdAt(LocalDateTime.now())
+					.build(),
+				MasterKeyword.builder()
+					.category(KeywordCategory.RESULT)
+					.keyword("불편한 대화")
+					.createdAt(LocalDateTime.now())
+					.build()
+			);
+
+			// when
+			userKeywordUsecase.setupKeyword(savedUser.getId());
+
+			// then
+			List<UserKeyword> userKeywords = userKeywordRepository.findAll();
+			List<MasterKeyword> savedMasterKeywords = masterKeywordService.findAll();
+
+			assertThat(userKeywords).hasSize(savedMasterKeywords.size());
+
+			assertThat(userKeywords)
+				.allMatch(uk -> uk.getUser().getId().equals(savedUser.getId()));
+
+			List<String> masterKeywordValues = savedMasterKeywords.stream()
+				.map(uk -> uk.getCategory() + ":" + uk.getKeyword())
+				.toList();
+
+			List<String> userKeywordValues = userKeywords.stream()
+				.map(uk -> uk.getCategory() + ":" + uk.getKeyword())
+				.toList();
+
+			assertThat(userKeywordValues)
+				.containsExactlyInAnyOrderElementsOf(masterKeywordValues);
+		}
+	}
+}

--- a/src/test/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCaseTest.java
+++ b/src/test/java/im/toduck/domain/diary/domain/usecase/UserKeywordUseCaseTest.java
@@ -206,7 +206,7 @@ class UserKeywordUseCaseTest extends ServiceTest {
 	@DisplayName("키워드 삭제")
 	class deleteKeyword {
 		private User savedUser;
-		UserKeywordRequest userKeywordRequest;
+		private UserKeywordRequest userKeywordRequest;
 
 		@BeforeEach
 		void setUp() {
@@ -242,7 +242,7 @@ class UserKeywordUseCaseTest extends ServiceTest {
 	@DisplayName("특정 사용자 키워드 목록 반환")
 	class getKeyword {
 		private User savedUser;
-		UserKeywordRequest userKeywordRequest, userKeywordRequest2;
+		private UserKeywordRequest userKeywordRequest, userKeywordRequest2;
 
 		@BeforeEach
 		void setUp() {


### PR DESCRIPTION
## ✨ 작업 내용

일기에 들어가는 키워드 기능을 개발했습니다.
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/9840c9d7-9eb5-4b6a-ab0c-82c469dfdbe1" />

  <br/>ERD 다이어그램은 다음과 같습니다.
<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/15afd0ab-b4cc-45a4-ad69-b5ecc8e7ce56" />

  <br/>사용자는 기본적으로 제공되는 키워드(마스터 키워드)를 선택할 수 있고 삭제도 가능합니다. 또한 본인이 필요한 키워드가 있다면 카테고리와 함께 추가 가능합니다.
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/f6ff06ad-bd96-45be-9cdf-1a19ec3ad3a7" />

  <br/>사용자가 기본적으로 제공되는 마스터 키워드를 삭제할 수 있어야 하기 때문에 마스터 키워드 테이블을 만들어 초기에 사용자마다 마스터 테이블에 있는 키워드를 복사하도록 했습니다. 복사된 키워드들은 UserKeyword에 저장되며 일기와 키워드의 다대다 관계를 표현하기 위해 DiaryKeyword 테이블도 생성했습니다.

구체적으로는 아래와 같은 API를 개발했으며 키워드가 추가됨에 따라 일기 목록을 가져올 때 해당 일기에 들어가는 키워드 목록도 함께 받아오도록 수정했습니다.

UserKeyword
setup : 마스터 테이블에 있는 키워드를 특정 사용자의 id와 함께 UserKeyword에 복사합니다. 회원가입 시에 해당 API를 호출하면 될 것 같습니다.
create : 특정 사용자가 키워드를 생성합니다. 논리적 삭제를 사용하고 있기 때문에 기존에 삭제된 키워드를 다시 생성하는 경우 deleted_at을 복구하도록 구현했습니다.
delete : 특정 사용자의 키워드를 삭제합니다.
getKeyword : 특정 사용자의 키워드 목록을 가져옵니다.

DiaryKeyword
create : 일기 id와 키워드id를 사용하여 일기와 키워드를 연결시켜줍니다.

## ✅ 리뷰 요구사항(선택)

> 1. 사용자에게 setup을 사용하여 마스터 키워드의 값들을 복사해 주도록 했는데 setup을 실행하는 시점이 회원가입 시라고 하면 기존 사용자들에게는 어떻게 마스터 키워드 값을 복사해줄 수 있을까요?
> 2. 마스터 테이블은 기존에 채워놔야 하는데 SQL문을 작성해서 직접 쿼리를 날릴지 아니면 관리자가 직접 추가할 수 있는 API를 개발할지 고민이 됩니다. API를 실행할 수 있는 공간이 어플뿐이다보니 관리자는 위한 페이지가 없는 현재로써는 쿼리를 직접 날리는 게 좋을까요?
> 3. 만약 마스터 테이블에 변화가 생긴다면 모든 사용자에게 적용을 시켜야 할까요? 새로 생성된 키워드만 사용자에게 추가해줘도 괜찮을 것 같기도 합니다.
> 4. 마스터 테이블에 변화가 생겼을 때 이를 사용자들에게 적용 시킨다면 API 호출을 통해서 하나요? API를 통해서 한다면 관리자만 할 수 있도록 해야 할 것 같아 질문드립니다. 2번 질문이랑 비슷하네요.
> 5. 이외에 개선해야 할 점이나 다른 의견이 있다면 말씀해주시면 감사하겠습니다!!
