### PR TITLE
루틴 알림 시간 정보 추가

### DIFF
--- a/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
+++ b/src/main/java/im/toduck/domain/routine/common/mapper/RoutineMapper.java
@@ -15,6 +15,7 @@ import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadLis
 import im.toduck.domain.routine.presentation.dto.response.MyRoutineRecordReadMultipleDatesResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineCreateResponse;
 import im.toduck.domain.routine.presentation.dto.response.RoutineDetailResponse;
+import im.toduck.domain.routine.presentation.vo.RoutineReminderTime;
 import im.toduck.domain.social.presentation.dto.response.UserProfileRoutineListResponse;
 import im.toduck.domain.user.persistence.entity.User;
 import im.toduck.global.helper.DaysOfWeekBitmask;
@@ -106,6 +107,7 @@ public class RoutineMapper {
 			.isInDeletedState(routine.isInDeletedState())
 			.daysOfWeek(daysOfWeek)
 			.isCompleted(isCompleted)
+			.reminderTime(RoutineReminderTime.fromMinutes(routine.getReminderMinutes()))
 			.build();
 	}
 
@@ -125,6 +127,7 @@ public class RoutineMapper {
 			.isPublic(routine.getIsPublic())
 			.isInDeletedState(routine.isInDeletedState())
 			.daysOfWeek(daysOfWeek)
+			.reminderTime(RoutineReminderTime.fromMinutes(routine.getReminderMinutes()))
 			.build();
 	}
 
@@ -147,6 +150,7 @@ public class RoutineMapper {
 			.color(routine.getColorValue())
 			.title(routine.getTitle())
 			.memo(routine.getMemoValue())
+			.reminderTime(RoutineReminderTime.fromMinutes(routine.getReminderMinutes()))
 			.build();
 	}
 
@@ -177,6 +181,7 @@ public class RoutineMapper {
 			.time(routine.getTime())
 			.sharedCount(routine.getSharedCount())
 			.daysOfWeek(daysOfWeek)
+			.reminderTime(RoutineReminderTime.fromMinutes(routine.getReminderMinutes()))
 			.build();
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineAvailableListResponse.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineAvailableListResponse.java
@@ -3,6 +3,7 @@ package im.toduck.domain.routine.presentation.dto.response;
 import java.util.List;
 
 import im.toduck.domain.person.persistence.entity.PlanCategory;
+import im.toduck.domain.routine.presentation.vo.RoutineReminderTime;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -29,7 +30,10 @@ public record MyRoutineAvailableListResponse(
 		String title,
 
 		@Schema(description = "루틴 메모", example = "눈 뜨자마자 이부자리 정리하는 사람은 성공한다더라..")
-		String memo
+		String memo,
+
+		@Schema(description = "루틴 리마인더 시간 (null이면 알림 없음)", example = "THIRTY_MINUTE")
+		RoutineReminderTime reminderTime
 	) {
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineRecordReadListResponse.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/response/MyRoutineRecordReadListResponse.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 
 import im.toduck.domain.person.persistence.entity.PlanCategory;
+import im.toduck.domain.routine.presentation.vo.RoutineReminderTime;
 import im.toduck.global.serializer.DayOfWeekListSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -62,7 +63,10 @@ public record MyRoutineRecordReadListResponse(
 		String memo,
 
 		@Schema(description = "루틴 완료 여부", example = "true")
-		Boolean isCompleted
+		Boolean isCompleted,
+
+		@Schema(description = "루틴 리마인더 시간 (null이면 알림 없음)", example = "THIRTY_MINUTE")
+		RoutineReminderTime reminderTime
 	) {
 	}
 }

--- a/src/main/java/im/toduck/domain/routine/presentation/dto/response/RoutineDetailResponse.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/dto/response/RoutineDetailResponse.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 
 import im.toduck.domain.person.persistence.entity.PlanCategory;
+import im.toduck.domain.routine.presentation.vo.RoutineReminderTime;
 import im.toduck.global.serializer.DayOfWeekListSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -44,6 +45,9 @@ public record RoutineDetailResponse(
 	List<DayOfWeek> daysOfWeek,
 
 	@Schema(description = "루틴 메모", example = "눈 뜨자마자 이부자리 정리하는 사람은 성공한다더라..")
-	String memo
+	String memo,
+
+	@Schema(description = "루틴 리마인더 시간 (null이면 알림 없음)", example = "THIRTY_MINUTE")
+	RoutineReminderTime reminderTime
 ) {
 }

--- a/src/main/java/im/toduck/domain/routine/presentation/vo/RoutineReminderTime.java
+++ b/src/main/java/im/toduck/domain/routine/presentation/vo/RoutineReminderTime.java
@@ -1,0 +1,43 @@
+package im.toduck.domain.routine.presentation.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 루틴 리마인더 시간 Enum
+ * <p>
+ * 앱 호환성을 위해 예외적으로 API 응답 시에만 사용되는 Enum입니다.
+ * DB에는 Integer 분 단위로 저장되지만, 클라이언트에게는 Enum 문자열로 반환합니다.
+ * </p>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum RoutineReminderTime {
+	TEN_MINUTE(10),
+	THIRTY_MINUTE(30),
+	ONE_HOUR(60),
+	ONE_DAY(1440);
+
+	private final int minutes;
+
+	/**
+	 * DB에 저장된 분 단위 값을 Enum으로 변환
+	 *
+	 * @param minutes DB에 저장된 알림 시간 (분 단위)
+	 * @return 해당하는 Enum 값, 0이거나 null이면 null 반환
+	 */
+	public static RoutineReminderTime fromMinutes(Integer minutes) {
+		if (minutes == null || minutes == 0) {
+			return null;
+		}
+
+		for (RoutineReminderTime reminderTime : values()) {
+			if (reminderTime.minutes == minutes) {
+				return reminderTime;
+			}
+		}
+
+		// 정의되지 않은 값의 경우 null 반환
+		return null;
+	}
+}

--- a/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
+++ b/src/main/java/im/toduck/domain/social/presentation/dto/response/UserProfileRoutineListResponse.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 
 import im.toduck.domain.person.persistence.entity.PlanCategory;
+import im.toduck.domain.routine.presentation.vo.RoutineReminderTime;
 import im.toduck.global.serializer.DayOfWeekListSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -47,7 +48,10 @@ public record UserProfileRoutineListResponse(
 		@JsonSerialize(using = LocalTimeSerializer.class)
 		@JsonFormat(pattern = "HH:mm")
 		@Schema(description = "루틴 시간 (null 이면 종일 루틴)", type = "string", example = "07:30")
-		LocalTime time
+		LocalTime time,
+
+		@Schema(description = "루틴 리마인더 시간 (null이면 알림 없음)", example = "THIRTY_MINUTE")
+		RoutineReminderTime reminderTime
 	) {
 	}
 }


### PR DESCRIPTION
 ## ✨ 작업 내용

  **1️⃣ 루틴 알림 시간 Enum 추가**

  - `RoutineReminderTime` enum 생성으로 알림 시간 타입 표준화
  - 10분, 30분, 1시간, 1일 알림 시간 옵션 제공
  - DB 분 단위 값과 Enum 간 변환 로직 구현

  **2️⃣ 루틴 관련 응답 DTO 업데이트**

  - `MyRoutineAvailableListResponse`에 `reminderTime` 필드 추가
  - `MyRoutineRecordReadListResponse`에 `reminderTime` 필드 추가
  - `RoutineDetailResponse`에 `reminderTime` 필드 추가
  - `UserProfileRoutineListResponse`에 `reminderTime` 필드 추가

  **3️⃣ 매퍼 로직 개선**

  - `RoutineMapper`에서 DB 저장 값을 Enum으로 변환하는 로직 추가
  - 알림 시간이 0이거나 null인 경우 null 반환 처리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 루틴에 리마인더 시간이 추가되어 상세, 내 루틴 목록, 사용자 프로필 목록에서 확인할 수 있습니다.
  - 지원 값: 10분 전, 30분 전, 1시간 전, 1일 전. 리마인더가 없으면 표시되지 않습니다.
- 문서
  - 리마인더 시간에 대한 설명과 예시가 API 문서에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->